### PR TITLE
Refactor: Member/MemberAuth 간 비동기 로직 제거 및 Facade 패턴 적용

### DIFF
--- a/src/main/kotlin/com/bandage/v1/domain/auth/controller/MemberAuthController.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/auth/controller/MemberAuthController.kt
@@ -6,6 +6,7 @@ import com.bandage.v1.domain.auth.service.MemberAuthService
 import com.bandage.v1.global.common.constants.PathPrefix.PREFIX
 import com.bandage.v1.global.common.response.ApiResponse
 import com.bandage.v1.global.util.CookieUtil
+import com.bandage.v1.global.util.SecurityUtil
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.servlet.http.HttpServletResponse
@@ -38,7 +39,7 @@ class MemberAuthController(
     @PostMapping("/logout")
     @Operation(summary = "회원 로그인 API", description = "회원 로그아웃을 진행하고 redis, 쿠키에 저장된 refresh 토큰을 만료시킵니다.")
     fun logout(response: HttpServletResponse): ApiResponse<Nothing> {
-        memberAuthService.processLogout()
+        memberAuthService.processLogout(SecurityUtil.getCurrentMemberId())
         response.setHeader(HttpHeaders.SET_COOKIE, CookieUtil.expireCookie())
         return ApiResponse.success()
     }

--- a/src/main/kotlin/com/bandage/v1/domain/auth/dto/req/MemberAuthCreateRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/auth/dto/req/MemberAuthCreateRequest.kt
@@ -1,10 +1,7 @@
 package com.bandage.v1.domain.auth.dto.req
 
-import com.bandage.v1.global.common.domain.enums.MemberRole
-
 data class MemberAuthCreateRequest(
     val memberId: Long,
     val email: String,
-    val password: String,
-    val role: MemberRole,
+    val rawPassword: String,
 )

--- a/src/main/kotlin/com/bandage/v1/domain/auth/dto/req/MemberAuthCreateRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/auth/dto/req/MemberAuthCreateRequest.kt
@@ -1,0 +1,10 @@
+package com.bandage.v1.domain.auth.dto.req
+
+import com.bandage.v1.global.common.domain.enums.MemberRole
+
+data class MemberAuthCreateRequest(
+    val memberId: Long,
+    val email: String,
+    val password: String,
+    val role: MemberRole,
+)

--- a/src/main/kotlin/com/bandage/v1/domain/auth/handler/AuthEventHandler.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/auth/handler/AuthEventHandler.kt
@@ -1,43 +1,35 @@
 package com.bandage.v1.domain.auth.handler
 
-import com.bandage.v1.domain.auth.model.MemberAuth
 import com.bandage.v1.domain.auth.repository.MemberAuthRepository
-import com.bandage.v1.global.async.event.MemberJoinEvent
-import com.bandage.v1.global.async.event.MemberWithdrawnEvent
-import com.bandage.v1.global.error.errorcode.ErrorCode
-import com.bandage.v1.global.error.exception.BusinessException
-import jakarta.transaction.Transactional
-import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
-import org.springframework.transaction.event.TransactionPhase
-import org.springframework.transaction.event.TransactionalEventListener
 
+@Deprecated(message = "회원 인증 로직: 이벤트 기반 아키텍처 적용 X")
 @Component
 class AuthEventHandler(
     private val memberAuthRepository: MemberAuthRepository,
 ) {
-    @Async
-    @Transactional
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    fun handleMemberJoinEvent(event: MemberJoinEvent) {
-        memberAuthRepository.save(
-            MemberAuth.create(
-                memberId = event.memberId,
-                email = event.memberEmail,
-                password = event.memberPassword,
-                role = event.memberRole,
-            ),
-        )
-    }
-
-    @Async
-    @Transactional
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    fun handleMemberWithdrawnEvent(event: MemberWithdrawnEvent) {
-        val memberAuth =
-            memberAuthRepository.findByMemberId(event.memberId)
-                ?: throw BusinessException(ErrorCode.MEMBER_NOT_FOUND)
-        memberAuth.markAsDeleted()
-        memberAuthRepository.save(memberAuth)
-    }
+//    @Async
+//    @Transactional
+//    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+//    fun handleMemberJoinEvent(event: MemberJoinEvent) {
+//        memberAuthRepository.save(
+//            MemberAuth.create(
+//                memberId = event.memberId,
+//                email = event.memberEmail,
+//                password = event.memberPassword,
+//                role = event.memberRole,
+//            ),
+//        )
+//    }
+//
+//    @Async
+//    @Transactional
+//    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+//    fun handleMemberWithdrawnEvent(event: MemberWithdrawnEvent) {
+//        val memberAuth =
+//            memberAuthRepository.findByMemberId(event.memberId)
+//                ?: throw BusinessException(ErrorCode.MEMBER_NOT_FOUND)
+//        memberAuth.markAsDeleted()
+//        memberAuthRepository.save(memberAuth)
+//    }
 }

--- a/src/main/kotlin/com/bandage/v1/domain/auth/model/MemberAuth.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/auth/model/MemberAuth.kt
@@ -1,14 +1,14 @@
 package com.bandage.v1.domain.auth.model
 
+import com.bandage.v1.domain.auth.model.enums.MemberRole
 import com.bandage.v1.global.common.domain.BaseTimeEntity
-import com.bandage.v1.global.common.domain.enums.MemberRole
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import org.hibernate.annotations.SQLRestriction
-import org.hibernate.annotations.UuidGenerator
-import java.util.UUID
 
 @Entity
 @Table(name = "p_member_auth")
@@ -20,11 +20,6 @@ open class MemberAuth(
     role: MemberRole = MemberRole.MEMBER,
 ) : BaseTimeEntity() {
     @Id
-    @Column(name = "member_auth_id")
-    @UuidGenerator(style = UuidGenerator.Style.VERSION_7)
-    lateinit var id: UUID
-        protected set
-
     @Column(name = "member_id", unique = true, nullable = false)
     val memberId: Long = memberId
 
@@ -32,23 +27,26 @@ open class MemberAuth(
     val email: String = email
 
     @Column(name = "password", nullable = false)
-    val password: String = password
+    var password: String = password
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "role", nullable = false)
-    val role: MemberRole = role
+    var role: MemberRole = role
 
     companion object {
         fun create(
             memberId: Long,
             email: String,
             password: String,
-            role: MemberRole,
         ): MemberAuth =
             MemberAuth(
                 memberId = memberId,
                 email = email,
                 password = password,
-                role = role,
             )
+    }
+
+    fun updatePassword(newPassword: String) {
+        this.password = newPassword
     }
 }

--- a/src/main/kotlin/com/bandage/v1/domain/auth/model/enums/MemberRole.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/auth/model/enums/MemberRole.kt
@@ -1,4 +1,4 @@
-package com.bandage.v1.global.common.domain.enums
+package com.bandage.v1.domain.auth.model.enums
 
 enum class MemberRole(
     val value: String,

--- a/src/main/kotlin/com/bandage/v1/domain/auth/repository/MemberAuthRepository.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/auth/repository/MemberAuthRepository.kt
@@ -9,4 +9,6 @@ interface MemberAuthRepository : JpaRepository<MemberAuth, Long> {
     fun findByEmail(email: String): MemberAuth?
 
     fun findByMemberId(memberId: Long): MemberAuth?
+
+    fun existsByMemberId(memberId: Long): Boolean
 }

--- a/src/main/kotlin/com/bandage/v1/domain/auth/service/MemberAuthService.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/auth/service/MemberAuthService.kt
@@ -9,7 +9,6 @@ import com.bandage.v1.global.error.errorcode.ErrorCode
 import com.bandage.v1.global.error.exception.BusinessException
 import com.bandage.v1.global.security.jwt.JwtProvider
 import com.bandage.v1.global.security.jwt.RefreshTokenRepository
-import com.bandage.v1.global.util.SecurityUtil
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -29,8 +28,7 @@ class MemberAuthService(
             MemberAuth.create(
                 memberId = request.memberId,
                 email = request.email,
-                password = request.password,
-                role = request.role,
+                password = encodePassword(request.rawPassword),
             ),
         )
     }
@@ -55,8 +53,8 @@ class MemberAuthService(
         )
     }
 
