### PR TITLE
Feat: Token Refresh 구현

### DIFF
--- a/src/main/kotlin/com/bandage/v1/domain/auth/controller/MemberAuthController.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/auth/controller/MemberAuthController.kt
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.HttpHeaders
+import org.springframework.web.bind.annotation.CookieValue
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -40,5 +41,18 @@ class MemberAuthController(
         memberAuthService.processLogout()
         response.setHeader(HttpHeaders.SET_COOKIE, CookieUtil.expireCookie())
         return ApiResponse.success()
+    }
+
+    @PostMapping("/refresh")
+    @Operation(summary = "토큰 리프레시 API", description = "refresh 토큰을 검증하고, 새로운 access, refresh 토큰을 발급합니다.")
+    fun tokenRefresh(
+        @CookieValue refreshToken: String,
+        response: HttpServletResponse,
+    ): ApiResponse<MemberLoginResponse> {
+        val tokens = memberAuthService.reissueToken(refreshToken)
+        response.setHeader(HttpHeaders.SET_COOKIE, CookieUtil.generateCookieFrom(tokens.refreshToken))
+        return ApiResponse.success(
+            MemberLoginResponse(tokens.accessToken),
+        )
     }
 }

--- a/src/main/kotlin/com/bandage/v1/domain/auth/service/MemberAuthService.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/auth/service/MemberAuthService.kt
@@ -9,6 +9,7 @@ import com.bandage.v1.global.async.publisher.EventPublisher
 import com.bandage.v1.global.error.errorcode.ErrorCode
 import com.bandage.v1.global.error.exception.BusinessException
 import com.bandage.v1.global.security.jwt.JwtProvider
+import com.bandage.v1.global.security.jwt.RefreshTokenService
 import com.bandage.v1.global.util.SecurityUtil
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.stereotype.Service
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Service
 @Service
 class MemberAuthService(
     private val memberAuthRepository: MemberAuthRepository,
+    private val refreshTokenService: RefreshTokenService,
     private val passwordEncoder: BCryptPasswordEncoder,
     private val jwtProvider: JwtProvider,
     private val eventPublisher: EventPublisher,
@@ -29,7 +31,7 @@ class MemberAuthService(
             throw BusinessException(ErrorCode.INVALID_PASSWORD)
         }
 
-        val memberId: Long = memberAuth.memberId ?: throw BusinessException(ErrorCode.MEMBER_ID_NOT_FOUND)
+        val memberId = memberAuth.memberId
         val accessToken = jwtProvider.createAccessToken(memberId, memberAuth.role)
         val refreshToken = jwtProvider.createRefreshToken(memberId)
 
@@ -43,5 +45,18 @@ class MemberAuthService(
 
     fun processLogout() {
         eventPublisher.publish(MemberLogoutEvent.of(SecurityUtil.getCurrentMemberId()))
+    }
+
+    fun reissueToken(oldRefreshToken: String): TokenDto {
+        val memberId = jwtProvider.getMemberIdFromToken(oldRefreshToken)
+        refreshTokenService.validateRefreshToken(oldRefreshToken, memberId)
+        val memberAuth = memberAuthRepository.findByMemberId(memberId) ?: throw BusinessException(ErrorCode.MEMBER_AUTH_NOT_FOUND)
+        val newAccessToken = jwtProvider.createAccessToken(memberAuth.memberId, memberAuth.role)
+        val newRefreshToken = jwtProvider.createRefreshToken(memberAuth.memberId)
+        refreshTokenService.saveRefreshToken(memberAuth.memberId, newRefreshToken)
+        return TokenDto(
+            accessToken = newAccessToken,
+            refreshToken = newRefreshToken,
+        )
     }
 }

--- a/src/main/kotlin/com/bandage/v1/global/error/errorcode/ErrorCode.kt
+++ b/src/main/kotlin/com/bandage/v1/global/error/errorcode/ErrorCode.kt
@@ -17,6 +17,11 @@ enum class ErrorCode(
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "유효하지 않은 비밀번호입니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 회원가입된 e-mail 입니다"),
 
+    // auth
+    MEMBER_AUTH_NOT_FOUND(HttpStatus.NOT_FOUND, "회원 인증 정보를 찾을 수 없습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다."),
+    EXPIRED_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "만료된 토큰입니다."),
+
     // band
     BAND_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 밴드 정보를 찾을 수 없습니다."),
     DUPLICATE_BAND_NAME(HttpStatus.CONFLICT, "이미 사용 중인 밴드 이름입니다."),

