### PR TITLE
Feat: Practice Song CRUD 구현

### DIFF
--- a/src/main/kotlin/com/bandage/v1/domain/performance/dto/req/PerformanceCreateRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/dto/req/PerformanceCreateRequest.kt
@@ -20,6 +20,6 @@ data class PerformanceCreateRequest(
     @field:Min(1)
     @Schema(description = "공연 시간 (분)", example = "120")
     val durationMinutes: Int,
-    @Schema(description = "공연 장소", example = "홍대 클럽 빵")
+    @Schema(description = "공연 장소", example = "Club FF")
     val venue: String?,
 )

--- a/src/main/kotlin/com/bandage/v1/domain/performance/dto/req/PerformanceUpdateRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/dto/req/PerformanceUpdateRequest.kt
@@ -17,6 +17,6 @@ data class PerformanceUpdateRequest(
     @field:Min(1)
     @Schema(description = "공연 시간 (분)", example = "90")
     val durationMinutes: Int,
-    @Schema(description = "공연 장소", example = "강남 클럽")
+    @Schema(description = "공연 장소", example = "Club FF")
     val venue: String?,
 )

--- a/src/main/kotlin/com/bandage/v1/domain/performance/dto/res/PerformanceDetailResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/dto/res/PerformanceDetailResponse.kt
@@ -17,7 +17,7 @@ data class PerformanceDetailResponse(
     val startAt: LocalDateTime,
     @Schema(description = "공연 시간 (분)", example = "120")
     val durationMinutes: Int,
-    @Schema(description = "공연 장소", example = "홍대 클럽 빵")
+    @Schema(description = "공연 장소", example = "Club FF")
     val venue: String?,
     @Schema(description = "참여 밴드 아이디 목록")
     val bandIds: List<UUID>,

--- a/src/main/kotlin/com/bandage/v1/domain/performance/dto/res/PerformanceListResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/dto/res/PerformanceListResponse.kt
@@ -17,7 +17,7 @@ data class PerformanceListResponse(
     val startAt: LocalDateTime,
     @Schema(description = "공연 시간 (분)", example = "120")
     val durationMinutes: Int,
-    @Schema(description = "공연 장소", example = "홍대 클럽 빵")
+    @Schema(description = "공연 장소", example = "Club FF")
     val venue: String?,
 ) {
     companion object {

--- a/src/main/kotlin/com/bandage/v1/domain/practice/controller/PracticeSongController.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/controller/PracticeSongController.kt
@@ -7,6 +7,7 @@ import com.bandage.v1.global.common.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -30,5 +31,12 @@ class PracticeSongController(
         return ApiResponse.success()
     }
 
-    // TODO: Practice Song 참조 링크 삭제
+    @DeleteMapping("/{songId}/ref-link")
+    @Operation(summary = "합주곡 참조 링크 삭제 API", description = "합주곡 참조 링크를 삭제합니다.")
+    fun deleteRefLink(
+        @PathVariable songId: UUID,
+    ): ApiResponse<Unit> {
+        practiceService.deletePracticeSongRefLink(songId)
+        return ApiResponse.success()
+    }
 }

--- a/src/main/kotlin/com/bandage/v1/domain/practice/controller/PracticeSongController.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/controller/PracticeSongController.kt
@@ -1,0 +1,34 @@
+package com.bandage.v1.domain.practice.controller
+
+import com.bandage.v1.domain.practice.dto.req.PracticeSongRefLinkUpsertRequest
+import com.bandage.v1.domain.practice.service.PracticeService
+import com.bandage.v1.global.common.constants.PathPrefix.PREFIX
+import com.bandage.v1.global.common.response.ApiResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@Tag(name = "practice-songs", description = "합주곡 API")
+@RestController
+@RequestMapping("$PREFIX/practice-songs")
+class PracticeSongController(
+    private val practiceService: PracticeService,
+) {
+    @PutMapping("/{songId}/ref-link")
+    @Operation(summary = "합주곡 참조 링크 upsert API", description = "합주곡 참조 링크를 등록하거나 수정합니다.")
+    fun upsertRefLink(
+        @PathVariable songId: UUID,
+        @Valid @RequestBody request: PracticeSongRefLinkUpsertRequest,
+    ): ApiResponse<Unit> {
+        practiceService.upsertPracticeSongRefLink(songId, request)
+        return ApiResponse.success()
+    }
+
+    // TODO: Practice Song 참조 링크 삭제
+}

--- a/src/main/kotlin/com/bandage/v1/domain/practice/dto/req/PracticeSongRefLinkUpsertRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/dto/req/PracticeSongRefLinkUpsertRequest.kt
@@ -1,0 +1,11 @@
+package com.bandage.v1.domain.practice.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+
+@Schema(description = "합주곡 참조 링크 upsert 요청")
+data class PracticeSongRefLinkUpsertRequest(
+    @field:NotBlank
+    @Schema(description = "참조 링크 URL", example = "https://www.youtube.com/watch?v=example")
+    val refLink: String,
+)

--- a/src/main/kotlin/com/bandage/v1/domain/practice/dto/req/PracticeVenueUpdateRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/dto/req/PracticeVenueUpdateRequest.kt
@@ -5,6 +5,6 @@ import jakarta.validation.constraints.NotBlank
 
 @Schema(description = "합주 장소 변경 요청")
 data class PracticeVenueUpdateRequest(
-    @NotBlank @Schema(description = "합주 장소", example = "홍대 스튜디오")
+    @NotBlank @Schema(description = "합주 장소", example = "Club FF")
     val venue: String,
 )

--- a/src/main/kotlin/com/bandage/v1/domain/practice/dto/res/PracticeDetailResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/dto/res/PracticeDetailResponse.kt
@@ -12,7 +12,7 @@ data class PracticeDetailResponse(
     val practiceId: UUID,
     @Schema(description = "합주 타이틀", example = "TuNA 정기공연 1주차 합주")
     val title: String,
-    @Schema(description = "합주 장소", example = "홍대 스튜디오")
+    @Schema(description = "합주 장소", example = "Club FF")
     val venue: String?,
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm", shape = JsonFormat.Shape.STRING, timezone = "Asia/Seoul")
     @Schema(description = "합주 시작 시간", example = "2026-03-15 18:00")

--- a/src/main/kotlin/com/bandage/v1/domain/practice/model/PracticeSong.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/model/PracticeSong.kt
@@ -63,4 +63,8 @@ open class PracticeSong(
     fun updateRefLink(refLink: String) {
         this.refLink = refLink
     }
+
+    fun deleteRefLink() {
+        this.refLink = null
+    }
 }

--- a/src/main/kotlin/com/bandage/v1/domain/practice/service/PracticeService.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/service/PracticeService.kt
@@ -158,6 +158,12 @@ class PracticeService(
         song.updateRefLink(request.refLink)
     }
 
+    @Transactional
+    fun deletePracticeSongRefLink(songId: UUID) {
+        val song = getPracticeSong(songId)
+        song.deleteRefLink()
+    }
+
     // --- 내부 유틸리티 메서드 ---
     private fun getPractice(practiceId: UUID): Practice =
         practiceRepository.findByIdOrNull(practiceId)

--- a/src/main/kotlin/com/bandage/v1/domain/practice/service/PracticeService.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/service/PracticeService.kt
@@ -4,6 +4,7 @@ import com.bandage.v1.domain.practice.dto.req.PracticeCreateRequest
 import com.bandage.v1.domain.practice.dto.req.PracticeMemberAddRequest
 import com.bandage.v1.domain.practice.dto.req.PracticeScheduleUpdateRequest
 import com.bandage.v1.domain.practice.dto.req.PracticeSessionCreateRequest
+import com.bandage.v1.domain.practice.dto.req.PracticeSongRefLinkUpsertRequest
 import com.bandage.v1.domain.practice.dto.req.PracticeVenueUpdateRequest
 import com.bandage.v1.domain.practice.dto.res.PracticeDetailResponse
 import com.bandage.v1.domain.practice.dto.res.PracticeParticipantResponse
@@ -146,6 +147,15 @@ class PracticeService(
     ) {
         val practice = getPractice(practiceId)
         practice.markAsDeleted(memberId)
+    }
+
+    @Transactional
+    fun upsertPracticeSongRefLink(
+        songId: UUID,
+        request: PracticeSongRefLinkUpsertRequest,
+    ) {
+        val song = getPracticeSong(songId)
+        song.updateRefLink(request.refLink)
     }
 
     // --- 내부 유틸리티 메서드 ---


### PR DESCRIPTION
## 🛠️Issue Number                                                                                                                                                            
  ### closes #13                                                                                                                                                                
                                                                                                                                                                                
  📌 **작업 내용 및 특이사항**                                                                                                                                                  
                                                            
  ### 변경 사항                                                                                                                                                                 
                                                            
  **합주곡 참조 링크 CRUD API 구현**                                                                                                                                            
                                                            
  - `PracticeSong.deleteRefLink()` 메서드 추가 — `refLink` 필드를 null로 초기화                                                                                                 
  - `PracticeSongRefLinkUpsertRequest` DTO 추가 (`@NotBlank` 검증)
  - `PracticeService.upsertPracticeSongRefLink()` / `deletePracticeSongRefLink()` 구현                                                                                          
  - `PracticeSongController` 신규 생성                                                                                                                                          
    - `PUT /practice-songs/{songId}/ref-link` — 참조 링크 등록/수정                                                                                                             
    - `DELETE /practice-songs/{songId}/ref-link` — 참조 링크 삭제                                                                                                               
  - 두 엔드포인트 모두 `@CurrentMemberId`로 인증 적용                                                                                                                           
                                                                                                                                                                                
  **Swagger 예시 수정**                                                                                                                                                         
                                                                                                                                                                                
  - Performance/Practice API의 venue 예시 값 통일 (`"Club FF"`)                                                                                                                 
   
  📚 **참고사항**                                                                                                                                                               
                                                            
  - 참조 링크 upsert는 `PUT` + `updateRefLink()` 활용 (기존 메서드 재사용)                                                                                                      
  - 삭제는 hard delete 없이 `refLink = null` 처리 (소프트 nullable 패턴)
