### PR TITLE
Fix: refresh 토큰 재발급 403 수정 + 인증 화이트리스트 정리

### DIFF
--- a/API_SPEC.md
+++ b/API_SPEC.md
@@ -2,7 +2,7 @@
 
 Base URL: `/api/v1`
 
-모든 응답은 `ApiResponse<T>` 래퍼로 감싸져 반환됩니다.  
+모든 응답은 `ApiResponse<T>` 래퍼로 감싸져 반환됩니다.
 인증이 필요한 API는 `Authorization: Bearer {accessToken}` 헤더를 사용합니다.
 
 ---
@@ -142,7 +142,7 @@ Base URL: `/api/v1`
 
 ### 3-2. 밴드 단건 조회
 - **GET** `/api/v1/bands/{bandId}`
-- **인증 불필요**
+- **인증 필요**
 - **Path Variable**: `bandId` (UUID)
 - **Response**
   ```json
@@ -158,7 +158,7 @@ Base URL: `/api/v1`
 
 ### 3-3. 밴드 목록 조회 (커서 페이징)
 - **GET** `/api/v1/bands`
-- **인증 불필요**
+- **인증 필요**
 - **Query Parameters**
   | 파라미터 | 타입 | 필수 | 기본값 | 설명 |
   |---------|------|------|--------|------|
@@ -170,7 +170,7 @@ Base URL: `/api/v1`
 
 ### 3-4. 밴드 멤버 단건 조회
 - **GET** `/api/v1/bands/{bandId}/members/{bandMemberId}`
-- **인증 불필요**
+- **인증 필요**
 - **Path Variables**: `bandId` (UUID), `bandMemberId` (UUID)
 - **Response**
   ```json
@@ -186,7 +186,7 @@ Base URL: `/api/v1`
 
 ### 3-5. 밴드 멤버 목록 조회 (커서 페이징)
 - **GET** `/api/v1/bands/{bandId}/members`
-- **인증 불필요**
+- **인증 필요**
 - **Path Variable**: `bandId` (UUID)
 - **Query Parameters**: `lastId` (UUID, optional), `pageSize` (Int 1~100, 기본값 10)
 - **Response**: `CursorResponse<BandMemberInfoResponse, UUID>`
@@ -257,13 +257,13 @@ Base URL: `/api/v1`
 
 ### 4-1. 합주 생성
 - **POST** `/api/v1/practices`