--- a/src/main/kotlin/com/bandage/v1/global/security/jwt/JwtProvider.kt
+++ b/src/main/kotlin/com/bandage/v1/global/security/jwt/JwtProvider.kt
@@ -76,4 +76,15 @@ class JwtProvider(
 
         return UsernamePasswordAuthenticationToken(principal, token, authorities)
     }
+
+    fun getMemberIdFromToken(token: String): Long {
+        val claims =
+            Jwts
+                .parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .payload
+        return claims.subject.toLong()
+    }
 }

--- a/src/main/kotlin/com/bandage/v1/global/security/jwt/RefreshTokenService.kt
+++ b/src/main/kotlin/com/bandage/v1/global/security/jwt/RefreshTokenService.kt
@@ -1,5 +1,7 @@
 package com.bandage.v1.global.security.jwt
 
+import com.bandage.v1.global.error.errorcode.ErrorCode
+import com.bandage.v1.global.error.exception.BusinessException
 import com.bandage.v1.global.properties.JwtProperties
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Service
@@ -9,6 +11,7 @@ import java.time.Duration
 class RefreshTokenService(
     private val redisTemplate: RedisTemplate<String, String>,
     private val jwtProperties: JwtProperties,
+    private val jwtProvider: JwtProvider,
 ) {
     val refreshExpr = jwtProperties.refreshTokenExpr
 
@@ -27,11 +30,21 @@ class RefreshTokenService(
         )
     }
 
-    fun getRefreshToken(memberId: Long): String? = redisTemplate.opsForValue().get(getRtKey(memberId))
+    fun validateRefreshToken(
+        refreshToken: String,
+        memberId: Long,
+    ) {
+        if (!jwtProvider.validateToken(refreshToken)) throw BusinessException(ErrorCode.INVALID_REFRESH_TOKEN)
+        val memberId = jwtProvider.getMemberIdFromToken(refreshToken)
+        val savedRefreshToken = getRefreshToken(memberId) ?: throw BusinessException(ErrorCode.EXPIRED_REFRESH_TOKEN)
+        if (refreshToken != savedRefreshToken) throw BusinessException(ErrorCode.INVALID_REFRESH_TOKEN)
+    }
 
     fun deleteRefreshToken(memberId: Long) {
         redisTemplate.delete(getRtKey(memberId))
     }
 
     private fun getRtKey(memberId: Long): String = "$RT_PREFIX$memberId"
+
+    private fun getRefreshToken(memberId: Long): String? = redisTemplate.opsForValue().get(getRtKey(memberId))
 }

--- a/src/main/kotlin/com/bandage/v1/global/security/jwt/TokenPayload.kt
+++ b/src/main/kotlin/com/bandage/v1/global/security/jwt/TokenPayload.kt
@@ -1,0 +1,6 @@
+package com.bandage.v1.global.security.jwt
+
+data class TokenPayload(
+    val memberId: Long,
+    val role: String,
+)


### PR DESCRIPTION

## 🛠️ Issue Number
### closes #33 

📌 **작업 내용 및 특이사항**

- refreshToken 에 대한 재발급 로직 구현
- /auth/refresh API 개발
- auth-refreshTokenService 간 동기적 구조 복원



📚 **참고사항**
- 추후 Member-Auth 도메인 간 비동기 로직 복원 예정