### PR TITLE
fix: 405 Method Not Allowed 가 401 로 오염되는 문제 수정

### DIFF
--- a/src/main/kotlin/com/bandage/v1/global/error/errorcode/ErrorCode.kt
+++ b/src/main/kotlin/com/bandage/v1/global/error/errorcode/ErrorCode.kt
@@ -10,6 +10,8 @@ enum class ErrorCode(
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "올바르지 않은 입력값입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
     NO_CHANGE(HttpStatus.BAD_REQUEST, "변경된 사항이 없습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메서드입니다."),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
 
     // member
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 회원 정보를 찾을 수 없습니다."),

--- a/src/main/kotlin/com/bandage/v1/global/error/handler/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/bandage/v1/global/error/handler/GlobalExceptionHandler.kt
@@ -7,11 +7,13 @@ import com.bandage.v1.global.error.exception.Exception
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.HttpRequestMethodNotSupportedException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.servlet.resource.NoResourceFoundException
 
-@RestControllerAdvice(basePackages = ["com.bandage.v1.domain"])
+@RestControllerAdvice
 open class GlobalExceptionHandler {
     @ExceptionHandler
     protected fun handleBusinessException(e: BusinessException): ResponseEntity<ApiResponse<Nothing>> {
@@ -33,6 +35,22 @@ open class GlobalExceptionHandler {
         val message = e.message
         val response = ApiResponse.error(message)
         return ResponseEntity(response, HttpStatus.BAD_REQUEST)
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException::class)
+    protected fun handleMethodNotSupported(e: HttpRequestMethodNotSupportedException): ResponseEntity<ApiResponse<Nothing>> {
+        val errorCode = ErrorCode.METHOD_NOT_ALLOWED
+        return ResponseEntity
+            .status(errorCode.status)
+            .body(ApiResponse.error("${errorCode.message} (요청 메서드: ${e.method})"))
+    }
+
+    @ExceptionHandler(NoResourceFoundException::class)
+    protected fun handleNoResourceFound(e: NoResourceFoundException): ResponseEntity<ApiResponse<Nothing>> {
+        val errorCode = ErrorCode.RESOURCE_NOT_FOUND
+        return ResponseEntity
+            .status(errorCode.status)
+            .body(ApiResponse.error(errorCode.message))
     }
 
     @ExceptionHandler(Exception::class)


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #58

📌 **작업 내용 및 특이사항**

### 증상
유효한 Bearer 토큰으로 `GET /api/v1/practices` 를 호출하면(해당 경로에 GET 핸들러가 없음) 원래대로라면 405 Method Not Allowed 가 나와야 하지만, 실제 응답은 아래와 같이 **401 + `Allow: POST` + `WWW-Authenticate: Bearer error="invalid_token"`** 로 오염됩니다.

```http
HTTP/1.1 401
Allow: POST
WWW-Authenticate: Bearer error="invalid_token"
{"success":false,"message":"인증되지 않은 회원입니다.",...}
```

프론트(`bandage-fe`) 의 `apiClient` 401 인터셉터는 이를 토큰 만료로 해석하여 refresh 루프를 돌고 결국 세션을 초기화하여 로그인 화면으로 강제 리다이렉트합니다.

### 근본 원인
- `GlobalExceptionHandler` 에 `HttpRequestMethodNotSupportedException` 전용 `@ExceptionHandler` 가 없음.
- Spring 의 `DefaultHandlerExceptionResolver` 가 응답을 405 로 세팅한 뒤 기본 에러 디스패치(`/error`) 로 포워딩.
- 포워드된 요청은 내부 디스패치라 원본의 Authorization 헤더를 잃은 채 다시 `SecurityFilterChain` 을 통과.
- 인증 실패로 `JwtAuthenticationEntryPoint` 가 발동하여 최종 응답이 401 로 덮어씌워짐. `Allow` 헤더만 원래 405 의 흔적으로 남음.

### 변경 내용
- `GlobalExceptionHandler` 에 다음 두 핸들러 추가:
  - `HttpRequestMethodNotSupportedException` → 405 + `ApiResponse.error("${message} (요청 메서드: $method)")`
  - `NoResourceFoundException` → 404 + `ApiResponse.error`
  @ExceptionHandler 로 직접 응답이 작성되므로 에러 디스패치 포워딩이 발생하지 않아, 재인증 필터 통과로 인한 오염이 근본적으로 차단됩니다.
- `@RestControllerAdvice(basePackages = ["com.bandage.v1.domain"])` → `@RestControllerAdvice` 로 변경. 컨트롤러 라우팅 이전에 발생하는 프레임워크 레벨 예외도 포괄해야 하므로 패키지 한정을 해제합니다.
- `ErrorCode` 에 `METHOD_NOT_ALLOWED`, `RESOURCE_NOT_FOUND` 추가.

### 검증
- `./gradlew build` , `./gradlew test` 통과.
- 실서버 엔드투엔드 curl 검증은 현재 IntelliJ 에서 실행 중인 로컬 인스턴스가 있어 본 PR 에서는 생략. 머지 이후 사용자 환경에서 재시작 + curl 확인 권장:

  ```bash
  TOKEN=$(curl -s -X POST http://localhost:8080/api/v1/auth/login -H 'Content-Type: application/json' -d '{"email":"...","password":"..."}' | jq -r .data.accessToken)
  curl -i -H "Authorization: Bearer $TOKEN" http://localhost:8080/api/v1/practices
  # 기대: HTTP/1.1 405, Allow 헤더 있음, {"success":false,"message":"지원하지 않는 HTTP 메서드입니다. (요청 메서드: GET)",...}
  ```

📚 **참고사항**

- 프론트 대응 완료: `bandage-fe` `fix: 405 가 401 로 오염된 응답에서 refresh 루프 탈출 (#31)` 머지됨. 백엔드 수정 배포 전까지의 방어로 유지됩니다.
- 결과: `GET /api/v1/practices` 엔드포인트 자체가 아직 없는 상태는 별개 이슈. 본 PR 은 오직 405 → 401 오염만 교정하고, 실제 합주 리스트 API 구현은 별도 트랙.