-- **인증 불필요** (TODO: 인증 추가 예정)
+- **인증 필요**
 - **Request Body**
   ```json
   {
     "title": "TuNA 정기공연 1주차 합주",
     "song": "550e8400-e29b-41d4-a716-446655440000",
-    "venue": "TuNA",
+    "venue": "홍대 스튜디오",
     "startAt": "2026-03-15 18:00",
     "durationMinutes": 60
   }
@@ -281,18 +281,316 @@ Base URL: `/api/v1`
 
 ---
 
-## 미구현 (TODO)
+### 4-2. 합주 상세 조회
+- **GET** `/api/v1/practices/{practiceId}`
+- **인증 필요**
+- **Path Variable**: `practiceId` (UUID)
+- **Response**
+  ```json
+  {
+    "practiceId": "550e8400-e29b-41d4-a716-446655440000",
+    "title": "TuNA 정기공연 1주차 합주",
+    "venue": "홍대 스튜디오",
+    "startAt": "2026-03-15 18:00",
+    "durationMinutes": 60,
+    "song": {
+      "songId": "550e8400-e29b-41d4-a716-446655440000",
+      "title": "Stairway to Heaven",
+      "artist": "Led Zeppelin"
+    },
+    "sessions": [
+      {
+        "sessionId": "550e8400-e29b-41d4-a716-446655440000",
+        "label": "Guitar 2",
+        "type": "GUITAR",
+        "participant": null
+      }
+    ],
+    "participants": [
+      {
+        "participantId": "550e8400-e29b-41d4-a716-446655440000",
+        "memberId": 1
+      }
+    ]
+  }
+  ```
 
-`PracticeController`에 명시된 미구현 API 목록:
+---
 
-| 기능 | 설명 |
-|------|------|
-| 합주 조회 | 합주 단건/목록 조회 |
-| 합주 세션 생성 | 합주 내 세션 추가 |
-| 합주 세션 삭제 | 합주 세션 제거 |
-| 합주 멤버 추가 | 합주에 멤버 추가 |
-| 합주 세션 멤버 지정 | 세션 참여 신청 (본인) |
-| 합주 세션 멤버 지정 취소 | 세션 참여 취소 (본인) |
-| 합주 일정 변경 | 날짜/시간 수정 |
-| 합주 장소 변경 | 장소 수정 |
-| 합주 삭제 | 합주 soft delete |
+### 4-3. 합주 세션 생성
+- **POST** `/api/v1/practices/{practiceId}/sessions`
+- **인증 필요**
+- **Path Variable**: `practiceId` (UUID)
+- **Request Body**
+  ```json
+  {
+    "label": "Guitar 2",
+    "type": "GUITAR"
+  }
+  ```
+  - `type` enum — `VOCAL` | `CHORUS` | `GUITAR` | `BASS` | `DRUM` | `PERCUSSION` | `SYNTH` | `ETC` (기본값: `ETC`)
+- **Response**
+  ```json
+  {
+    "sessionId": "550e8400-e29b-41d4-a716-446655440000",
+    "label": "Guitar 2",
+    "type": "GUITAR",
+    "participant": null
+  }
+  ```
+
+---
+
+### 4-4. 합주 세션 삭제
+- **DELETE** `/api/v1/practices/{practiceId}/sessions/{sessionId}`
+- **인증 필요**
+- **Path Variables**: `practiceId` (UUID), `sessionId` (UUID)
+
+---
+
+### 4-5. 합주 멤버 추가
+- **POST** `/api/v1/practices/{practiceId}/participants`
+- **인증 필요**
+- **Path Variable**: `practiceId` (UUID)
+- **Request Body**
+  ```json
+  {
+    "memberId": 1
+  }
+  ```
+- **Response**
+  ```json
+  {
+    "participantId": "550e8400-e29b-41d4-a716-446655440000",
+    "memberId": 1
+  }
+  ```
+
+---
+
+### 4-6. 합주 세션 멤버 지정 (본인)
+- **PATCH** `/api/v1/practices/{practiceId}/sessions/{sessionId}/assignment`
+- **인증 필요**
+- **Path Variables**: `practiceId` (UUID), `sessionId` (UUID)
+- **비고**: 본인을 해당 세션에 배정
+
+---
+
+### 4-7. 합주 세션 멤버 지정 취소 (본인)
+- **DELETE** `/api/v1/practices/{practiceId}/sessions/{sessionId}/assignment`
+- **인증 필요**
+- **Path Variables**: `practiceId` (UUID), `sessionId` (UUID)
+- **비고**: 본인의 세션 배정 취소
+
+---
+
+### 4-8. 합주 일정 변경
+- **PATCH** `/api/v1/practices/{practiceId}/schedule`
+- **인증 필요**
+- **Path Variable**: `practiceId` (UUID)
+- **Request Body**
+  ```json
+  {
+    "startAt": "2026-03-15 18:00",
+    "durationMinutes": 90
+  }
+  ```
+  - `startAt` 형식: `yyyy-MM-dd HH:mm` (Asia/Seoul 기준)
+
+---
+
+### 4-9. 합주 장소 변경
+- **PATCH** `/api/v1/practices/{practiceId}/venue`
+- **인증 필요**
+- **Path Variable**: `practiceId` (UUID)
+- **Request Body**
+  ```json
+  {
+    "venue": "Club FF"
+  }
+  ```
+
+---
+
+### 4-10. 합주 삭제
+- **DELETE** `/api/v1/practices/{practiceId}`
+- **인증 필요**
+- **Path Variable**: `practiceId` (UUID)
+
+---
+
+## 5. 합주곡 (Practice Song)
+
+### 5-1. 합주곡 참조 링크 등록/수정 (Upsert)
+- **PUT** `/api/v1/practice-songs/{songId}/ref-link`
+- **인증 필요**
+- **Path Variable**: `songId` (UUID)
+- **Request Body**
+  ```json
+  {
+    "refLink": "https://www.youtube.com/watch?v=example"
+  }
+  ```
+
+---
+
+### 5-2. 합주곡 참조 링크 삭제
+- **DELETE** `/api/v1/practice-songs/{songId}/ref-link`
+- **인증 필요**
+- **Path Variable**: `songId` (UUID)
+
+---
+
+## 6. 공연 (Performance)
+
+### 6-1. 공연 생성
+- **POST** `/api/v1/performances`
+- **인증 필요**
+- **Request Body**
+  ```json
+  {
+    "title": "TuNA 정기공연",
+    "bandIds": ["550e8400-e29b-41d4-a716-446655440000"],
+    "startAt": "2026-06-15 18:00",
+    "durationMinutes": 120,
+    "venue": "Club FF"
+  }
+  ```
+  - `bandIds`: optional (기본값 빈 배열)
+  - `venue`: optional
+  - `startAt` 형식: `yyyy-MM-dd HH:mm` (Asia/Seoul 기준)
+- **Response**
+  ```json
+  {
+    "performanceId": "550e8400-e29b-41d4-a716-446655440000",
+    "title": "TuNA 정기공연"
+  }
+  ```
+- **비고**: 생성자는 자동으로 PerformanceManager로 등록
+
+---
+
+### 6-2. 공연 목록 조회 (커서 페이징)
+- **GET** `/api/v1/performances`
+- **인증 필요**
+- **Query Parameters**
+  | 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+  |---------|------|------|--------|------|
+  | `bandId` | UUID | N | - | 특정 밴드 소속 공연만 조회 |
+  | `lastId` | UUID | N | - | 이전 페이지 마지막 공연 ID |
+  | `pageSize` | Int (1~100) | N | 10 | 페이지 크기 |
+- **Response**: `CursorResponse<PerformanceListResponse, UUID>`
+  ```json
+  {
+    "performanceId": "550e8400-e29b-41d4-a716-446655440000",
+    "title": "TuNA 정기공연",
+    "startAt": "2026-06-15 18:00",
+    "durationMinutes": 120,
+    "venue": "Club FF"
+  }
+  ```
+
+---
+
+### 6-3. 공연 상세 조회
+- **GET** `/api/v1/performances/{performanceId}`
+- **인증 필요**
+- **Path Variable**: `performanceId` (UUID)
+- **Response**
+  ```json
+  {
+    "performanceId": "550e8400-e29b-41d4-a716-446655440000",
+    "title": "TuNA 정기공연",
+    "startAt": "2026-06-15 18:00",
+    "durationMinutes": 120,
+    "venue": "Club FF",
+    "bandIds": ["550e8400-e29b-41d4-a716-446655440000"],
+    "managerIds": [1],
+    "practiceIds": ["550e8400-e29b-41d4-a716-446655440001"]
+  }
+  ```
+
+---
+
+### 6-4. 공연 정보 수정
+- **PATCH** `/api/v1/performances/{performanceId}`
+- **인증 필요** (PerformanceManager)
+- **Path Variable**: `performanceId` (UUID)
+- **Request Body**
+  ```json
+  {
+    "title": "TuNA 정기공연 (수정)",
+    "startAt": "2026-06-15 19:00",
+    "durationMinutes": 90,
+    "venue": "Club FF"
+  }
+  ```
+  - `venue`: optional
+
+---
+
+### 6-5. 공연 합주 추가 (신규 생성)
+- **POST** `/api/v1/performances/{performanceId}/practices`
+- **인증 필요** (PerformanceManager)
+- **Path Variable**: `performanceId` (UUID)
+- **Request Body**
+  ```json
+  {
+    "title": "TuNA 정기공연 합주",
+    "songId": "550e8400-e29b-41d4-a716-446655440000",
+    "startAt": "2026-06-01 18:00",
+    "durationMinutes": 60,
+    "venue": "홍대 스튜디오"
+  }
+  ```
+  - `title`: optional (미입력 시 곡 제목으로 대체)
+  - `venue`: optional
+- **Response**
+  ```json
+  {
+    "performancePracticeId": "550e8400-e29b-41d4-a716-446655440000",
+    "practiceId": "550e8400-e29b-41d4-a716-446655440001"
+  }
+  ```
+- **비고**: 빈 합주를 즉시 생성하여 공연에 연결
+
+---
+
+### 6-6. 공연 합주 일괄 추가 (기존 합주 연결)
+- **POST** `/api/v1/performances/{performanceId}/practices/batch`
+- **인증 필요** (PerformanceManager)
+- **Path Variable**: `performanceId` (UUID)
+- **Request Body**
+  ```json
+  {
+    "practiceIds": [
+      "550e8400-e29b-41d4-a716-446655440000",
+      "550e8400-e29b-41d4-a716-446655440001"
+    ]
+  }
+  ```
+- **Response**: `List<PerformancePracticeResponse>`
+  ```json
+  [
+    {
+      "performancePracticeId": "550e8400-e29b-41d4-a716-446655440000",
+      "practiceId": "550e8400-e29b-41d4-a716-446655440001"
+    }
+  ]
+  ```
+
+---
+
+### 6-7. 공연 합주 삭제
+- **DELETE** `/api/v1/performances/{performanceId}/practices/{practiceId}`
+- **인증 필요** (PerformanceManager)
+- **Path Variables**: `performanceId` (UUID), `practiceId` (UUID)
+- **비고**: 공연과 합주의 연결을 제거 (합주 자체는 삭제되지 않음)
+
+---
+
+### 6-8. 공연 삭제
+- **DELETE** `/api/v1/performances/{performanceId}`
+- **인증 필요** (PerformanceManager)
+- **Path Variable**: `performanceId` (UUID)
+- **비고**: 연관된 합주도 함께 삭제

--- a/src/main/kotlin/com/bandage/v1/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/member/controller/MemberController.kt
@@ -1,6 +1,7 @@
 package com.bandage.v1.domain.member.controller
 
 import com.bandage.v1.domain.member.dto.req.MemberInfoUpdateRequest
+import com.bandage.v1.domain.member.dto.res.MemberInfoResponse
 import com.bandage.v1.domain.member.service.MemberService
 import com.bandage.v1.facade.MemberJoinFacade
 import com.bandage.v1.facade.MemberWithdrawFacade
@@ -44,10 +45,10 @@ class MemberController(
     @Operation(summary = "회원 정보 조회 API", description = "회원 본인의 정보를 조회합니다.")
     fun getMemberInfo(
         @CurrentMemberId memberId: Long,
-    ): ApiResponse<Unit> {
-        memberService.getMemberInfo(memberId)
-        return ApiResponse.success()
-    }
+    ): ApiResponse<MemberInfoResponse> =
+        ApiResponse.success(
+            memberService.getMemberInfo(memberId),
+        )
 
     @PatchMapping("/me")
     @Operation(summary = "회원 기본 정보 변경 API", description = "회원 본인의 정보를 조회합니다.")

--- a/src/main/kotlin/com/bandage/v1/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/bandage/v1/global/security/SecurityConfig.kt
@@ -2,6 +2,7 @@ package com.bandage.v1.global.security
 
 import com.bandage.v1.global.security.constants.SecurityPathConstants
 import com.bandage.v1.global.security.filter.JwtAuthenticationFilter
+import com.bandage.v1.global.security.handler.JwtAuthenticationEntryPoint
 import com.bandage.v1.global.security.jwt.JwtProvider
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -16,6 +17,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableWebSecurity
 class SecurityConfig(
     private val jwtProvider: JwtProvider,
+    private val jwtAuthenticationEntryPoint: JwtAuthenticationEntryPoint,
 ) {
     @Bean
     fun passwordEncoder(): BCryptPasswordEncoder = BCryptPasswordEncoder()
@@ -37,7 +39,8 @@ class SecurityConfig(
                     ).permitAll()
                     .anyRequest()
                     .authenticated()
-            }.addFilterBefore(JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter::class.java)
+            }.exceptionHandling { it.authenticationEntryPoint(jwtAuthenticationEntryPoint) }
+            .addFilterBefore(JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter::class.java)
 
         return http.build()
     }

--- a/src/main/kotlin/com/bandage/v1/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/bandage/v1/global/security/SecurityConfig.kt
@@ -6,12 +6,17 @@ import com.bandage.v1.global.security.handler.JwtAuthenticationEntryPoint
 import com.bandage.v1.global.security.jwt.JwtProvider
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.CorsConfigurationSource
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 
 @Configuration
 @EnableWebSecurity
@@ -26,6 +31,7 @@ class SecurityConfig(
     fun filterChain(http: HttpSecurity): SecurityFilterChain {
         http
             .csrf { it.disable() }
+            .cors { it.configurationSource(corsConfigurationSource()) }
             .formLogin { it.disable() }
             .httpBasic { it.disable() }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
@@ -43,5 +49,33 @@ class SecurityConfig(
             .addFilterBefore(JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter::class.java)
 
         return http.build()
+    }
+
+    @Bean
+    fun corsConfigurationSource(): CorsConfigurationSource {
+        val configuration =
+            CorsConfiguration().apply {
+                allowedOriginPatterns =
+                    listOf(
+                        "http://localhost:*",
+                        "http://127.0.0.1:*",
+                    )
+                allowedMethods =
+                    listOf(
+                        HttpMethod.GET.name(),
+                        HttpMethod.POST.name(),
+                        HttpMethod.PUT.name(),
+                        HttpMethod.PATCH.name(),
+                        HttpMethod.DELETE.name(),
+                        HttpMethod.OPTIONS.name(),
+                    )
+                allowedHeaders = listOf(CorsConfiguration.ALL)
+                exposedHeaders = listOf(HttpHeaders.SET_COOKIE)
+                allowCredentials = true
+                maxAge = 3600
+            }
+        return UrlBasedCorsConfigurationSource().apply {
+            registerCorsConfiguration("/**", configuration)
+        }
     }
 }

--- a/src/main/kotlin/com/bandage/v1/global/security/constants/SecurityPathConstants.kt
+++ b/src/main/kotlin/com/bandage/v1/global/security/constants/SecurityPathConstants.kt
@@ -6,6 +6,7 @@ object SecurityPathConstants {
     val AUTH_WHITELIST =
         arrayOf(
             "${PathPrefix.PREFIX}/auth/login",
+            "${PathPrefix.PREFIX}/auth/refresh",
             "${PathPrefix.PREFIX}/members/join",
         )
 

--- a/src/main/kotlin/com/bandage/v1/global/security/constants/SecurityPathConstants.kt
+++ b/src/main/kotlin/com/bandage/v1/global/security/constants/SecurityPathConstants.kt
@@ -28,7 +28,8 @@ object SecurityPathConstants {
     val TMP_FOR_TEST =
         arrayOf(
 //            "${PathPrefix.PREFIX}/bands/**",
-            "${PathPrefix.PREFIX}/practices/**",
-            "${PathPrefix.PREFIX}/performances/**",
+//            "${PathPrefix.PREFIX}/practices/**",
+//            "${PathPrefix.PREFIX}/performances/**",
+            "${PathPrefix.PREFIX}/tmp/**",
         )
 }

--- a/src/main/kotlin/com/bandage/v1/global/security/handler/JwtAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/com/bandage/v1/global/security/handler/JwtAuthenticationEntryPoint.kt
@@ -1,0 +1,29 @@
+package com.bandage.v1.global.security.handler
+
+import com.bandage.v1.global.error.errorcode.ErrorCode
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+
+@Component
+class JwtAuthenticationEntryPoint : AuthenticationEntryPoint {
+    override fun commence(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authException: AuthenticationException,
+    ) {
+        val errorCode = ErrorCode.UNAUTHORIZED
+        response.status = errorCode.status.value()
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        response.characterEncoding = Charsets.UTF_8.name()
+        response.setHeader(HttpHeaders.WWW_AUTHENTICATE, """Bearer error="invalid_token"""")
+        response.writer.write(
+            """{"success":false,"message":"${errorCode.message}","data":null,"timestamp":"${LocalDateTime.now()}"}""",
+        )
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/global/security/jwt/JwtProvider.kt
+++ b/src/main/kotlin/com/bandage/v1/global/security/jwt/JwtProvider.kt
@@ -1,9 +1,9 @@
 package com.bandage.v1.global.security.jwt
 
 import com.bandage.v1.domain.auth.model.enums.MemberRole
-import com.bandage.v1.global.error.exception.Exception
 import com.bandage.v1.global.properties.JwtProperties
 import com.bandage.v1.global.security.PrincipalDetails
+import io.jsonwebtoken.JwtException
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.io.Decoders
 import io.jsonwebtoken.security.Keys
@@ -56,7 +56,9 @@ class JwtProvider(
                 .build()
                 .parseSignedClaims(token)
             true
-        } catch (e: Exception) {
+        } catch (e: JwtException) {
+            false
+        } catch (e: IllegalArgumentException) {
             false
         }
 


### PR DESCRIPTION
## 🛠️ Issue Number
### relates to #55

📌 **작업 내용 및 특이사항**

프론트(`feat/#8-auth-member`) 의 인증/회원 API 연동 검증 중 발견된 백엔드 결함을 수정합니다.