-    fun processLogout() {
-        refreshTokenRepository.delete(SecurityUtil.getCurrentMemberId())
+    fun processLogout(memberId: Long) {
+        refreshTokenRepository.delete(memberId)
     }
 
     fun reissueToken(oldRefreshToken: String): TokenDto {
@@ -93,4 +91,8 @@ class MemberAuthService(
     private fun getMemberAuth(memberId: Long): MemberAuth =
         memberAuthRepository.findByMemberId(memberId)
             ?: throw BusinessException(ErrorCode.MEMBER_NOT_FOUND)
+
+    private fun encodePassword(rawPassword: String): String =
+        passwordEncoder.encode(rawPassword)
+            ?: throw BusinessException(ErrorCode.INTERNAL_SERVER_ERROR)
 }

--- a/src/main/kotlin/com/bandage/v1/domain/auth/service/MemberAuthService.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/auth/service/MemberAuthService.kt
@@ -7,6 +7,7 @@ import com.bandage.v1.domain.auth.model.MemberAuth
 import com.bandage.v1.domain.auth.repository.MemberAuthRepository
 import com.bandage.v1.global.error.errorcode.ErrorCode
 import com.bandage.v1.global.error.exception.BusinessException
+import com.bandage.v1.global.properties.JwtProperties
 import com.bandage.v1.global.security.jwt.JwtProvider
 import com.bandage.v1.global.security.jwt.RefreshTokenRepository
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
@@ -20,6 +21,7 @@ class MemberAuthService(
     private val refreshTokenRepository: RefreshTokenRepository,
     private val passwordEncoder: BCryptPasswordEncoder,
     private val jwtProvider: JwtProvider,
+    private val jwtProperties: JwtProperties,
 ) {
     @Transactional
     fun createMemberAuth(request: MemberAuthCreateRequest): MemberAuth {
@@ -44,8 +46,13 @@ class MemberAuthService(
 
         val accessToken = jwtProvider.createAccessToken(memberId, memberAuth.role)
         val refreshToken = jwtProvider.createRefreshToken(memberId)
+        val expiration = jwtProperties.refreshTokenExpr
 
-        refreshTokenRepository.save(memberId, refreshToken)
+        refreshTokenRepository.save(
+            memberId = memberAuth.memberId,
+            refreshToken = refreshToken,
+            expiration = expiration,
+        )
 
         return TokenDto(
             accessToken = accessToken,
@@ -59,15 +66,20 @@ class MemberAuthService(
 
     fun reissueToken(oldRefreshToken: String): TokenDto {
         val memberId = jwtProvider.getMemberIdFromToken(oldRefreshToken)
-        refreshTokenRepository.validate(oldRefreshToken, memberId)
+        validateRefreshToken(oldRefreshToken, memberId)
         val memberAuth =
             memberAuthRepository.findByMemberId(memberId)
                 ?: throw BusinessException(ErrorCode.MEMBER_AUTH_NOT_FOUND)
 
         val newAccessToken = jwtProvider.createAccessToken(memberAuth.memberId, memberAuth.role)
         val newRefreshToken = jwtProvider.createRefreshToken(memberAuth.memberId)
+        val expiration = jwtProperties.refreshTokenExpr
 
-        refreshTokenRepository.save(memberAuth.memberId, newRefreshToken)
+        refreshTokenRepository.save(
+            memberId = memberAuth.memberId,
+            refreshToken = newRefreshToken,
+            expiration = expiration,
+        )
 
         return TokenDto(
             accessToken = newAccessToken,
@@ -95,4 +107,15 @@ class MemberAuthService(
     private fun encodePassword(rawPassword: String): String =
         passwordEncoder.encode(rawPassword)
             ?: throw BusinessException(ErrorCode.INTERNAL_SERVER_ERROR)
+
+    private fun validateRefreshToken(
+        refreshToken: String,
+        memberId: Long,
+    ) {
+        if (!jwtProvider.validateToken(refreshToken)) throw BusinessException(ErrorCode.INVALID_REFRESH_TOKEN)
+        val savedRefreshToken =
+            refreshTokenRepository.get(memberId)
+                ?: throw BusinessException(ErrorCode.EXPIRED_REFRESH_TOKEN)
+        if (refreshToken != savedRefreshToken) throw BusinessException(ErrorCode.INVALID_REFRESH_TOKEN)
+    }
 }

--- a/src/main/kotlin/com/bandage/v1/domain/auth/service/MemberAuthService.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/auth/service/MemberAuthService.kt
@@ -1,41 +1,53 @@
 package com.bandage.v1.domain.auth.service
 
+import com.bandage.v1.domain.auth.dto.req.MemberAuthCreateRequest
 import com.bandage.v1.domain.auth.dto.req.MemberLoginRequest
 import com.bandage.v1.domain.auth.dto.res.TokenDto
+import com.bandage.v1.domain.auth.model.MemberAuth
 import com.bandage.v1.domain.auth.repository.MemberAuthRepository
-import com.bandage.v1.global.async.event.MemberLoginEvent
-import com.bandage.v1.global.async.event.MemberLogoutEvent
-import com.bandage.v1.global.async.publisher.EventPublisher
 import com.bandage.v1.global.error.errorcode.ErrorCode
 import com.bandage.v1.global.error.exception.BusinessException
 import com.bandage.v1.global.security.jwt.JwtProvider
-import com.bandage.v1.global.security.jwt.RefreshTokenService
+import com.bandage.v1.global.security.jwt.RefreshTokenRepository
 import com.bandage.v1.global.util.SecurityUtil
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
+@Transactional(readOnly = true)
 class MemberAuthService(
     private val memberAuthRepository: MemberAuthRepository,
-    private val refreshTokenService: RefreshTokenService,
+    private val refreshTokenRepository: RefreshTokenRepository,
     private val passwordEncoder: BCryptPasswordEncoder,
     private val jwtProvider: JwtProvider,
-    private val eventPublisher: EventPublisher,
 ) {
+    @Transactional
+    fun createMemberAuth(request: MemberAuthCreateRequest): MemberAuth {
+        isMemberAuthAlreadyExists(request)
+        return memberAuthRepository.save(
+            MemberAuth.create(
+                memberId = request.memberId,
+                email = request.email,
+                password = request.password,
+                role = request.role,
+            ),
+        )
+    }
+
     fun processLogin(request: MemberLoginRequest): TokenDto {
         val memberAuth =
             memberAuthRepository.findByEmail(request.email)
                 ?: throw BusinessException(ErrorCode.MEMBER_NOT_FOUND)
-
         if (!passwordEncoder.matches(request.password, memberAuth.password)) {
             throw BusinessException(ErrorCode.INVALID_PASSWORD)
         }
-
         val memberId = memberAuth.memberId
+
         val accessToken = jwtProvider.createAccessToken(memberId, memberAuth.role)
         val refreshToken = jwtProvider.createRefreshToken(memberId)
 
-        eventPublisher.publish(MemberLoginEvent.of(memberId, refreshToken))
+        refreshTokenRepository.save(memberId, refreshToken)
 
         return TokenDto(
             accessToken = accessToken,
@@ -44,19 +56,41 @@ class MemberAuthService(
     }
 
     fun processLogout() {
-        eventPublisher.publish(MemberLogoutEvent.of(SecurityUtil.getCurrentMemberId()))
+        refreshTokenRepository.delete(SecurityUtil.getCurrentMemberId())
     }
 
     fun reissueToken(oldRefreshToken: String): TokenDto {
         val memberId = jwtProvider.getMemberIdFromToken(oldRefreshToken)
-        refreshTokenService.validateRefreshToken(oldRefreshToken, memberId)
-        val memberAuth = memberAuthRepository.findByMemberId(memberId) ?: throw BusinessException(ErrorCode.MEMBER_AUTH_NOT_FOUND)
+        refreshTokenRepository.validate(oldRefreshToken, memberId)
+        val memberAuth =
+            memberAuthRepository.findByMemberId(memberId)
+                ?: throw BusinessException(ErrorCode.MEMBER_AUTH_NOT_FOUND)
+
         val newAccessToken = jwtProvider.createAccessToken(memberAuth.memberId, memberAuth.role)
         val newRefreshToken = jwtProvider.createRefreshToken(memberAuth.memberId)
-        refreshTokenService.saveRefreshToken(memberAuth.memberId, newRefreshToken)
+
+        refreshTokenRepository.save(memberAuth.memberId, newRefreshToken)
+
         return TokenDto(
             accessToken = newAccessToken,
             refreshToken = newRefreshToken,
         )
     }
+
+    @Transactional
+    fun deleteMemberAuth(memberId: Long) {
+        val memberAuth = getMemberAuth(memberId)
+        memberAuth.markAsDeleted()
+        memberAuthRepository.save(memberAuth)
+    }
+
+    private fun isMemberAuthAlreadyExists(request: MemberAuthCreateRequest) {
+        if (memberAuthRepository.existsByMemberId(request.memberId)) {
+            throw BusinessException(ErrorCode.MEMBER_AUTH_ALREADY_EXISTS)
+        }
+    }
+
+    private fun getMemberAuth(memberId: Long): MemberAuth =
+        memberAuthRepository.findByMemberId(memberId)
+            ?: throw BusinessException(ErrorCode.MEMBER_NOT_FOUND)
 }

--- a/src/main/kotlin/com/bandage/v1/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/member/controller/MemberController.kt
@@ -8,6 +8,7 @@ import com.bandage.v1.facade.dto.MemberResponse
 import com.bandage.v1.global.common.constants.PathPrefix.PREFIX
 import com.bandage.v1.global.common.response.ApiResponse
 import com.bandage.v1.global.util.CookieUtil
+import com.bandage.v1.global.util.SecurityUtil
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.servlet.http.HttpServletResponse
@@ -38,7 +39,7 @@ class MemberController(
     @DeleteMapping
     @Operation(summary = "회원 탈퇴 API", description = "회원 정보를 삭제하고 로그아웃 처리합니다.")
     fun withdrawMember(response: HttpServletResponse): ApiResponse<Nothing> {
-        memberWithdrawFacade.withdrawMember()
+        memberWithdrawFacade.withdrawMember(SecurityUtil.getCurrentMemberId())
         response.setHeader(HttpHeaders.SET_COOKIE, CookieUtil.expireCookie())
         return ApiResponse.success()
     }

--- a/src/main/kotlin/com/bandage/v1/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/member/controller/MemberController.kt
@@ -1,8 +1,10 @@
 package com.bandage.v1.domain.member.controller
 
-import com.bandage.v1.domain.member.dto.req.MemberJoinRequest
-import com.bandage.v1.domain.member.dto.res.MemberResponse
 import com.bandage.v1.domain.member.service.MemberService
+import com.bandage.v1.facade.MemberJoinFacade
+import com.bandage.v1.facade.MemberWithdrawFacade
+import com.bandage.v1.facade.dto.MemberJoinRequest
+import com.bandage.v1.facade.dto.MemberResponse
 import com.bandage.v1.global.common.constants.PathPrefix.PREFIX
 import com.bandage.v1.global.common.response.ApiResponse
 import com.bandage.v1.global.util.CookieUtil
@@ -21,17 +23,22 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("$PREFIX/members")
 class MemberController(
     private val memberService: MemberService,
+    private val memberJoinFacade: MemberJoinFacade,
+    private val memberWithdrawFacade: MemberWithdrawFacade,
 ) {
     @PostMapping("/join")
     @Operation(summary = "회원 가입 API", description = "신규 회원을 생성합니다.")
     fun joinMember(
         @RequestBody request: MemberJoinRequest,
-    ): ApiResponse<MemberResponse> = ApiResponse.success(memberService.createMember(request))
+    ): ApiResponse<MemberResponse> =
+        ApiResponse.success(
+            memberJoinFacade.joinMember(request),
+        )
 
     @DeleteMapping
     @Operation(summary = "회원 탈퇴 API", description = "회원 정보를 삭제하고 로그아웃 처리합니다.")
     fun withdrawMember(response: HttpServletResponse): ApiResponse<Nothing> {
-        memberService.deleteMember()
+        memberWithdrawFacade.withdrawMember()
         response.setHeader(HttpHeaders.SET_COOKIE, CookieUtil.expireCookie())
         return ApiResponse.success()
     }

--- a/src/main/kotlin/com/bandage/v1/domain/member/dto/req/MemberCreateRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/member/dto/req/MemberCreateRequest.kt
@@ -2,7 +2,6 @@ package com.bandage.v1.domain.member.dto.req
 
 data class MemberCreateRequest(
     val email: String,
-    val password: String,
     val name: String,
     val contact: String,
 )

--- a/src/main/kotlin/com/bandage/v1/domain/member/dto/req/MemberCreateRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/member/dto/req/MemberCreateRequest.kt
@@ -1,0 +1,8 @@
+package com.bandage.v1.domain.member.dto.req
+
+data class MemberCreateRequest(
+    val email: String,
+    val password: String,
+    val name: String,
+    val contact: String,
+)

--- a/src/main/kotlin/com/bandage/v1/domain/member/model/Member.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/member/model/Member.kt
@@ -1,7 +1,6 @@
 package com.bandage.v1.domain.member.model
 
 import com.bandage.v1.global.common.domain.BaseTimeEntity
-import com.bandage.v1.global.common.domain.enums.MemberRole
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
@@ -15,22 +14,16 @@ import org.hibernate.annotations.SQLRestriction
 @SQLRestriction("deleted_at IS NULL")
 open class Member(
     email: String,
-    password: String,
     name: String,
     contact: String,
-    role: MemberRole = MemberRole.MEMBER,
 ) : BaseTimeEntity() {
     @Id
     @Column(name = "member_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null
+    val id: Long = 0L
 
     @Column(name = "email", unique = true, nullable = false)
     var email: String = email
-        protected set
-
-    @Column(name = "password", nullable = false)
-    var password: String = password
         protected set
 
     @Column(name = "name", nullable = false)
@@ -41,20 +34,14 @@ open class Member(
     var contact: String = contact
         protected set
 
-    @Column(name = "role", nullable = false)
-    var role: MemberRole = role
-        protected set
-
     companion object {
         fun create(
             email: String,
-            password: String,
             name: String,
             contact: String,
         ): Member =
             Member(
                 email = email,
-                password = password,
                 name = name,
                 contact = contact,
             )

--- a/src/main/kotlin/com/bandage/v1/domain/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/member/repository/MemberRepository.kt
@@ -6,7 +6,5 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface MemberRepository : JpaRepository<Member, Long> {
-    fun findByEmail(email: String): Member?
-
-    fun existsMemberByEmail(email: String): Boolean
+    fun existsByEmail(email: String): Boolean
 }

--- a/src/main/kotlin/com/bandage/v1/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/member/service/MemberService.kt
@@ -1,15 +1,10 @@
 package com.bandage.v1.domain.member.service
 
-import com.bandage.v1.domain.member.dto.req.MemberJoinRequest
-import com.bandage.v1.domain.member.dto.res.MemberResponse
+import com.bandage.v1.domain.member.dto.req.MemberCreateRequest
 import com.bandage.v1.domain.member.model.Member
 import com.bandage.v1.domain.member.repository.MemberRepository
-import com.bandage.v1.global.async.event.MemberJoinEvent
-import com.bandage.v1.global.async.event.MemberWithdrawnEvent
-import com.bandage.v1.global.async.publisher.EventPublisher
 import com.bandage.v1.global.error.errorcode.ErrorCode
 import com.bandage.v1.global.error.exception.BusinessException
-import com.bandage.v1.global.util.SecurityUtil
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.stereotype.Service
@@ -20,34 +15,29 @@ import org.springframework.transaction.annotation.Transactional
 class MemberService(
     private val memberRepository: MemberRepository,
     private val passwordEncoder: BCryptPasswordEncoder,
-    private val eventPublisher: EventPublisher,
 ) {
     @Transactional
-    fun createMember(request: MemberJoinRequest): MemberResponse {
-        validateMemberJoin(request)
-        val member =
-            memberRepository.save(
-                Member.create(
-                    email = request.email,
-                    password = encodePassword(request.password),
-                    name = request.name,
-                    contact = request.contact,
-                ),
-            )
-        eventPublisher.publish(MemberJoinEvent.of(member))
-        return MemberResponse.of(member)
+    fun createMember(request: MemberCreateRequest): Member {
+        isMemberAlreadyExists(request)
+        return memberRepository.save(
+            Member.create(
+                email = request.email,
+                password = encodePassword(request.password),
+                name = request.name,
+                contact = request.contact,
+            ),
+        )
     }
 
     @Transactional
-    fun deleteMember() {
-        val member = getMember()
+    fun deleteMember(memberId: Long) {
+        val member = getMember(memberId)
         member.markAsDeleted()
         memberRepository.save(member)
-        eventPublisher.publish(MemberWithdrawnEvent.of(member.id!!))
     }
 
-    private fun validateMemberJoin(request: MemberJoinRequest) {
-        if (memberRepository.existsMemberByEmail(request.email)) {
+    private fun isMemberAlreadyExists(request: MemberCreateRequest) {
+        if (memberRepository.existsByEmail(request.email)) {
             throw BusinessException(ErrorCode.DUPLICATE_EMAIL)
         }
     }
@@ -56,7 +46,7 @@ class MemberService(
         passwordEncoder.encode(rawPassword)
             ?: throw BusinessException(ErrorCode.INTERNAL_SERVER_ERROR)
 
-    private fun getMember(): Member =
-        memberRepository.findByIdOrNull(SecurityUtil.getCurrentMemberId())
+    private fun getMember(memberId: Long): Member =
+        memberRepository.findByIdOrNull(memberId)
             ?: throw BusinessException(ErrorCode.MEMBER_NOT_FOUND)
 }

--- a/src/main/kotlin/com/bandage/v1/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/member/service/MemberService.kt
@@ -6,7 +6,6 @@ import com.bandage.v1.domain.member.repository.MemberRepository
 import com.bandage.v1.global.error.errorcode.ErrorCode
 import com.bandage.v1.global.error.exception.BusinessException
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -14,7 +13,6 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional(readOnly = true)
 class MemberService(
     private val memberRepository: MemberRepository,
-    private val passwordEncoder: BCryptPasswordEncoder,
 ) {
     @Transactional
     fun createMember(request: MemberCreateRequest): Member {
@@ -22,7 +20,6 @@ class MemberService(
         return memberRepository.save(
             Member.create(
                 email = request.email,
-                password = encodePassword(request.password),
                 name = request.name,
                 contact = request.contact,
             ),
@@ -41,10 +38,6 @@ class MemberService(
             throw BusinessException(ErrorCode.DUPLICATE_EMAIL)
         }
     }
-
-    private fun encodePassword(rawPassword: String): String =
-        passwordEncoder.encode(rawPassword)
-            ?: throw BusinessException(ErrorCode.INTERNAL_SERVER_ERROR)
 
     private fun getMember(memberId: Long): Member =
         memberRepository.findByIdOrNull(memberId)

--- a/src/main/kotlin/com/bandage/v1/facade/MemberJoinFacade.kt
+++ b/src/main/kotlin/com/bandage/v1/facade/MemberJoinFacade.kt
@@ -1,0 +1,29 @@
+package com.bandage.v1.facade
+
+import com.bandage.v1.domain.auth.dto.req.MemberAuthCreateRequest
+import com.bandage.v1.domain.auth.service.MemberAuthService
+import com.bandage.v1.domain.member.service.MemberService
+import com.bandage.v1.facade.dto.MemberJoinRequest
+import com.bandage.v1.facade.dto.MemberResponse
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Service
+
+@Service
+class MemberJoinFacade(
+    private val memberService: MemberService,
+    private val memberAuthService: MemberAuthService,
+) {
+    @Transactional
+    fun joinMember(request: MemberJoinRequest): MemberResponse {
+        val member = memberService.createMember(request.toMemberCreateRequest())
+        val authRequest =
+            MemberAuthCreateRequest(
+                memberId = member.id!!,
+                email = member.email,
+                password = member.password,
+                role = member.role,
+            )
+        memberAuthService.createMemberAuth(authRequest)
+        return MemberResponse.of(member)
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/facade/MemberJoinFacade.kt
+++ b/src/main/kotlin/com/bandage/v1/facade/MemberJoinFacade.kt
@@ -1,6 +1,5 @@
 package com.bandage.v1.facade
 
-import com.bandage.v1.domain.auth.dto.req.MemberAuthCreateRequest
 import com.bandage.v1.domain.auth.service.MemberAuthService
 import com.bandage.v1.domain.member.service.MemberService
 import com.bandage.v1.facade.dto.MemberJoinRequest
@@ -16,14 +15,7 @@ class MemberJoinFacade(
     @Transactional
     fun joinMember(request: MemberJoinRequest): MemberResponse {
         val member = memberService.createMember(request.toMemberCreateRequest())
-        val authRequest =
-            MemberAuthCreateRequest(
-                memberId = member.id!!,
-                email = member.email,
-                password = member.password,
-                role = member.role,
-            )
-        memberAuthService.createMemberAuth(authRequest)
+        memberAuthService.createMemberAuth(request.toMemberAuthCreateRequest(member.id))
         return MemberResponse.of(member)
     }
 }

--- a/src/main/kotlin/com/bandage/v1/facade/MemberWithdrawFacade.kt
+++ b/src/main/kotlin/com/bandage/v1/facade/MemberWithdrawFacade.kt
@@ -1,0 +1,23 @@
+package com.bandage.v1.facade
+
+import com.bandage.v1.domain.auth.service.MemberAuthService
+import com.bandage.v1.domain.member.service.MemberService
+import com.bandage.v1.global.security.jwt.RefreshTokenRepository
+import com.bandage.v1.global.util.SecurityUtil
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Service
+
+@Service
+class MemberWithdrawFacade(
+    private val memberService: MemberService,
+    private val memberAuthService: MemberAuthService,
+    private val refreshTokenRepository: RefreshTokenRepository,
+) {
+    @Transactional
+    fun withdrawMember() {
+        val memberId = SecurityUtil.getCurrentMemberId()
+        memberService.deleteMember(memberId)
+        memberAuthService.deleteMemberAuth(memberId)
+        refreshTokenRepository.delete(memberId)
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/facade/MemberWithdrawFacade.kt
+++ b/src/main/kotlin/com/bandage/v1/facade/MemberWithdrawFacade.kt
@@ -3,7 +3,6 @@ package com.bandage.v1.facade
 import com.bandage.v1.domain.auth.service.MemberAuthService
 import com.bandage.v1.domain.member.service.MemberService
 import com.bandage.v1.global.security.jwt.RefreshTokenRepository
-import com.bandage.v1.global.util.SecurityUtil
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
 
@@ -14,8 +13,7 @@ class MemberWithdrawFacade(
     private val refreshTokenRepository: RefreshTokenRepository,
 ) {
     @Transactional
-    fun withdrawMember() {
-        val memberId = SecurityUtil.getCurrentMemberId()
+    fun withdrawMember(memberId: Long) {
         memberService.deleteMember(memberId)
         memberAuthService.deleteMemberAuth(memberId)
         refreshTokenRepository.delete(memberId)

--- a/src/main/kotlin/com/bandage/v1/facade/dto/MemberJoinRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/facade/dto/MemberJoinRequest.kt
@@ -1,5 +1,6 @@
 package com.bandage.v1.facade.dto
 
+import com.bandage.v1.domain.auth.dto.req.MemberAuthCreateRequest
 import com.bandage.v1.domain.member.dto.req.MemberCreateRequest
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Email
@@ -21,8 +22,14 @@ data class MemberJoinRequest(
     fun toMemberCreateRequest(): MemberCreateRequest =
         MemberCreateRequest(
             email = this.email,
-            password = this.password,
             name = this.name,
             contact = this.contact,
+        )
+
+    fun toMemberAuthCreateRequest(memberId: Long): MemberAuthCreateRequest =
+        MemberAuthCreateRequest(
+            memberId = memberId,
+            email = this.email,
+            rawPassword = this.password,
         )
 }

--- a/src/main/kotlin/com/bandage/v1/facade/dto/MemberJoinRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/facade/dto/MemberJoinRequest.kt
@@ -1,5 +1,6 @@
-package com.bandage.v1.domain.member.dto.req
+package com.bandage.v1.facade.dto
 
+import com.bandage.v1.domain.member.dto.req.MemberCreateRequest
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
@@ -16,4 +17,12 @@ data class MemberJoinRequest(
     val name: String,
     @NotBlank @Schema(description = "회원 연락처", example = "010-1234-5678")
     val contact: String,
-)
+) {
+    fun toMemberCreateRequest(): MemberCreateRequest =
+        MemberCreateRequest(
+            email = this.email,
+            password = this.password,
+            name = this.name,
+            contact = this.contact,
+        )
+}

--- a/src/main/kotlin/com/bandage/v1/facade/dto/MemberResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/facade/dto/MemberResponse.kt
@@ -1,4 +1,4 @@
-package com.bandage.v1.domain.member.dto.res
+package com.bandage.v1.facade.dto
 
 import com.bandage.v1.domain.member.model.Member
 import io.swagger.v3.oas.annotations.media.Schema

--- a/src/main/kotlin/com/bandage/v1/global/async/event/MemberJoinEvent.kt
+++ b/src/main/kotlin/com/bandage/v1/global/async/event/MemberJoinEvent.kt
@@ -1,8 +1,8 @@
 package com.bandage.v1.global.async.event
 
-import com.bandage.v1.domain.member.model.Member
-import com.bandage.v1.global.common.domain.enums.MemberRole
+import com.bandage.v1.domain.auth.model.enums.MemberRole
 
+@Deprecated(message = "회원 인증 로직: 이벤트 기반 아키텍처 적용 X")
 data class MemberJoinEvent(
     val memberId: Long,
     val memberEmail: String,
@@ -12,13 +12,13 @@ data class MemberJoinEvent(
         eventType = EventType.MEMBER_JOIN,
         aggregateId = memberId.toString(),
     ) {
-    companion object {
-        fun of(member: Member): MemberJoinEvent =
-            MemberJoinEvent(
-                memberId = member.id!!,
-                memberEmail = member.email,
-                memberPassword = member.password,
-                memberRole = member.role,
-            )
-    }
+//    companion object {
+//        fun of(member: Member): MemberJoinEvent =
+//            MemberJoinEvent(
+//                memberId = member.id!!,
+//                memberEmail = member.email,
+//                memberPassword = member.password,
+//                memberRole = member.role,
+//            )
+//    }
 }

--- a/src/main/kotlin/com/bandage/v1/global/async/event/MemberLoginEvent.kt
+++ b/src/main/kotlin/com/bandage/v1/global/async/event/MemberLoginEvent.kt
@@ -1,5 +1,6 @@
 package com.bandage.v1.global.async.event
 
+@Deprecated(message = "회원 인증 로직: 이벤트 기반 아키텍처 적용 X")
 data class MemberLoginEvent(
     val memberId: Long,
     val refreshToken: String,
@@ -7,14 +8,14 @@ data class MemberLoginEvent(
         eventType = EventType.MEMBER_LOGIN,
         aggregateId = memberId.toString(),
     ) {
-    companion object {
-        fun of(
-            memberId: Long,
-            refreshToken: String,
-        ): MemberLoginEvent =
-            MemberLoginEvent(
-                memberId = memberId,
-                refreshToken = refreshToken,
-            )
-    }
+//    companion object {
+//        fun of(
+//            memberId: Long,
+//            refreshToken: String,
+//        ): MemberLoginEvent =
+//            MemberLoginEvent(
+//                memberId = memberId,
+//                refreshToken = refreshToken,
+//            )
+//    }
 }

--- a/src/main/kotlin/com/bandage/v1/global/async/event/MemberLogoutEvent.kt
+++ b/src/main/kotlin/com/bandage/v1/global/async/event/MemberLogoutEvent.kt
@@ -1,15 +1,16 @@
 package com.bandage.v1.global.async.event
 
+@Deprecated(message = "회원 인증 로직: 이벤트 기반 아키텍처 적용 X")
 data class MemberLogoutEvent(
     val memberId: Long,
 ) : CommonEvent(
         eventType = EventType.MEMBER_LOGOUT,
         aggregateId = memberId.toString(),
     ) {
-    companion object {
-        fun of(memberId: Long): MemberLogoutEvent =
-            MemberLogoutEvent(
-                memberId = memberId,
-            )
-    }
+//    companion object {
+//        fun of(memberId: Long): MemberLogoutEvent =
+//            MemberLogoutEvent(
+//                memberId = memberId,
+//            )
+//    }
 }

--- a/src/main/kotlin/com/bandage/v1/global/async/event/MemberWithdrawnEvent.kt
+++ b/src/main/kotlin/com/bandage/v1/global/async/event/MemberWithdrawnEvent.kt
@@ -1,15 +1,16 @@
 package com.bandage.v1.global.async.event
 
+@Deprecated(message = "회원 인증 로직: 이벤트 기반 아키텍처 적용 X")
 data class MemberWithdrawnEvent(
     val memberId: Long,
 ) : CommonEvent(
         eventType = EventType.MEMBER_WITHDRAW,
         aggregateId = memberId.toString(),
     ) {
-    companion object {
-        fun of(memberId: Long): MemberWithdrawnEvent =
-            MemberWithdrawnEvent(
-                memberId = memberId,
-            )
-    }
+//    companion object {
+//        fun of(memberId: Long): MemberWithdrawnEvent =
+//            MemberWithdrawnEvent(
+//                memberId = memberId,
+//            )
+//    }
 }

--- a/src/main/kotlin/com/bandage/v1/global/error/errorcode/ErrorCode.kt
+++ b/src/main/kotlin/com/bandage/v1/global/error/errorcode/ErrorCode.kt
@@ -19,6 +19,7 @@ enum class ErrorCode(
 
     // auth
     MEMBER_AUTH_NOT_FOUND(HttpStatus.NOT_FOUND, "회원 인증 정보를 찾을 수 없습니다."),
+    MEMBER_AUTH_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 회원가입된 e-mail 입니다"),
     INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다."),
     EXPIRED_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "만료된 토큰입니다."),
 

--- a/src/main/kotlin/com/bandage/v1/global/security/handler/RefreshTokenEventHandler.kt
+++ b/src/main/kotlin/com/bandage/v1/global/security/handler/RefreshTokenEventHandler.kt
@@ -1,37 +1,31 @@
 package com.bandage.v1.global.security.handler
 
-import com.bandage.v1.global.async.event.MemberLoginEvent
-import com.bandage.v1.global.async.event.MemberLogoutEvent
-import com.bandage.v1.global.async.event.MemberWithdrawnEvent
-import com.bandage.v1.global.security.jwt.RefreshTokenService
-import org.springframework.context.event.EventListener
-import org.springframework.scheduling.annotation.Async
+import com.bandage.v1.global.security.jwt.RefreshTokenRepository
 import org.springframework.stereotype.Component
-import org.springframework.transaction.event.TransactionPhase
-import org.springframework.transaction.event.TransactionalEventListener
 
+@Deprecated(message = "회원 인증 로직: 이벤트 기반 아키텍처 적용 X")
 @Component
 class RefreshTokenEventHandler(
-    private val refreshTokenService: RefreshTokenService,
+    private val refreshTokenRepository: RefreshTokenRepository,
 ) {
-    @Async
-    @EventListener
-    fun handleMemberLoginEvent(event: MemberLoginEvent) {
-        refreshTokenService.saveRefreshToken(
-            memberId = event.memberId,
-            refreshToken = event.refreshToken,
-        )
-    }
-
-    @Async
-    @EventListener
-    fun handleMemberLogoutEvent(event: MemberLogoutEvent) {
-        refreshTokenService.deleteRefreshToken(event.memberId)
-    }
-
-    @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    fun handleMemberWithdrawnEvent(event: MemberWithdrawnEvent) {
-        refreshTokenService.deleteRefreshToken(event.memberId)
-    }
+//    @Async
+//    @EventListener
+//    fun handleMemberLoginEvent(event: MemberLoginEvent) {
+//        refreshTokenRepository.save(
+//            memberId = event.memberId,
+//            refreshToken = event.refreshToken,
+//        )
+//    }
+//
+//    @Async
+//    @EventListener
+//    fun handleMemberLogoutEvent(event: MemberLogoutEvent) {
+//        refreshTokenRepository.delete(event.memberId)
+//    }
+//
+//    @Async
+//    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+//    fun handleMemberWithdrawnEvent(event: MemberWithdrawnEvent) {
+//        refreshTokenRepository.delete(event.memberId)
+//    }
 }

--- a/src/main/kotlin/com/bandage/v1/global/security/jwt/JwtProvider.kt
+++ b/src/main/kotlin/com/bandage/v1/global/security/jwt/JwtProvider.kt
@@ -1,6 +1,6 @@
 package com.bandage.v1.global.security.jwt
 
-import com.bandage.v1.global.common.domain.enums.MemberRole
+import com.bandage.v1.domain.auth.model.enums.MemberRole
 import com.bandage.v1.global.error.exception.Exception
 import com.bandage.v1.global.properties.JwtProperties
 import com.bandage.v1.global.security.PrincipalDetails

--- a/src/main/kotlin/com/bandage/v1/global/security/jwt/RedisRefreshTokenAdapter.kt
+++ b/src/main/kotlin/com/bandage/v1/global/security/jwt/RedisRefreshTokenAdapter.kt
@@ -8,18 +8,18 @@ import org.springframework.stereotype.Service
 import java.time.Duration
 
 @Service
-class RefreshTokenService(
+class RedisRefreshTokenAdapter(
     private val redisTemplate: RedisTemplate<String, String>,
     private val jwtProperties: JwtProperties,
     private val jwtProvider: JwtProvider,
-) {
+) : RefreshTokenRepository {
     val refreshExpr = jwtProperties.refreshTokenExpr
 
     companion object {
         private const val RT_PREFIX = "RT:"
     }
 
-    fun saveRefreshToken(
+    override fun save(
         memberId: Long,
         refreshToken: String,
     ) {
@@ -30,7 +30,7 @@ class RefreshTokenService(
         )
     }
 
-    fun validateRefreshToken(
+    override fun validate(
         refreshToken: String,
         memberId: Long,
     ) {
@@ -40,7 +40,7 @@ class RefreshTokenService(
         if (refreshToken != savedRefreshToken) throw BusinessException(ErrorCode.INVALID_REFRESH_TOKEN)
     }
 
-    fun deleteRefreshToken(memberId: Long) {
+    override fun delete(memberId: Long) {
         redisTemplate.delete(getRtKey(memberId))
     }
 

--- a/src/main/kotlin/com/bandage/v1/global/security/jwt/RedisRefreshTokenAdapter.kt
+++ b/src/main/kotlin/com/bandage/v1/global/security/jwt/RedisRefreshTokenAdapter.kt
@@ -1,8 +1,5 @@
 package com.bandage.v1.global.security.jwt
 
-import com.bandage.v1.global.error.errorcode.ErrorCode
-import com.bandage.v1.global.error.exception.BusinessException
-import com.bandage.v1.global.properties.JwtProperties
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Service
 import java.time.Duration
@@ -10,11 +7,7 @@ import java.time.Duration
 @Service
 class RedisRefreshTokenAdapter(
     private val redisTemplate: RedisTemplate<String, String>,
-    private val jwtProperties: JwtProperties,
-    private val jwtProvider: JwtProvider,
 ) : RefreshTokenRepository {
-    val refreshExpr = jwtProperties.refreshTokenExpr
-
     companion object {
         private const val RT_PREFIX = "RT:"
     }
@@ -22,29 +15,20 @@ class RedisRefreshTokenAdapter(
     override fun save(
         memberId: Long,
         refreshToken: String,
+        expiration: Long,
     ) {
         redisTemplate.opsForValue().set(
             getRtKey(memberId),
             refreshToken,
-            Duration.ofMillis(refreshExpr),
+            Duration.ofMillis(expiration),
         )
-    }
-
-    override fun validate(
-        refreshToken: String,
-        memberId: Long,
-    ) {
-        if (!jwtProvider.validateToken(refreshToken)) throw BusinessException(ErrorCode.INVALID_REFRESH_TOKEN)
-        val memberId = jwtProvider.getMemberIdFromToken(refreshToken)
-        val savedRefreshToken = getRefreshToken(memberId) ?: throw BusinessException(ErrorCode.EXPIRED_REFRESH_TOKEN)
-        if (refreshToken != savedRefreshToken) throw BusinessException(ErrorCode.INVALID_REFRESH_TOKEN)
     }
 
     override fun delete(memberId: Long) {
         redisTemplate.delete(getRtKey(memberId))
     }
 
-    private fun getRtKey(memberId: Long): String = "$RT_PREFIX$memberId"
+    override fun get(memberId: Long): String? = redisTemplate.opsForValue().get(getRtKey(memberId))
 
-    private fun getRefreshToken(memberId: Long): String? = redisTemplate.opsForValue().get(getRtKey(memberId))
+    private fun getRtKey(memberId: Long): String = "$RT_PREFIX$memberId"
 }

--- a/src/main/kotlin/com/bandage/v1/global/security/jwt/RefreshTokenRepository.kt
+++ b/src/main/kotlin/com/bandage/v1/global/security/jwt/RefreshTokenRepository.kt
@@ -4,12 +4,10 @@ interface RefreshTokenRepository {
     fun save(
         memberId: Long,
         refreshToken: String,
+        expiration: Long,
     )
 
     fun delete(memberId: Long)
 
-    fun validate(
-        refreshToken: String,
-        memberId: Long,
-    )
+    fun get(memberId: Long): String?
 }

--- a/src/main/kotlin/com/bandage/v1/global/security/jwt/RefreshTokenRepository.kt
+++ b/src/main/kotlin/com/bandage/v1/global/security/jwt/RefreshTokenRepository.kt
@@ -1,0 +1,15 @@
+package com.bandage.v1.global.security.jwt
+
+interface RefreshTokenRepository {
+    fun save(
+        memberId: Long,
+        refreshToken: String,
+    )
+
+    fun delete(memberId: Long)
+
+    fun validate(
+        refreshToken: String,
+        memberId: Long,
+    )
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #40 

📌 **작업 내용 및 특이사항**

- Member-MemberAuth 간 동기화 로직 롤백(비동기 이벤트 처리 -> 동기 호출)
- Facade 패턴 도입(MembrJoinFacade, MemberWithdrawFacade)
- Port/Adapter 패턴 도입(인프라게층 추상화)
- Member 인증 관련 필드 (MemberRole, Password) -> MemberAuth 이동 (도메인 책임 단일화)
- MemberAuth PK -> Member와 식별자 공유
- redisRepository: 인프라 계층 상호 작용 외 로직 제거(JWT 검증 등)


📚 **참고사항**