### 1. \`POST /api/v1/auth/refresh\` 403 수정
- \`SecurityPathConstants.AUTH_WHITELIST\` 에 \`/api/v1/auth/refresh\` 추가
- 원인: refresh 는 Authorization 헤더 없이 쿠키만으로 호출되는데, 화이트리스트에 빠져 있어 \`anyRequest().authenticated()\` 매처에 걸려 \`Http403ForbiddenEntryPoint\` 로 마감되고 있었음
- 토큰 자체 검증은 컨트롤러 → \`MemberAuthService.reissueToken\` → \`validateRefreshToken\` 에서 쿠키값 + Redis 저장값 일치까지 확인하므로 보안 손실 없음

### 2. \`JwtProvider.validateToken\` 의 catch 정정
- 잘못된 import (\`com.bandage.v1.global.error.exception.Exception\`) 를 제거
- \`catch (e: JwtException)\` + \`catch (e: IllegalArgumentException)\` 로 분리
- 원인: 기존 catch 가 프로젝트 커스텀 \`Exception\` 만 잡고 있어 JJWT 의 \`MalformedJwtException\`/\`ExpiredJwtException\`/\`SignatureException\` 이 필터 밖으로 그대로 빠져나가 ERROR 로그가 찍히고 응답이 비정상 503/403 으로 마감되던 문제

### 3. \`JwtAuthenticationEntryPoint\` 등록 (401 분리)
- 신규 \`JwtAuthenticationEntryPoint\` 작성: \`401 Unauthorized\` + \`WWW-Authenticate: Bearer error=\"invalid_token\"\` + \`ApiResponse.error(...)\` 본문 반환
- \`SecurityConfig.exceptionHandling\` 에 주입
- 효과: 인증 누락/무효 토큰 → 401 (프론트 \`apiClient\` 의 401 인터셉터가 자동 refresh 트리거 가능), 권한 부족(추후) → 403 으로 의미 분리

### 4. SecurityWhiteList 정리 + API 스펙 동기화
- \`TMP_FOR_TEST\` 에서 \`/practices/**\`, \`/performances/**\` 주석 처리 (테스트용 블랭킷 공개 회수). \`/tmp/**\` 만 잔류
- \`API_SPEC.md\` 의 3-2~3-5, 4-1, 4-2, 5-1, 5-2, 6-2, 6-3 항목을 모두 \`인증 필요\` 로 갱신, \`(TODO: 인증 추가 예정)\` 주석 제거
- 결과: 공개 엔드포인트는 \`/auth/login\`, \`/auth/refresh\`, \`/members/join\` 3개로 수렴

📚 **참고사항**

- 검증 리포트(프론트 측 작성): \`auth-member-api-verification-2026-04-24.md\` — 본 PR 의 근거 문서
- 변경 파일
  - \`src/main/kotlin/com/bandage/v1/global/security/SecurityConfig.kt\`
  - \`src/main/kotlin/com/bandage/v1/global/security/constants/SecurityPathConstants.kt\`
  - \`src/main/kotlin/com/bandage/v1/global/security/jwt/JwtProvider.kt\`
  - \`src/main/kotlin/com/bandage/v1/global/security/handler/JwtAuthenticationEntryPoint.kt\` (신규)
  - \`API_SPEC.md\`
- 테스트: \`./gradlew test\` 통과 (\`V1ApplicationTests.contextLoads\`)