### PR TITLE
refactor: API E2E 테스트 결과 반영 및 신규 API 추가 구현 (#61)

### DIFF
--- a/API_SPEC.md
+++ b/API_SPEC.md
@@ -168,6 +168,19 @@ Base URL: `/api/v1`
 
 ---
 
+### 3-3-1. 내 밴드 목록 조회 (커서 페이징)
+- **GET** `/api/v1/bands/me`
+- **인증 필요**
+- **Query Parameters**
+  | 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+  |---------|------|------|--------|------|
+  | `lastId` | UUID | N | - | 이전 페이지 마지막 밴드 ID |
+  | `pageSize` | Int (1~100) | N | 10 | 페이지 크기 |
+- **Response**: `CursorResponse<BandInfoResponse, UUID>`
+- **비고**: 현재 로그인한 회원이 소속된 밴드만 조회
+
+---
+
 ### 3-4. 밴드 멤버 단건 조회
 - **GET** `/api/v1/bands/{bandId}/members/{bandMemberId}`
 - **인증 필요**
@@ -278,6 +291,28 @@ Base URL: `/api/v1`
     "practiceTitle": "TuNA 정기공연 1주차 합주"
   }
   ```
+
+---
+
+### 4-1-1. 내 합주 목록 조회 (커서 페이징)
+- **GET** `/api/v1/practices/me`
+- **인증 필요**
+- **Query Parameters**
+  | 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+  |---------|------|------|--------|------|
+  | `lastId` | UUID | N | - | 이전 페이지 마지막 합주 ID |
+  | `pageSize` | Int (1~100) | N | 10 | 페이지 크기 |
+- **Response**: `CursorResponse<PracticeListResponse, UUID>`
+  ```json
+  {
+    "practiceId": "550e8400-e29b-41d4-a716-446655440000",
+    "title": "TuNA 정기공연 1주차 합주",
+    "startAt": "2026-03-15 18:00",
+    "durationMinutes": 60,
+    "venue": "홍대 스튜디오"
+  }
+  ```
+- **비고**: 현재 로그인한 회원이 참여 중인 합주만 조회
 
 ---
 
@@ -489,6 +524,19 @@ Base URL: `/api/v1`
     "venue": "Club FF"
   }
   ```
+
+---
+
+### 6-2-1. 내 공연 목록 조회 (커서 페이징)
+- **GET** `/api/v1/performances/me`
+- **인증 필요**
+- **Query Parameters**
+  | 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+  |---------|------|------|--------|------|
+  | `lastId` | UUID | N | - | 이전 페이지 마지막 공연 ID |
+  | `pageSize` | Int (1~100) | N | 10 | 페이지 크기 |
+- **Response**: `CursorResponse<PerformanceListResponse, UUID>`
+- **비고**: 현재 로그인한 회원이 속한 밴드가 참여하는 모든 공연 조회 (소속 밴드가 없으면 빈 목록 반환)
 
 ---
 

--- a/API_SPEC.md
+++ b/API_SPEC.md
@@ -3,7 +3,43 @@
 Base URL: `/api/v1`
 
 모든 응답은 `ApiResponse<T>` 래퍼로 감싸져 반환됩니다.
+
+```json
+{
+  "success": true|false,
+  "message": "...",          // error 시에만
+  "code": "ERROR_CODE",      // error 시에만 (ErrorCode enum 이름)
+  "data": <T>,               // success 시 페이로드
+  "fieldErrors": {            // 유효성 오류일 때만 (필드명 → 메시지)
+    "name": "이름은 필수입니다."
+  },
+  "timestamp": "2026-04-25T12:00:00"
+}
+```
+
 인증이 필요한 API는 `Authorization: Bearer {accessToken}` 헤더를 사용합니다.
+
+---
+
+## 0. 프론트 검증 리포트 대응 현황 (2026-04-25)
+
+`bandage-fe/.taskmaster/reports/` 의 5개 검증 리포트에서 제기된 이슈에 대한 처리 현황입니다.
+
+| # | 이슈 | 출처 | 상태 | 비고 |
+|---|---|---|---|---|
+| 1 | `BandCreateRequest.profileImg` non-null → optional | MVP 통합 §4 | ✅ 해소 | DTO를 `String?`로 변경 (3-1 참조) |
+| 2 | `PerformanceUpdateRequest` 부분 업데이트 불가 | Performance §3-A | ✅ 해소 | 모든 필드 nullable + 서비스 partial update (6-4 참조) |
+| 3 | `GET /api/v1/practices` 미구현 (405) | MVP 통합 §6, Practice §3-B | ✅ 해소 | 신규 엔드포인트 추가 (4-1-2 참조) |
+| 4 | API_SPEC 인증 표기 vs 실제 인증 요구 불일치 | Band §3-A, Practice §3-C | ✅ 해소 | 본 문서의 모든 보호 엔드포인트는 "인증 필요"로 정렬됨 (`/auth/login`, `/auth/refresh`, `/members/join`만 공개) |
+| 5 | `CursorResponse.nextCursor` 일관성 (`hasNext=false`일 때 null) | Band §3-C, Performance §3-C | ✅ 해소 | 모든 RepositoryImpl에서 `hasNext=false` 시 `nextCursor=null` |
+| 6 | 인증(401) / 인가(403) 응답 코드 분리 | Auth §C, Band §3-B, Performance §3-B | ✅ 해소 (검증 완료) | `NOT_A_LEADER`, `NOT_A_PERFORMANCE_MANAGER` 모두 `HttpStatus.FORBIDDEN`로 매핑됨. JWT 무효/누락은 `JwtAuthenticationEntryPoint`가 401 + `WWW-Authenticate` 헤더 반환 |
+| 7 | `ApiResponse`에 `code` / `fieldErrors` 추가 | Auth §D | ✅ 해소 | 본 문서 상단 응답 스키마 참조. `code`는 `ErrorCode` enum 이름. 유효성 오류 시 `fieldErrors` 맵 동봉 |
+| 8 | `PerformanceDetailResponse` 요약 필드 (밴드명/합주 제목) | Performance §3-D | ✅ 해소 | `bandIds`, `practiceIds` → `bands: [{bandId, bandName}]`, `practices: [{practiceId, title, startAt}]`로 확장 (6-3 참조) |
+| 9 | `GET /bands/me` 응답에 본인 역할 (`myRole`) 포함 | Band §3-D | ✅ 해소 (옵션 9-C) | 응답 항목 타입을 `MyBandInfoResponse`로 변경, `myRole: BandRole` 필드 추가 (3-3-1 참조) |
+
+### 미해소 / 프론트 책임
+
+- **`MemberInfoResponse.memberId` vs 프론트 기대 `id`** (MVP 통합 §3): 백엔드는 도메인 prefix 컨벤션(`bandId`, `practiceId`, `songId`, `bandMemberId`...)을 따르므로 `memberId` 유지. 프론트 타입을 `memberId`로 갱신 필요.
 
 ---
 
@@ -129,6 +165,7 @@ Base URL: `/api/v1`
     "profileImg": "url"
   }
   ```
+  - `profileImg`: optional
 - **Response**
   ```json
   {
@@ -176,8 +213,37 @@ Base URL: `/api/v1`
   |---------|------|------|--------|------|
   | `lastId` | UUID | N | - | 이전 페이지 마지막 밴드 ID |
   | `pageSize` | Int (1~100) | N | 10 | 페이지 크기 |
+- **Response**: `CursorResponse<MyBandInfoResponse, UUID>`
+  ```json
+  {
+    "content": [
+      {
+        "bandId": "550e8400-e29b-41d4-a716-446655440000",
+        "bandName": "TuNA",
+        "description": "...",
+        "profileImg": "url",
+        "myRole": "LEADER"
+      }
+    ],
+    "nextCursor": null,
+    "hasNext": false
+  }
+  ```
+- **비고**: 현재 로그인한 회원이 소속된 밴드만 조회. 응답 항목에 본인의 밴드 내 역할(`myRole`)이 포함되어 별도 멤버 목록 조회 없이도 권한 판정 가능. `myRole` enum — `LEADER` | `ADMIN` | `MEMBER`
+
+---
+
+### 3-3-2. 밴드 검색 (커서 페이징)
+- **GET** `/api/v1/bands/search`
+- **인증 필요**
+- **Query Parameters**
+  | 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+  |---------|------|------|--------|------|
+  | `keyword` | String | Y | - | 검색 키워드 (밴드 이름) |
+  | `lastId` | UUID | N | - | 이전 페이지 마지막 밴드 ID |
+  | `pageSize` | Int (1~100) | N | 10 | 페이지 크기 |
 - **Response**: `CursorResponse<BandInfoResponse, UUID>`
-- **비고**: 현재 로그인한 회원이 소속된 밴드만 조회
+- **비고**: 밴드 이름에 `keyword`가 포함된 밴드를 대소문자 구분 없이 부분 매칭 조회
 
 ---
 
@@ -294,6 +360,20 @@ Base URL: `/api/v1`
 
 ---
 
+### 4-1-2. 합주 목록 조회 (커서 페이징)
+- **GET** `/api/v1/practices`
+- **인증 필요**
+- **Query Parameters**
+  | 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+  |---------|------|------|--------|------|
+  | `bandId` | UUID | N | - | 특정 밴드 멤버가 참여 중인 합주만 조회 |
+  | `lastId` | UUID | N | - | 이전 페이지 마지막 합주 ID |
+  | `pageSize` | Int (1~100) | N | 10 | 페이지 크기 |
+- **Response**: `CursorResponse<PracticeListResponse, UUID>`
+- **비고**: `bandId` 미제공 시 모든 합주 조회. `bandId` 제공 시 해당 밴드 소속 멤버 중 1명 이상이 참여하는 합주만 반환 (밴드에 멤버가 없으면 빈 목록).
+
+---
+
 ### 4-1-1. 내 합주 목록 조회 (커서 페이징)
 - **GET** `/api/v1/practices/me`
 - **인증 필요**
@@ -313,6 +393,20 @@ Base URL: `/api/v1`
   }
   ```
 - **비고**: 현재 로그인한 회원이 참여 중인 합주만 조회
+
+---
+
+### 4-1-3. 내 합주 검색 (커서 페이징)
+- **GET** `/api/v1/practices/me/search`
+- **인증 필요**
+- **Query Parameters**
+  | 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+  |---------|------|------|--------|------|
+  | `keyword` | String | Y | - | 검색 키워드 (합주 타이틀 또는 곡 제목) |
+  | `lastId` | UUID | N | - | 이전 페이지 마지막 합주 ID |
+  | `pageSize` | Int (1~100) | N | 10 | 페이지 크기 |
+- **Response**: `CursorResponse<PracticeListResponse, UUID>`
+- **비고**: 본인이 참여 중인 합주 중 합주 타이틀 또는 합주곡 제목에 `keyword`가 포함된 합주만 대소문자 구분 없이 조회
 
 ---
 
@@ -456,7 +550,120 @@ Base URL: `/api/v1`
 
 ## 5. 합주곡 (Practice Song)
 
-### 5-1. 합주곡 참조 링크 등록/수정 (Upsert)
+### 5-1. 합주곡 검색 (Song)
+- **GET** `/api/v1/practice-songs/search`
+- **인증 필요**
+- **Query Parameters**
+  | 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+  |---------|------|------|--------|------|
+  | `keyword` | String | Y | - | 검색 키워드 (곡 제목 또는 아티스트) |
+- **Response**: `List<Song>` — 외부 시스템 곡 정보 (DB 엔티티로 관리되지 않는 전송용 DTO)
+  ```json
+  [
+    {
+      "title": "Vicarious",
+      "artist": "Tool",
+      "album": "10,000 Days",
+      "duration": 426,
+      "refLink": null
+    }
+  ]
+  ```
+- **비고**:
+  - 외부 음원 검색 API / gRPC 연동 전 임시 mock 응답 (Tool 곡 고정 반환). 추후 외부 시스템과 연동 예정.
+  - 응답 배열의 각 `Song` 객체는 그대로 [5-3](#5-3-합주곡-생성-song-객체--외부-시스템-결과-사용)의 `song` 필드 또는 [5-5](#5-5-합주곡-upsert-song-객체)의 Request Body로 전달 가능 (재가공 불필요).
+
+---
+
+### 5-2. 합주곡 생성 (필드 입력 — 자작곡 등)
+- **POST** `/api/v1/practice-songs`
+- **인증 필요**
+- **Request Body**
+  ```json
+  {
+    "practiceId": "550e8400-e29b-41d4-a716-446655440000",
+    "title": "자작곡 No.1",
+    "artist": "TuNA",
+    "album": "TuNA Demo",
+    "duration": 300,
+    "refLink": null
+  }
+  ```
+  - `refLink`: optional
+- **Response**: `PracticeSongResponse`
+  ```json
+  {
+    "songId": "550e8400-e29b-41d4-a716-446655440001",
+    "title": "자작곡 No.1",
+    "artist": "TuNA",
+    "album": "TuNA Demo",
+    "duration": 300,
+    "refLink": null
+  }
+  ```
+- **비고**: 자작곡 등 외부 API 연동이 필요 없는 곡을 사용자가 각 필드를 직접 입력하여 합주곡으로 생성. 생성된 합주곡은 `practiceId`의 합주에 1:1 바인딩.
+
+---
+
+### 5-3. 합주곡 생성 (Song 객체 — 외부 시스템 결과 사용)
+- **POST** `/api/v1/practice-songs/from-song`
+- **인증 필요**
+- **Request Body**
+  ```json
+  {
+    "practiceId": "550e8400-e29b-41d4-a716-446655440000",
+    "song": {
+      "title": "Vicarious",
+      "artist": "Tool",
+      "album": "10,000 Days",
+      "duration": 426,
+      "refLink": null
+    }
+  }
+  ```
+- **Response**: `PracticeSongResponse` (5-2와 동일 구조)
+- **비고**: 외부 시스템에서 받아온 Song 객체를 그대로 사용하여 합주곡을 생성. 생성된 합주곡은 `practiceId`의 합주에 1:1 바인딩. `song` 필드는 [5-1](#5-1-합주곡-검색-song) 응답의 항목을 재가공 없이 그대로 사용 가능.
+
+---
+
+### 5-4. 합주곡 부분 수정
+- **PATCH** `/api/v1/practice-songs/{songId}`
+- **인증 필요**
+- **Path Variable**: `songId` (UUID)
+- **Request Body** (모든 필드 optional, 전달된 필드만 업데이트)
+  ```json
+  {
+    "title": "Vicarious",
+    "artist": "Tool",
+    "album": "10,000 Days",
+    "duration": 426,
+    "refLink": "https://www.youtube.com/watch?v=example"
+  }
+  ```
+- **Response**: `PracticeSongResponse`
+
+---
+
+### 5-5. 합주곡 Upsert (Song 객체)
+- **PUT** `/api/v1/practice-songs/{songId}`
+- **인증 필요**
+- **Path Variable**: `songId` (UUID)
+- **Request Body**: `Song` (전체 필드)
+  ```json
+  {
+    "title": "Vicarious",
+    "artist": "Tool",
+    "album": "10,000 Days",
+    "duration": 426,
+    "refLink": "https://www.youtube.com/watch?v=example"
+  }
+  ```
+- **Response**: `PracticeSongResponse`
+- **비고**: Song 객체의 값으로 모든 필드를 갱신. Request Body는 [5-1](#5-1-합주곡-검색-song) 응답의 항목을 재가공 없이 그대로 사용 가능.
+
+---
+
+### 5-6. 합주곡 참조 링크 등록/수정 (Upsert)
 - **PUT** `/api/v1/practice-songs/{songId}/ref-link`
 - **인증 필요**
 - **Path Variable**: `songId` (UUID)
@@ -469,7 +676,7 @@ Base URL: `/api/v1`
 
 ---
 
-### 5-2. 합주곡 참조 링크 삭제
+### 5-7. 합주곡 참조 링크 삭제
 - **DELETE** `/api/v1/practice-songs/{songId}/ref-link`
 - **인증 필요**
 - **Path Variable**: `songId` (UUID)
@@ -540,11 +747,25 @@ Base URL: `/api/v1`
 
 ---
 
+### 6-2-2. 공연 검색 (커서 페이징)
+- **GET** `/api/v1/performances/search`
+- **인증 필요**
+- **Query Parameters**
+  | 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+  |---------|------|------|--------|------|
+  | `keyword` | String | Y | - | 검색 키워드 (공연 이름) |
+  | `lastId` | UUID | N | - | 이전 페이지 마지막 공연 ID |
+  | `pageSize` | Int (1~100) | N | 10 | 페이지 크기 |
+- **Response**: `CursorResponse<PerformanceListResponse, UUID>`
+- **비고**: 공연 제목에 `keyword`가 포함된 공연을 대소문자 구분 없이 부분 매칭 조회
+
+---
+
 ### 6-3. 공연 상세 조회
 - **GET** `/api/v1/performances/{performanceId}`
 - **인증 필요**
 - **Path Variable**: `performanceId` (UUID)
-- **Response**
+- **Response**: `PerformanceDetailResponse`
   ```json
   {
     "performanceId": "550e8400-e29b-41d4-a716-446655440000",
@@ -552,11 +773,20 @@ Base URL: `/api/v1`
     "startAt": "2026-06-15 18:00",
     "durationMinutes": 120,
     "venue": "Club FF",
-    "bandIds": ["550e8400-e29b-41d4-a716-446655440000"],
+    "bands": [
+      { "bandId": "550e8400-e29b-41d4-a716-446655440000", "bandName": "TuNA" }
+    ],
     "managerIds": [1],
-    "practiceIds": ["550e8400-e29b-41d4-a716-446655440001"]
+    "practices": [
+      {
+        "practiceId": "550e8400-e29b-41d4-a716-446655440001",
+        "title": "TuNA 정기공연 1주차 합주",
+        "startAt": "2026-06-01 18:00"
+      }
+    ]
   }
   ```
+- **비고**: 기존 `bandIds` / `practiceIds` 평면 배열은 각각 `bands` / `practices` 요약 객체 배열로 확장됨. 프론트가 별도 호출 없이 밴드 이름 / 합주 제목 / 합주 시작시각을 표시 가능.
 
 ---
 
@@ -564,7 +794,7 @@ Base URL: `/api/v1`
 - **PATCH** `/api/v1/performances/{performanceId}`
 - **인증 필요** (PerformanceManager)
 - **Path Variable**: `performanceId` (UUID)
-- **Request Body**
+- **Request Body** (모든 필드 optional, 전달된 필드만 갱신)
   ```json
   {
     "title": "TuNA 정기공연 (수정)",
@@ -573,7 +803,7 @@ Base URL: `/api/v1`
     "venue": "Club FF"
   }
   ```
-  - `venue`: optional
+  - 모든 필드 optional. 미전달 필드는 기존 값 유지.
 
 ---
 

--- a/src/main/kotlin/com/bandage/v1/domain/band/controller/BandController.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/band/controller/BandController.kt
@@ -3,10 +3,12 @@ package com.bandage.v1.domain.band.controller
 import com.bandage.v1.domain.band.dto.req.BandApplicationPagingQuery
 import com.bandage.v1.domain.band.dto.req.BandCreateRequest
 import com.bandage.v1.domain.band.dto.req.BandPagingQuery
+import com.bandage.v1.domain.band.dto.req.BandSearchQuery
 import com.bandage.v1.domain.band.dto.res.BandApplicationInfoResponse
 import com.bandage.v1.domain.band.dto.res.BandInfoResponse
 import com.bandage.v1.domain.band.dto.res.BandMemberInfoResponse
 import com.bandage.v1.domain.band.dto.res.BandResponse
+import com.bandage.v1.domain.band.dto.res.MyBandInfoResponse
 import com.bandage.v1.domain.band.model.enums.ApplicationStatus
 import com.bandage.v1.domain.band.service.BandService
 import com.bandage.v1.global.common.constants.PathPrefix.PREFIX
@@ -69,11 +71,20 @@ class BandController(
     ): ApiResponse<CursorResponse<BandInfoResponse, UUID>> = ApiResponse.success(bandService.getBandsByCursor(query))
 
     @GetMapping("/me")
-    @Operation(summary = "내 밴드 목록 조회 API", description = "본인이 소속된 밴드 목록을 커서 기반으로 조회합니다.")
+    @Operation(
+        summary = "내 밴드 목록 조회 API",
+        description = "본인이 소속된 밴드 목록을 커서 기반으로 조회합니다. 응답에 본인의 밴드 내 역할(`myRole`)이 포함됩니다.",
+    )
     fun getMyBands(
         @Valid query: BandPagingQuery,
         @CurrentMemberId memberId: Long,
-    ): ApiResponse<CursorResponse<BandInfoResponse, UUID>> = ApiResponse.success(bandService.getMyBandsByCursor(memberId, query))
+    ): ApiResponse<CursorResponse<MyBandInfoResponse, UUID>> = ApiResponse.success(bandService.getMyBandsByCursor(memberId, query))
+
+    @GetMapping("/search")
+    @Operation(summary = "밴드 검색 API", description = "밴드 이름에 키워드가 포함된 밴드를 커서 기반으로 조회합니다.")
+    fun searchBands(
+        @Valid query: BandSearchQuery,
+    ): ApiResponse<CursorResponse<BandInfoResponse, UUID>> = ApiResponse.success(bandService.searchBandsByCursor(query))
 
     @GetMapping("/{bandId}/members/{bandMemberId}")
     @Operation(summary = "밴드 멤버 단건 조회 API", description = "밴드 내 특정 멤버의 프로필 및 권한 정보를 조회합니다.")

--- a/src/main/kotlin/com/bandage/v1/domain/band/controller/BandController.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/band/controller/BandController.kt
@@ -68,6 +68,13 @@ class BandController(
         @Valid query: BandPagingQuery,
     ): ApiResponse<CursorResponse<BandInfoResponse, UUID>> = ApiResponse.success(bandService.getBandsByCursor(query))
 
+    @GetMapping("/me")
+    @Operation(summary = "내 밴드 목록 조회 API", description = "본인이 소속된 밴드 목록을 커서 기반으로 조회합니다.")
+    fun getMyBands(
+        @Valid query: BandPagingQuery,
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<CursorResponse<BandInfoResponse, UUID>> = ApiResponse.success(bandService.getMyBandsByCursor(memberId, query))
+
     @GetMapping("/{bandId}/members/{bandMemberId}")
     @Operation(summary = "밴드 멤버 단건 조회 API", description = "밴드 내 특정 멤버의 프로필 및 권한 정보를 조회합니다.")
     fun getBandMember(

--- a/src/main/kotlin/com/bandage/v1/domain/band/dto/req/BandCreateRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/band/dto/req/BandCreateRequest.kt
@@ -9,6 +9,6 @@ data class BandCreateRequest(
     val name: String,
     @NotBlank @Schema(description = "밴드 상세 설명/소개", example = "성균관대학교 문과대 락밴드 TuNA 입니다.")
     val description: String,
-    @Schema(description = "밴드 프로필 이미지 Url", example = "url")
-    val profileImg: String,
+    @Schema(description = "밴드 프로필 이미지 Url (optional)", example = "url")
+    val profileImg: String? = null,
 )

--- a/src/main/kotlin/com/bandage/v1/domain/band/dto/req/BandSearchQuery.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/band/dto/req/BandSearchQuery.kt
@@ -1,0 +1,20 @@
+package com.bandage.v1.domain.band.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import java.util.UUID
+
+@Schema(description = "밴드 검색 쿼리")
+data class BandSearchQuery(
+    @field:NotBlank
+    @Schema(description = "검색 키워드 (밴드 이름)", example = "TuNA")
+    val keyword: String,
+    @Schema(description = "마지막으로 조회된 밴드 ID (커서)", example = "550e8400-e29b-41d4-a716-446655440000")
+    val lastId: UUID?,
+    @field:Min(1)
+    @field:Max(100)
+    @Schema(description = "페이지 크기", example = "10")
+    val pageSize: Int = 10,
+)

--- a/src/main/kotlin/com/bandage/v1/domain/band/dto/res/MyBandInfoResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/band/dto/res/MyBandInfoResponse.kt
@@ -1,0 +1,34 @@
+package com.bandage.v1.domain.band.dto.res
+
+import com.bandage.v1.domain.band.model.Band
+import com.bandage.v1.domain.band.model.enums.BandRole
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.UUID
+
+@Schema(description = "내 밴드 목록 항목 (밴드 정보 + 본인 역할)")
+data class MyBandInfoResponse(
+    @Schema(description = "밴드 고유 식별자 (UUID)", example = "550e8400-e29b-41d4-a716-446655440000")
+    val bandId: UUID,
+    @Schema(description = "밴드 이름", example = "TuNA")
+    val bandName: String,
+    @Schema(description = "밴드 상세 설명")
+    val description: String?,
+    @Schema(description = "밴드 프로필 이미지 url")
+    val profileImg: String?,
+    @Schema(description = "본인의 밴드 내 역할", example = "LEADER")
+    val myRole: BandRole,
+) {
+    companion object {
+        fun of(
+            band: Band,
+            myRole: BandRole,
+        ): MyBandInfoResponse =
+            MyBandInfoResponse(
+                bandId = band.id,
+                bandName = band.name,
+                description = band.description,
+                profileImg = band.profileImg,
+                myRole = myRole,
+            )
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/band/repository/BandApplicationRepositoryImpl.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/band/repository/BandApplicationRepositoryImpl.kt
@@ -34,7 +34,7 @@ class BandApplicationRepositoryImpl(
 
         val resultContents = if (hasNext) contents.dropLast(1) else contents // 사이즈 확인 후 마지막 1개 항목 제외 반환
 
-        val nextCursor = resultContents.lastOrNull()?.id
+        val nextCursor = if (hasNext) resultContents.lastOrNull()?.id else null
 
         return CursorResponse(
             content = resultContents,

--- a/src/main/kotlin/com/bandage/v1/domain/band/repository/BandMemberRepository.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/band/repository/BandMemberRepository.kt
@@ -18,6 +18,11 @@ interface BandMemberRepository :
         @Param("memberId") memberId: Long,
     ): List<UUID>
 
+    @Query("SELECT bm.member FROM BandMember bm WHERE bm.band.id = :bandId")
+    fun findAllMemberIdsByBand(
+        @Param("bandId") bandId: UUID,
+    ): List<Long>
+
     fun existsBandMemberByBandAndMember(
         band: Band,
         member: Long,

--- a/src/main/kotlin/com/bandage/v1/domain/band/repository/BandMemberRepository.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/band/repository/BandMemberRepository.kt
@@ -4,6 +4,8 @@ import com.bandage.v1.domain.band.model.Band
 import com.bandage.v1.domain.band.model.BandMember
 import com.bandage.v1.domain.band.model.enums.BandRole
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import java.util.UUID
 
@@ -11,6 +13,11 @@ import java.util.UUID
 interface BandMemberRepository :
     JpaRepository<BandMember, UUID>,
     BandMemberRepositoryCustom {
+    @Query("SELECT bm.band.id FROM BandMember bm WHERE bm.member = :memberId")
+    fun findAllBandIdsByMember(
+        @Param("memberId") memberId: Long,
+    ): List<UUID>
+
     fun existsBandMemberByBandAndMember(
         band: Band,
         member: Long,

--- a/src/main/kotlin/com/bandage/v1/domain/band/repository/BandMemberRepositoryImpl.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/band/repository/BandMemberRepositoryImpl.kt
@@ -31,7 +31,7 @@ class BandMemberRepositoryImpl(
 
         val resultContents = if (hasNext) contents.dropLast(1) else contents // 사이즈 확인 후 마지막 1개 항목 제외 반환
 
-        val nextCursor = resultContents.lastOrNull()?.id
+        val nextCursor = if (hasNext) resultContents.lastOrNull()?.id else null
 
         return CursorResponse(
             content = resultContents,

--- a/src/main/kotlin/com/bandage/v1/domain/band/repository/BandRepositoryCustom.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/band/repository/BandRepositoryCustom.kt
@@ -9,4 +9,10 @@ interface BandRepositoryCustom {
         lastId: UUID?,
         pageSize: Int,
     ): CursorResponse<Band, UUID>
+
+    fun findAllByMemberAndPaging(
+        memberId: Long,
+        lastId: UUID?,
+        pageSize: Int,
+    ): CursorResponse<Band, UUID>
 }

--- a/src/main/kotlin/com/bandage/v1/domain/band/repository/BandRepositoryCustom.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/band/repository/BandRepositoryCustom.kt
@@ -1,6 +1,7 @@
 package com.bandage.v1.domain.band.repository
 
 import com.bandage.v1.domain.band.model.Band
+import com.bandage.v1.domain.band.model.enums.BandRole
 import com.bandage.v1.global.common.response.CursorResponse
 import java.util.UUID
 
@@ -15,4 +16,21 @@ interface BandRepositoryCustom {
         lastId: UUID?,
         pageSize: Int,
     ): CursorResponse<Band, UUID>
+
+    fun findAllByMemberWithRoleAndPaging(
+        memberId: Long,
+        lastId: UUID?,
+        pageSize: Int,
+    ): CursorResponse<BandWithRole, UUID>
+
+    fun searchByNameAndPaging(
+        keyword: String,
+        lastId: UUID?,
+        pageSize: Int,
+    ): CursorResponse<Band, UUID>
+
+    data class BandWithRole(
+        val band: Band,
+        val role: BandRole,
+    )
 }

--- a/src/main/kotlin/com/bandage/v1/domain/band/repository/BandRepositoryImpl.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/band/repository/BandRepositoryImpl.kt
@@ -29,7 +29,7 @@ class BandRepositoryImpl(
 
         val resultContents = if (hasNext) contents.dropLast(1) else contents // 사이즈 확인 후 마지막 1개 항목 제외 반환
 
-        val nextCursor = resultContents.lastOrNull()?.id
+        val nextCursor = if (hasNext) resultContents.lastOrNull()?.id else null
 
         return CursorResponse(
             content = resultContents,
@@ -60,7 +60,71 @@ class BandRepositoryImpl(
 
         val hasNext = contents.size > pageSize
         val resultContents = if (hasNext) contents.dropLast(1) else contents
-        val nextCursor = resultContents.lastOrNull()?.id
+        val nextCursor = if (hasNext) resultContents.lastOrNull()?.id else null
+
+        return CursorResponse(
+            content = resultContents,
+            nextCursor = nextCursor,
+            hasNext = hasNext,
+        )
+    }
+
+    override fun searchByNameAndPaging(
+        keyword: String,
+        lastId: UUID?,
+        pageSize: Int,
+    ): CursorResponse<Band, UUID> {
+        val qBand = QBand.band
+
+        val contents =
+            queryFactory
+                .selectFrom(qBand)
+                .where(qBand.name.containsIgnoreCase(keyword))
+                .where(ltBandId(lastId))
+                .orderBy(qBand.id.desc())
+                .limit(pageSize.toLong() + 1)
+                .fetch()
+
+        val hasNext = contents.size > pageSize
+        val resultContents = if (hasNext) contents.dropLast(1) else contents
+        val nextCursor = if (hasNext) resultContents.lastOrNull()?.id else null
+
+        return CursorResponse(
+            content = resultContents,
+            nextCursor = nextCursor,
+            hasNext = hasNext,
+        )
+    }
+
+    override fun findAllByMemberWithRoleAndPaging(
+        memberId: Long,
+        lastId: UUID?,
+        pageSize: Int,
+    ): CursorResponse<BandRepositoryCustom.BandWithRole, UUID> {
+        val qBand = QBand.band
+        val qBandMember = QBandMember.bandMember
+
+        val tuples =
+            queryFactory
+                .select(qBand, qBandMember.role)
+                .from(qBand)
+                .join(qBandMember)
+                .on(qBandMember.band.eq(qBand))
+                .where(qBandMember.member.eq(memberId))
+                .where(ltBandId(lastId))
+                .orderBy(qBand.id.desc())
+                .limit(pageSize.toLong() + 1)
+                .fetch()
+
+        val hasNext = tuples.size > pageSize
+        val resultTuples = if (hasNext) tuples.dropLast(1) else tuples
+        val resultContents =
+            resultTuples.mapNotNull { tuple ->
+                val band = tuple.get(qBand) ?: return@mapNotNull null
+                val role = tuple.get(qBandMember.role) ?: return@mapNotNull null
+                BandRepositoryCustom.BandWithRole(band = band, role = role)
+            }
+        val nextCursor = if (hasNext) resultContents.lastOrNull()?.band?.id else null
 
         return CursorResponse(
             content = resultContents,

--- a/src/main/kotlin/com/bandage/v1/domain/band/repository/BandRepositoryImpl.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/band/repository/BandRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.bandage.v1.domain.band.repository
 
 import com.bandage.v1.domain.band.model.Band
 import com.bandage.v1.domain.band.model.QBand
+import com.bandage.v1.domain.band.model.QBandMember
 import com.bandage.v1.global.common.response.CursorResponse
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
@@ -28,6 +29,37 @@ class BandRepositoryImpl(
 
         val resultContents = if (hasNext) contents.dropLast(1) else contents // 사이즈 확인 후 마지막 1개 항목 제외 반환
 
+        val nextCursor = resultContents.lastOrNull()?.id
+
+        return CursorResponse(
+            content = resultContents,
+            nextCursor = nextCursor,
+            hasNext = hasNext,
+        )
+    }
+
+    override fun findAllByMemberAndPaging(
+        memberId: Long,
+        lastId: UUID?,
+        pageSize: Int,
+    ): CursorResponse<Band, UUID> {
+        val qBand = QBand.band
+        val qBandMember = QBandMember.bandMember
+
+        val contents =
+            queryFactory
+                .selectFrom(qBand)
+                .join(qBandMember)
+                .on(qBandMember.band.eq(qBand))
+                .where(qBandMember.member.eq(memberId))
+                .where(ltBandId(lastId))
+                .orderBy(qBand.id.desc())
+                .distinct()
+                .limit(pageSize.toLong() + 1)
+                .fetch()
+
+        val hasNext = contents.size > pageSize
+        val resultContents = if (hasNext) contents.dropLast(1) else contents
         val nextCursor = resultContents.lastOrNull()?.id
 
         return CursorResponse(

--- a/src/main/kotlin/com/bandage/v1/domain/band/service/BandService.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/band/service/BandService.kt
@@ -82,6 +82,18 @@ class BandService(
         )
     }
 
+    fun getMyBandsByCursor(
+        memberId: Long,
+        query: BandPagingQuery,
+    ): CursorResponse<BandInfoResponse, UUID> {
+        val result = bandRepository.findAllByMemberAndPaging(memberId, query.lastId, query.pageSize)
+        return CursorResponse(
+            content = result.content.map { BandInfoResponse.of(it) },
+            nextCursor = result.nextCursor,
+            hasNext = result.hasNext,
+        )
+    }
+
     fun getOnlyOneBandMember(bandMemberId: UUID): BandMemberInfoResponse =
         BandMemberInfoResponse.of(
             getBandMemberById(bandMemberId),

--- a/src/main/kotlin/com/bandage/v1/domain/band/service/BandService.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/band/service/BandService.kt
@@ -3,10 +3,12 @@ package com.bandage.v1.domain.band.service
 import com.bandage.v1.domain.band.dto.req.BandApplicationPagingQuery
 import com.bandage.v1.domain.band.dto.req.BandCreateRequest
 import com.bandage.v1.domain.band.dto.req.BandPagingQuery
+import com.bandage.v1.domain.band.dto.req.BandSearchQuery
 import com.bandage.v1.domain.band.dto.res.BandApplicationInfoResponse
 import com.bandage.v1.domain.band.dto.res.BandInfoResponse
 import com.bandage.v1.domain.band.dto.res.BandMemberInfoResponse
 import com.bandage.v1.domain.band.dto.res.BandResponse
+import com.bandage.v1.domain.band.dto.res.MyBandInfoResponse
 import com.bandage.v1.domain.band.model.Band
 import com.bandage.v1.domain.band.model.BandApplication
 import com.bandage.v1.domain.band.model.BandMember
@@ -85,8 +87,17 @@ class BandService(
     fun getMyBandsByCursor(
         memberId: Long,
         query: BandPagingQuery,
-    ): CursorResponse<BandInfoResponse, UUID> {
-        val result = bandRepository.findAllByMemberAndPaging(memberId, query.lastId, query.pageSize)
+    ): CursorResponse<MyBandInfoResponse, UUID> {
+        val result = bandRepository.findAllByMemberWithRoleAndPaging(memberId, query.lastId, query.pageSize)
+        return CursorResponse(
+            content = result.content.map { MyBandInfoResponse.of(it.band, it.role) },
+            nextCursor = result.nextCursor,
+            hasNext = result.hasNext,
+        )
+    }
+
+    fun searchBandsByCursor(query: BandSearchQuery): CursorResponse<BandInfoResponse, UUID> {
+        val result = bandRepository.searchByNameAndPaging(query.keyword, query.lastId, query.pageSize)
         return CursorResponse(
             content = result.content.map { BandInfoResponse.of(it) },
             nextCursor = result.nextCursor,

--- a/src/main/kotlin/com/bandage/v1/domain/performance/controller/PerformanceController.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/controller/PerformanceController.kt
@@ -55,6 +55,14 @@ class PerformanceController(
             ApiResponse.success(performanceService.getPerformances(query))
         }
 
+    @GetMapping("/me")
+    @Operation(summary = "내 공연 목록 조회 API", description = "본인이 속한 밴드가 참여하는 공연 목록을 커서 기반으로 조회합니다.")
+    fun getMyPerformances(
+        @Valid query: PerformancePagingQuery,
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<CursorResponse<PerformanceListResponse, UUID>> =
+        ApiResponse.success(performanceService.getMyPerformancesByCursor(memberId, query))
+
     @GetMapping("/{performanceId}")
     @Operation(summary = "공연 단건 조회 API", description = "공연 고유 식별 ID를 통해 공연 상세 정보를 조회합니다.")
     fun getPerformance(

--- a/src/main/kotlin/com/bandage/v1/domain/performance/controller/PerformanceController.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/controller/PerformanceController.kt
@@ -4,6 +4,7 @@ import com.bandage.v1.domain.performance.dto.req.PerformanceCreateRequest
 import com.bandage.v1.domain.performance.dto.req.PerformancePagingQuery
 import com.bandage.v1.domain.performance.dto.req.PerformancePracticeAddRequest
 import com.bandage.v1.domain.performance.dto.req.PerformancePracticeCreateRequest
+import com.bandage.v1.domain.performance.dto.req.PerformanceSearchQuery
 import com.bandage.v1.domain.performance.dto.req.PerformanceUpdateRequest
 import com.bandage.v1.domain.performance.dto.res.PerformanceDetailResponse
 import com.bandage.v1.domain.performance.dto.res.PerformanceListResponse
@@ -62,6 +63,13 @@ class PerformanceController(
         @CurrentMemberId memberId: Long,
     ): ApiResponse<CursorResponse<PerformanceListResponse, UUID>> =
         ApiResponse.success(performanceService.getMyPerformancesByCursor(memberId, query))
+
+    @GetMapping("/search")
+    @Operation(summary = "공연 검색 API", description = "공연 제목에 키워드가 포함된 공연을 커서 기반으로 조회합니다.")
+    fun searchPerformances(
+        @Valid query: PerformanceSearchQuery,
+    ): ApiResponse<CursorResponse<PerformanceListResponse, UUID>> =
+        ApiResponse.success(performanceService.searchPerformancesByCursor(query))
 
     @GetMapping("/{performanceId}")
     @Operation(summary = "공연 단건 조회 API", description = "공연 고유 식별 ID를 통해 공연 상세 정보를 조회합니다.")

--- a/src/main/kotlin/com/bandage/v1/domain/performance/dto/req/PerformanceSearchQuery.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/dto/req/PerformanceSearchQuery.kt
@@ -1,0 +1,20 @@
+package com.bandage.v1.domain.performance.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import java.util.UUID
+
+@Schema(description = "공연 검색 쿼리")
+data class PerformanceSearchQuery(
+    @field:NotBlank
+    @Schema(description = "검색 키워드 (공연 이름)", example = "TuNA 정기공연")
+    val keyword: String,
+    @Schema(description = "마지막으로 조회된 공연 ID (커서)", example = "550e8400-e29b-41d4-a716-446655440000")
+    val lastId: UUID?,
+    @field:Min(1)
+    @field:Max(100)
+    @Schema(description = "페이지 크기", example = "10")
+    val pageSize: Int = 10,
+)

--- a/src/main/kotlin/com/bandage/v1/domain/performance/dto/req/PerformanceUpdateRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/dto/req/PerformanceUpdateRequest.kt
@@ -3,20 +3,18 @@ package com.bandage.v1.domain.performance.dto.req
 import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Min
-import jakarta.validation.constraints.NotBlank
 import java.time.LocalDateTime
 
-@Schema(description = "공연 정보 수정 요청")
+@Schema(description = "공연 정보 수정 요청 (모든 필드 optional, 전달된 필드만 갱신)")
 data class PerformanceUpdateRequest(
-    @NotBlank
     @Schema(description = "공연 제목", example = "TuNA 정기공연 (수정)")
-    val title: String,
+    val title: String? = null,
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm", shape = JsonFormat.Shape.STRING, timezone = "Asia/Seoul")
     @Schema(description = "공연 시작 시간", example = "2026-06-15 19:00")
-    val startAt: LocalDateTime,
+    val startAt: LocalDateTime? = null,
     @field:Min(1)
     @Schema(description = "공연 시간 (분)", example = "90")
-    val durationMinutes: Int,
+    val durationMinutes: Int? = null,
     @Schema(description = "공연 장소", example = "Club FF")
-    val venue: String?,
+    val venue: String? = null,
 )

--- a/src/main/kotlin/com/bandage/v1/domain/performance/dto/res/PerformanceDetailResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/dto/res/PerformanceDetailResponse.kt
@@ -1,5 +1,6 @@
 package com.bandage.v1.domain.performance.dto.res
 
+import com.bandage.v1.domain.band.model.Band
 import com.bandage.v1.domain.performance.model.Performance
 import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
@@ -19,24 +20,58 @@ data class PerformanceDetailResponse(
     val durationMinutes: Int,
     @Schema(description = "공연 장소", example = "Club FF")
     val venue: String?,
-    @Schema(description = "참여 밴드 아이디 목록")
-    val bandIds: List<UUID>,
+    @Schema(description = "참여 밴드 요약 목록")
+    val bands: List<BandSummary>,
     @Schema(description = "매니저 멤버 아이디 목록")
     val managerIds: List<Long>,
-    @Schema(description = "연결된 합주 아이디 목록")
-    val practiceIds: List<UUID>,
+    @Schema(description = "연결된 합주 요약 목록")
+    val practices: List<PracticeSummary>,
 ) {
+    @Schema(description = "공연 참여 밴드 요약")
+    data class BandSummary(
+        @Schema(description = "밴드 고유 식별자", example = "550e8400-e29b-41d4-a716-446655440000")
+        val bandId: UUID,
+        @Schema(description = "밴드 이름", example = "TuNA")
+        val bandName: String,
+    )
+
+    @Schema(description = "공연 연결 합주 요약")
+    data class PracticeSummary(
+        @Schema(description = "합주 고유 식별자", example = "550e8400-e29b-41d4-a716-446655440000")
+        val practiceId: UUID,
+        @Schema(description = "합주 제목", example = "TuNA 정기공연 1주차 합주")
+        val title: String,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm", shape = JsonFormat.Shape.STRING, timezone = "Asia/Seoul")
+        @Schema(description = "합주 시작 시간", example = "2026-06-01 18:00")
+        val startAt: LocalDateTime,
+    )
+
     companion object {
-        fun of(performance: Performance): PerformanceDetailResponse =
-            PerformanceDetailResponse(
+        fun of(
+            performance: Performance,
+            bands: List<Band>,
+        ): PerformanceDetailResponse {
+            val bandById = bands.associateBy { it.id }
+            return PerformanceDetailResponse(
                 performanceId = performance.id,
                 title = performance.title,
                 startAt = performance.schedule.startAt,
                 durationMinutes = performance.schedule.durationMinutes,
                 venue = performance.schedule.venue,
-                bandIds = performance.bands.map { it.bandId },
+                bands =
+                    performance.bands.mapNotNull { pb ->
+                        bandById[pb.bandId]?.let { BandSummary(bandId = it.id, bandName = it.name) }
+                    },
                 managerIds = performance.managers.map { it.member },
-                practiceIds = performance.practices.map { it.practice.id },
+                practices =
+                    performance.practices.map { pp ->
+                        PracticeSummary(
+                            practiceId = pp.practice.id,
+                            title = pp.practice.title,
+                            startAt = pp.practice.schedule.startAt,
+                        )
+                    },
             )
+        }
     }
 }

--- a/src/main/kotlin/com/bandage/v1/domain/performance/repository/PerformanceRepositoryCustom.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/repository/PerformanceRepositoryCustom.kt
@@ -21,4 +21,10 @@ interface PerformanceRepositoryCustom {
         lastId: UUID?,
         pageSize: Int,
     ): CursorResponse<Performance, UUID>
+
+    fun searchByTitleAndPaging(
+        keyword: String,
+        lastId: UUID?,
+        pageSize: Int,
+    ): CursorResponse<Performance, UUID>
 }

--- a/src/main/kotlin/com/bandage/v1/domain/performance/repository/PerformanceRepositoryCustom.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/repository/PerformanceRepositoryCustom.kt
@@ -15,4 +15,10 @@ interface PerformanceRepositoryCustom {
         lastId: UUID?,
         pageSize: Int,
     ): CursorResponse<Performance, UUID>
+
+    fun findAllByBandIdsAndPaging(
+        bandIds: List<UUID>,
+        lastId: UUID?,
+        pageSize: Int,
+    ): CursorResponse<Performance, UUID>
 }

--- a/src/main/kotlin/com/bandage/v1/domain/performance/repository/PerformanceRepositoryImpl.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/repository/PerformanceRepositoryImpl.kt
@@ -67,5 +67,36 @@ class PerformanceRepositoryImpl(
         )
     }
 
+    override fun findAllByBandIdsAndPaging(
+        bandIds: List<UUID>,
+        lastId: UUID?,
+        pageSize: Int,
+    ): CursorResponse<Performance, UUID> {
+        val qPerformance = QPerformance.performance
+        val qPerformanceBand = QPerformanceBand.performanceBand
+
+        val contents =
+            queryFactory
+                .selectFrom(qPerformance)
+                .join(qPerformanceBand)
+                .on(qPerformanceBand.performance.eq(qPerformance))
+                .where(qPerformanceBand.bandId.`in`(bandIds))
+                .where(ltPerformanceId(lastId))
+                .orderBy(qPerformance.id.desc())
+                .distinct()
+                .limit(pageSize.toLong() + 1)
+                .fetch()
+
+        val hasNext = contents.size > pageSize
+        val resultContents = if (hasNext) contents.dropLast(1) else contents
+        val nextCursor = resultContents.lastOrNull()?.id
+
+        return CursorResponse(
+            content = resultContents,
+            nextCursor = nextCursor,
+            hasNext = hasNext,
+        )
+    }
+
     private fun ltPerformanceId(lastId: UUID?): BooleanExpression? = lastId?.let { QPerformance.performance.id.lt(it) }
 }

--- a/src/main/kotlin/com/bandage/v1/domain/performance/repository/PerformanceRepositoryImpl.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/repository/PerformanceRepositoryImpl.kt
@@ -27,7 +27,7 @@ class PerformanceRepositoryImpl(
 
         val hasNext = contents.size > pageSize
         val resultContents = if (hasNext) contents.dropLast(1) else contents
-        val nextCursor = resultContents.lastOrNull()?.id
+        val nextCursor = if (hasNext) resultContents.lastOrNull()?.id else null
 
         return CursorResponse(
             content = resultContents,
@@ -58,7 +58,7 @@ class PerformanceRepositoryImpl(
 
         val hasNext = contents.size > pageSize
         val resultContents = if (hasNext) contents.dropLast(1) else contents
-        val nextCursor = resultContents.lastOrNull()?.id
+        val nextCursor = if (hasNext) resultContents.lastOrNull()?.id else null
 
         return CursorResponse(
             content = resultContents,
@@ -89,7 +89,34 @@ class PerformanceRepositoryImpl(
 
         val hasNext = contents.size > pageSize
         val resultContents = if (hasNext) contents.dropLast(1) else contents
-        val nextCursor = resultContents.lastOrNull()?.id
+        val nextCursor = if (hasNext) resultContents.lastOrNull()?.id else null
+
+        return CursorResponse(
+            content = resultContents,
+            nextCursor = nextCursor,
+            hasNext = hasNext,
+        )
+    }
+
+    override fun searchByTitleAndPaging(
+        keyword: String,
+        lastId: UUID?,
+        pageSize: Int,
+    ): CursorResponse<Performance, UUID> {
+        val qPerformance = QPerformance.performance
+
+        val contents =
+            queryFactory
+                .selectFrom(qPerformance)
+                .where(qPerformance.title.containsIgnoreCase(keyword))
+                .where(ltPerformanceId(lastId))
+                .orderBy(qPerformance.id.desc())
+                .limit(pageSize.toLong() + 1)
+                .fetch()
+
+        val hasNext = contents.size > pageSize
+        val resultContents = if (hasNext) contents.dropLast(1) else contents
+        val nextCursor = if (hasNext) resultContents.lastOrNull()?.id else null
 
         return CursorResponse(
             content = resultContents,

--- a/src/main/kotlin/com/bandage/v1/domain/performance/service/PerformanceService.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/service/PerformanceService.kt
@@ -1,9 +1,11 @@
 package com.bandage.v1.domain.performance.service
 
 import com.bandage.v1.domain.band.repository.BandMemberRepository
+import com.bandage.v1.domain.band.repository.BandRepository
 import com.bandage.v1.domain.performance.dto.req.PerformanceCreateRequest
 import com.bandage.v1.domain.performance.dto.req.PerformancePagingQuery
 import com.bandage.v1.domain.performance.dto.req.PerformancePracticeAddRequest
+import com.bandage.v1.domain.performance.dto.req.PerformanceSearchQuery
 import com.bandage.v1.domain.performance.dto.req.PerformanceUpdateRequest
 import com.bandage.v1.domain.performance.dto.res.PerformanceDetailResponse
 import com.bandage.v1.domain.performance.dto.res.PerformanceListResponse
@@ -36,6 +38,7 @@ class PerformanceService(
     private val performancePracticeRepository: PerformancePracticeRepository,
     private val practiceRepository: PracticeRepository,
     private val bandMemberRepository: BandMemberRepository,
+    private val bandRepository: BandRepository,
 ) {
     @Transactional
     fun createPerformance(
@@ -95,7 +98,20 @@ class PerformanceService(
         )
     }
 
-    fun getPerformanceDetail(performanceId: UUID): PerformanceDetailResponse = PerformanceDetailResponse.of(getPerformance(performanceId))
+    fun searchPerformancesByCursor(query: PerformanceSearchQuery): CursorResponse<PerformanceListResponse, UUID> {
+        val result = performanceRepository.searchByTitleAndPaging(query.keyword, query.lastId, query.pageSize)
+        return CursorResponse(
+            content = result.content.map { PerformanceListResponse.of(it) },
+            nextCursor = result.nextCursor,
+            hasNext = result.hasNext,
+        )
+    }
+
+    fun getPerformanceDetail(performanceId: UUID): PerformanceDetailResponse {
+        val performance = getPerformance(performanceId)
+        val bands = bandRepository.findAllById(performance.bands.map { it.bandId })
+        return PerformanceDetailResponse.of(performance, bands)
+    }
 
     @Transactional
     fun updatePerformance(
@@ -105,8 +121,13 @@ class PerformanceService(
     ) {
         val performance = getPerformance(performanceId)
         validateIsManager(performance, memberId)
-        performance.updateTitle(request.title)
-        performance.updateSchedule(request.startAt, request.durationMinutes)
+        request.title?.let { performance.updateTitle(it) }
+        if (request.startAt != null || request.durationMinutes != null) {
+            performance.updateSchedule(
+                startAt = request.startAt ?: performance.schedule.startAt,
+                durationMinutes = request.durationMinutes ?: performance.schedule.durationMinutes,
+            )
+        }
         request.venue?.let { performance.updateVenue(it) }
     }
 

--- a/src/main/kotlin/com/bandage/v1/domain/performance/service/PerformanceService.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/service/PerformanceService.kt
@@ -1,5 +1,6 @@
 package com.bandage.v1.domain.performance.service
 
+import com.bandage.v1.domain.band.repository.BandMemberRepository
 import com.bandage.v1.domain.performance.dto.req.PerformanceCreateRequest
 import com.bandage.v1.domain.performance.dto.req.PerformancePagingQuery
 import com.bandage.v1.domain.performance.dto.req.PerformancePracticeAddRequest
@@ -34,6 +35,7 @@ class PerformanceService(
     private val performanceManagerRepository: PerformanceManagerRepository,
     private val performancePracticeRepository: PerformancePracticeRepository,
     private val practiceRepository: PracticeRepository,
+    private val bandMemberRepository: BandMemberRepository,
 ) {
     @Transactional
     fun createPerformance(
@@ -70,6 +72,22 @@ class PerformanceService(
         query: PerformancePagingQuery,
     ): CursorResponse<PerformanceListResponse, UUID> {
         val result = performanceRepository.findAllByBandIdAndPaging(bandId, query.lastId, query.pageSize)
+        return CursorResponse(
+            content = result.content.map { PerformanceListResponse.of(it) },
+            nextCursor = result.nextCursor,
+            hasNext = result.hasNext,
+        )
+    }
+
+    fun getMyPerformancesByCursor(
+        memberId: Long,
+        query: PerformancePagingQuery,
+    ): CursorResponse<PerformanceListResponse, UUID> {
+        val bandIds = bandMemberRepository.findAllBandIdsByMember(memberId)
+        if (bandIds.isEmpty()) {
+            return CursorResponse(content = emptyList(), nextCursor = null, hasNext = false)
+        }
+        val result = performanceRepository.findAllByBandIdsAndPaging(bandIds, query.lastId, query.pageSize)
         return CursorResponse(
             content = result.content.map { PerformanceListResponse.of(it) },
             nextCursor = result.nextCursor,

--- a/src/main/kotlin/com/bandage/v1/domain/practice/controller/PracticeController.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/controller/PracticeController.kt
@@ -2,16 +2,19 @@ package com.bandage.v1.domain.practice.controller
 
 import com.bandage.v1.domain.practice.dto.req.PracticeCreateRequest
 import com.bandage.v1.domain.practice.dto.req.PracticeMemberAddRequest
+import com.bandage.v1.domain.practice.dto.req.PracticePagingQuery
 import com.bandage.v1.domain.practice.dto.req.PracticeScheduleUpdateRequest
 import com.bandage.v1.domain.practice.dto.req.PracticeSessionCreateRequest
 import com.bandage.v1.domain.practice.dto.req.PracticeVenueUpdateRequest
 import com.bandage.v1.domain.practice.dto.res.PracticeDetailResponse
+import com.bandage.v1.domain.practice.dto.res.PracticeListResponse
 import com.bandage.v1.domain.practice.dto.res.PracticeParticipantResponse
 import com.bandage.v1.domain.practice.dto.res.PracticeResponse
 import com.bandage.v1.domain.practice.dto.res.PracticeSessionResponse
 import com.bandage.v1.domain.practice.service.PracticeService
 import com.bandage.v1.global.common.constants.PathPrefix.PREFIX
 import com.bandage.v1.global.common.response.ApiResponse
+import com.bandage.v1.global.common.response.CursorResponse
 import com.bandage.v1.global.security.annotation.CurrentMemberId
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -49,6 +52,14 @@ class PracticeController(
         ApiResponse.success(
             practiceService.getPracticeDetail(practiceId),
         )
+
+    @GetMapping("/me")
+    @Operation(summary = "내 합주 목록 조회 API", description = "본인이 참여 중인 합주 목록을 커서 기반으로 조회합니다.")
+    fun getMyPractices(
+        @Valid query: PracticePagingQuery,
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<CursorResponse<PracticeListResponse, UUID>> =
+        ApiResponse.success(practiceService.getMyPracticesByCursor(memberId, query))
 
     @PostMapping("/{practiceId}/sessions")
     @Operation(summary = "합주 세션 생성 API", description = "합주에 세션을 추가합니다.")

--- a/src/main/kotlin/com/bandage/v1/domain/practice/controller/PracticeController.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/controller/PracticeController.kt
@@ -4,6 +4,7 @@ import com.bandage.v1.domain.practice.dto.req.PracticeCreateRequest
 import com.bandage.v1.domain.practice.dto.req.PracticeMemberAddRequest
 import com.bandage.v1.domain.practice.dto.req.PracticePagingQuery
 import com.bandage.v1.domain.practice.dto.req.PracticeScheduleUpdateRequest
+import com.bandage.v1.domain.practice.dto.req.PracticeSearchQuery
 import com.bandage.v1.domain.practice.dto.req.PracticeSessionCreateRequest
 import com.bandage.v1.domain.practice.dto.req.PracticeVenueUpdateRequest
 import com.bandage.v1.domain.practice.dto.res.PracticeDetailResponse
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
@@ -44,6 +46,16 @@ class PracticeController(
             practiceService.createPractice(request),
         )
 
+    @GetMapping
+    @Operation(
+        summary = "합주 목록 조회 API",
+        description = "합주 목록을 커서 기반으로 조회합니다. bandId 제공 시 해당 밴드 멤버가 참여 중인 합주만 조회합니다.",
+    )
+    fun getPractices(
+        @RequestParam(required = false) bandId: UUID?,
+        @Valid query: PracticePagingQuery,
+    ): ApiResponse<CursorResponse<PracticeListResponse, UUID>> = ApiResponse.success(practiceService.getPracticesByCursor(bandId, query))
+
     @GetMapping("/{practiceId}")
     @Operation(summary = "합주 조회 API", description = "합주 상세 정보를 조회합니다.")
     fun getPractice(
@@ -60,6 +72,14 @@ class PracticeController(
         @CurrentMemberId memberId: Long,
     ): ApiResponse<CursorResponse<PracticeListResponse, UUID>> =
         ApiResponse.success(practiceService.getMyPracticesByCursor(memberId, query))
+
+    @GetMapping("/me/search")
+    @Operation(summary = "내 합주 검색 API", description = "본인이 참여 중인 합주 중 합주 타이틀 또는 곡 제목에 키워드가 포함된 합주를 커서 기반으로 조회합니다.")
+    fun searchMyPractices(
+        @Valid query: PracticeSearchQuery,
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<CursorResponse<PracticeListResponse, UUID>> =
+        ApiResponse.success(practiceService.searchMyPracticesByCursor(memberId, query))
 
     @PostMapping("/{practiceId}/sessions")
     @Operation(summary = "합주 세션 생성 API", description = "합주에 세션을 추가합니다.")

--- a/src/main/kotlin/com/bandage/v1/domain/practice/controller/PracticeSongController.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/controller/PracticeSongController.kt
@@ -1,6 +1,12 @@
 package com.bandage.v1.domain.practice.controller
 
+import com.bandage.v1.domain.practice.dto.Song
+import com.bandage.v1.domain.practice.dto.req.PracticeSongCreateFromSongRequest
+import com.bandage.v1.domain.practice.dto.req.PracticeSongCreateRequest
 import com.bandage.v1.domain.practice.dto.req.PracticeSongRefLinkUpsertRequest
+import com.bandage.v1.domain.practice.dto.req.PracticeSongSearchQuery
+import com.bandage.v1.domain.practice.dto.req.PracticeSongUpdateRequest
+import com.bandage.v1.domain.practice.dto.res.PracticeSongResponse
 import com.bandage.v1.domain.practice.service.PracticeService
 import com.bandage.v1.global.common.constants.PathPrefix.PREFIX
 import com.bandage.v1.global.common.response.ApiResponse
@@ -8,7 +14,10 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -21,6 +30,60 @@ import java.util.UUID
 class PracticeSongController(
     private val practiceService: PracticeService,
 ) {
+    @GetMapping("/search")
+    @Operation(
+        summary = "합주곡 검색 API",
+        description = "키워드로 외부 시스템에서 곡 정보를 검색합니다. 응답은 Song 객체로 반환되며 이 시스템에서 DB 엔티티로 관리되지 않습니다. (현재는 외부 연동 전 mock 응답)",
+    )
+    fun searchSongs(
+        @Valid query: PracticeSongSearchQuery,
+    ): ApiResponse<List<Song>> = ApiResponse.success(practiceService.searchSongs(query.keyword))
+
+    @PostMapping
+    @Operation(
+        summary = "합주곡 생성 API (필드 입력)",
+        description = "자작곡 등 외부 API 연동이 필요 없는 곡을 사용자가 각 필드를 직접 입력하여 합주곡으로 생성하고 합주에 1:1 바인딩합니다.",
+    )
+    fun createPracticeSong(
+        @Valid @RequestBody request: PracticeSongCreateRequest,
+    ): ApiResponse<PracticeSongResponse> =
+        ApiResponse.success(
+            practiceService.createPracticeSong(
+                practiceId = request.practiceId,
+                title = request.title,
+                artist = request.artist,
+                album = request.album,
+                duration = request.duration,
+                refLink = request.refLink,
+            ),
+        )
+
+    @PostMapping("/from-song")
+    @Operation(
+        summary = "합주곡 생성 API (Song 객체)",
+        description = "외부 시스템에서 받아온 Song 객체를 그대로 사용하여 합주곡을 생성하고 합주에 1:1 바인딩합니다.",
+    )
+    fun createPracticeSongFromSong(
+        @Valid @RequestBody request: PracticeSongCreateFromSongRequest,
+    ): ApiResponse<PracticeSongResponse> =
+        ApiResponse.success(
+            practiceService.createPracticeSong(request.practiceId, request.song),
+        )
+
+    @PatchMapping("/{songId}")
+    @Operation(summary = "합주곡 부분 수정 API", description = "합주곡의 일부 정보만 수정합니다. 전달된 필드만 업데이트됩니다.")
+    fun updatePracticeSong(
+        @PathVariable songId: UUID,
+        @Valid @RequestBody request: PracticeSongUpdateRequest,
+    ): ApiResponse<PracticeSongResponse> = ApiResponse.success(practiceService.updatePracticeSong(songId, request))
+
+    @PutMapping("/{songId}")
+    @Operation(summary = "합주곡 Upsert API", description = "Song 객체를 사용하여 합주곡 정보를 전체 갱신합니다.")
+    fun upsertPracticeSong(
+        @PathVariable songId: UUID,
+        @Valid @RequestBody song: Song,
+    ): ApiResponse<PracticeSongResponse> = ApiResponse.success(practiceService.upsertPracticeSong(songId, song))
+
     @PutMapping("/{songId}/ref-link")
     @Operation(summary = "합주곡 참조 링크 upsert API", description = "합주곡 참조 링크를 등록하거나 수정합니다.")
     fun upsertRefLink(

--- a/src/main/kotlin/com/bandage/v1/domain/practice/dto/Song.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/dto/Song.kt
@@ -1,0 +1,23 @@
+package com.bandage.v1.domain.practice.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+
+@Schema(description = "외부 시스템 곡 정보 (전송 전용 DTO, DB 엔티티로 관리되지 않음)")
+data class Song(
+    @field:NotBlank
+    @Schema(description = "곡 제목", example = "Vicarious")
+    val title: String,
+    @field:NotBlank
+    @Schema(description = "아티스트", example = "Tool")
+    val artist: String,
+    @field:NotBlank
+    @Schema(description = "앨범", example = "10,000 Days")
+    val album: String,
+    @field:Min(1)
+    @Schema(description = "곡 길이 (초)", example = "426")
+    val duration: Int,
+    @Schema(description = "참조 링크", example = "https://www.youtube.com/watch?v=example")
+    val refLink: String? = null,
+)

--- a/src/main/kotlin/com/bandage/v1/domain/practice/dto/req/PracticePagingQuery.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/dto/req/PracticePagingQuery.kt
@@ -1,0 +1,16 @@
+package com.bandage.v1.domain.practice.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import java.util.UUID
+
+@Schema(description = "합주 목록 조회 쿼리")
+data class PracticePagingQuery(
+    @Schema(description = "마지막으로 조회된 합주 ID (커서)", example = "550e8400-e29b-41d4-a716-446655440000")
+    val lastId: UUID?,
+    @field:Min(1)
+    @field:Max(100)
+    @Schema(description = "페이지 크기", example = "10")
+    val pageSize: Int = 10,
+)

--- a/src/main/kotlin/com/bandage/v1/domain/practice/dto/req/PracticeSearchQuery.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/dto/req/PracticeSearchQuery.kt
@@ -1,0 +1,20 @@
+package com.bandage.v1.domain.practice.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import java.util.UUID
+
+@Schema(description = "합주 검색 쿼리")
+data class PracticeSearchQuery(
+    @field:NotBlank
+    @Schema(description = "검색 키워드 (합주 타이틀 또는 곡 제목)", example = "Stairway")
+    val keyword: String,
+    @Schema(description = "마지막으로 조회된 합주 ID (커서)", example = "550e8400-e29b-41d4-a716-446655440000")
+    val lastId: UUID?,
+    @field:Min(1)
+    @field:Max(100)
+    @Schema(description = "페이지 크기", example = "10")
+    val pageSize: Int = 10,
+)

--- a/src/main/kotlin/com/bandage/v1/domain/practice/dto/req/PracticeSongCreateFromSongRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/dto/req/PracticeSongCreateFromSongRequest.kt
@@ -1,0 +1,15 @@
+package com.bandage.v1.domain.practice.dto.req
+
+import com.bandage.v1.domain.practice.dto.Song
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+import java.util.UUID
+
+@Schema(description = "합주곡 생성 요청 (Song 객체 사용 — 외부 시스템에서 받아온 실제 음원 정보를 그대로 등록)")
+data class PracticeSongCreateFromSongRequest(
+    @Schema(description = "합주 ID (1:1 바인딩 대상)", example = "550e8400-e29b-41d4-a716-446655440000")
+    val practiceId: UUID,
+    @field:Valid
+    @Schema(description = "외부 시스템 곡 정보")
+    val song: Song,
+)

--- a/src/main/kotlin/com/bandage/v1/domain/practice/dto/req/PracticeSongCreateRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/dto/req/PracticeSongCreateRequest.kt
@@ -1,0 +1,26 @@
+package com.bandage.v1.domain.practice.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import java.util.UUID
+
+@Schema(description = "합주곡 생성 요청 (필드 직접 입력 — 자작곡 등 외부 API 연동이 필요 없는 곡 등록용)")
+data class PracticeSongCreateRequest(
+    @Schema(description = "합주 ID (1:1 바인딩 대상)", example = "550e8400-e29b-41d4-a716-446655440000")
+    val practiceId: UUID,
+    @field:NotBlank
+    @Schema(description = "곡 제목", example = "자작곡 No.1")
+    val title: String,
+    @field:NotBlank
+    @Schema(description = "아티스트", example = "TuNA")
+    val artist: String,
+    @field:NotBlank
+    @Schema(description = "앨범", example = "TuNA Demo")
+    val album: String,
+    @field:Min(1)
+    @Schema(description = "곡 길이 (초)", example = "300")
+    val duration: Int,
+    @Schema(description = "참조 링크", example = "https://www.youtube.com/watch?v=example")
+    val refLink: String? = null,
+)

--- a/src/main/kotlin/com/bandage/v1/domain/practice/dto/req/PracticeSongSearchQuery.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/dto/req/PracticeSongSearchQuery.kt
@@ -1,0 +1,11 @@
+package com.bandage.v1.domain.practice.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+
+@Schema(description = "합주곡 검색 쿼리")
+data class PracticeSongSearchQuery(
+    @field:NotBlank
+    @Schema(description = "검색 키워드 (곡 제목 또는 아티스트)", example = "Tool")
+    val keyword: String,
+)

--- a/src/main/kotlin/com/bandage/v1/domain/practice/dto/req/PracticeSongUpdateRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/dto/req/PracticeSongUpdateRequest.kt
@@ -1,0 +1,19 @@
+package com.bandage.v1.domain.practice.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Min
+
+@Schema(description = "합주곡 수정 요청 (부분 수정)")
+data class PracticeSongUpdateRequest(
+    @Schema(description = "곡 제목", example = "Vicarious")
+    val title: String? = null,
+    @Schema(description = "아티스트", example = "Tool")
+    val artist: String? = null,
+    @Schema(description = "앨범", example = "10,000 Days")
+    val album: String? = null,
+    @field:Min(1)
+    @Schema(description = "곡 길이 (초)", example = "426")
+    val duration: Int? = null,
+    @Schema(description = "참조 링크", example = "https://www.youtube.com/watch?v=example")
+    val refLink: String? = null,
+)

--- a/src/main/kotlin/com/bandage/v1/domain/practice/dto/res/PracticeListResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/dto/res/PracticeListResponse.kt
@@ -1,0 +1,33 @@
+package com.bandage.v1.domain.practice.dto.res
+
+import com.bandage.v1.domain.practice.model.Practice
+import com.fasterxml.jackson.annotation.JsonFormat
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Schema(description = "합주 목록 조회 응답")
+data class PracticeListResponse(
+    @Schema(description = "합주 고유 식별자 (UUID)", example = "550e8400-e29b-41d4-a716-446655440000")
+    val practiceId: UUID,
+    @Schema(description = "합주 타이틀", example = "TuNA 정기공연 1주차 합주")
+    val title: String,
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm", shape = JsonFormat.Shape.STRING, timezone = "Asia/Seoul")
+    @Schema(description = "합주 시작 시간", example = "2026-03-15 18:00")
+    val startAt: LocalDateTime,
+    @Schema(description = "합주 시간 (분)", example = "60")
+    val durationMinutes: Int,
+    @Schema(description = "합주 장소", example = "홍대 스튜디오")
+    val venue: String?,
+) {
+    companion object {
+        fun of(practice: Practice): PracticeListResponse =
+            PracticeListResponse(
+                practiceId = practice.id,
+                title = practice.title,
+                startAt = practice.schedule.startAt,
+                durationMinutes = practice.schedule.durationMinutes,
+                venue = practice.schedule.venue,
+            )
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/practice/dto/res/PracticeSongResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/dto/res/PracticeSongResponse.kt
@@ -1,0 +1,33 @@
+package com.bandage.v1.domain.practice.dto.res
+
+import com.bandage.v1.domain.practice.model.PracticeSong
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.UUID
+
+@Schema(description = "합주곡 응답")
+data class PracticeSongResponse(
+    @Schema(description = "합주곡 고유 식별자 (UUID)", example = "550e8400-e29b-41d4-a716-446655440000")
+    val songId: UUID,
+    @Schema(description = "곡 제목", example = "Vicarious")
+    val title: String,
+    @Schema(description = "아티스트", example = "Tool")
+    val artist: String,
+    @Schema(description = "앨범", example = "10,000 Days")
+    val album: String,
+    @Schema(description = "곡 길이 (초)", example = "426")
+    val duration: Int,
+    @Schema(description = "참조 링크", example = "https://www.youtube.com/watch?v=example")
+    val refLink: String?,
+) {
+    companion object {
+        fun of(song: PracticeSong): PracticeSongResponse =
+            PracticeSongResponse(
+                songId = song.id,
+                title = song.title,
+                artist = song.artist,
+                album = song.album,
+                duration = song.duration,
+                refLink = song.refLink,
+            )
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/practice/model/PracticeSong.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/model/PracticeSong.kt
@@ -51,12 +51,14 @@ open class PracticeSong(
             artist: String,
             album: String,
             duration: Int,
+            refLink: String? = null,
         ): PracticeSong =
             PracticeSong(
                 title = title,
                 artist = artist,
                 album = album,
                 duration = duration,
+                refLink = refLink,
             )
     }
 
@@ -66,5 +68,35 @@ open class PracticeSong(
 
     fun deleteRefLink() {
         this.refLink = null
+    }
+
+    fun updateTitle(title: String) {
+        this.title = title
+    }
+
+    fun updateArtist(artist: String) {
+        this.artist = artist
+    }
+
+    fun updateAlbum(album: String) {
+        this.album = album
+    }
+
+    fun updateDuration(duration: Int) {
+        this.duration = duration
+    }
+
+    fun updateAll(
+        title: String,
+        artist: String,
+        album: String,
+        duration: Int,
+        refLink: String?,
+    ) {
+        this.title = title
+        this.artist = artist
+        this.album = album
+        this.duration = duration
+        this.refLink = refLink
     }
 }

--- a/src/main/kotlin/com/bandage/v1/domain/practice/repository/PracticeRepository.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/repository/PracticeRepository.kt
@@ -6,4 +6,6 @@ import org.springframework.stereotype.Repository
 import java.util.UUID
 
 @Repository
-interface PracticeRepository : JpaRepository<Practice, UUID>
+interface PracticeRepository :
+    JpaRepository<Practice, UUID>,
+    PracticeRepositoryCustom

--- a/src/main/kotlin/com/bandage/v1/domain/practice/repository/PracticeRepositoryCustom.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/repository/PracticeRepositoryCustom.kt
@@ -1,0 +1,13 @@
+package com.bandage.v1.domain.practice.repository
+
+import com.bandage.v1.domain.practice.model.Practice
+import com.bandage.v1.global.common.response.CursorResponse
+import java.util.UUID
+
+interface PracticeRepositoryCustom {
+    fun findAllByMemberAndPaging(
+        memberId: Long,
+        lastId: UUID?,
+        pageSize: Int,
+    ): CursorResponse<Practice, UUID>
+}

--- a/src/main/kotlin/com/bandage/v1/domain/practice/repository/PracticeRepositoryCustom.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/repository/PracticeRepositoryCustom.kt
@@ -5,8 +5,26 @@ import com.bandage.v1.global.common.response.CursorResponse
 import java.util.UUID
 
 interface PracticeRepositoryCustom {
+    fun findAllByPaging(
+        lastId: UUID?,
+        pageSize: Int,
+    ): CursorResponse<Practice, UUID>
+
+    fun findAllByMembersAndPaging(
+        memberIds: List<Long>,
+        lastId: UUID?,
+        pageSize: Int,
+    ): CursorResponse<Practice, UUID>
+
     fun findAllByMemberAndPaging(
         memberId: Long,
+        lastId: UUID?,
+        pageSize: Int,
+    ): CursorResponse<Practice, UUID>
+
+    fun searchByMemberAndKeywordAndPaging(
+        memberId: Long,
+        keyword: String,
         lastId: UUID?,
         pageSize: Int,
     ): CursorResponse<Practice, UUID>

--- a/src/main/kotlin/com/bandage/v1/domain/practice/repository/PracticeRepositoryImpl.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/repository/PracticeRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.bandage.v1.domain.practice.repository
 import com.bandage.v1.domain.practice.model.Practice
 import com.bandage.v1.domain.practice.model.QPractice
 import com.bandage.v1.domain.practice.model.QPracticeParticipant
+import com.bandage.v1.domain.practice.model.QPracticeSong
 import com.bandage.v1.global.common.response.CursorResponse
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
@@ -11,6 +12,62 @@ import java.util.UUID
 class PracticeRepositoryImpl(
     private val queryFactory: JPAQueryFactory,
 ) : PracticeRepositoryCustom {
+    override fun findAllByPaging(
+        lastId: UUID?,
+        pageSize: Int,
+    ): CursorResponse<Practice, UUID> {
+        val qPractice = QPractice.practice
+
+        val contents =
+            queryFactory
+                .selectFrom(qPractice)
+                .where(ltPracticeId(lastId))
+                .orderBy(qPractice.id.desc())
+                .limit(pageSize.toLong() + 1)
+                .fetch()
+
+        val hasNext = contents.size > pageSize
+        val resultContents = if (hasNext) contents.dropLast(1) else contents
+        val nextCursor = if (hasNext) resultContents.lastOrNull()?.id else null
+
+        return CursorResponse(
+            content = resultContents,
+            nextCursor = nextCursor,
+            hasNext = hasNext,
+        )
+    }
+
+    override fun findAllByMembersAndPaging(
+        memberIds: List<Long>,
+        lastId: UUID?,
+        pageSize: Int,
+    ): CursorResponse<Practice, UUID> {
+        val qPractice = QPractice.practice
+        val qParticipant = QPracticeParticipant.practiceParticipant
+
+        val contents =
+            queryFactory
+                .selectFrom(qPractice)
+                .join(qParticipant)
+                .on(qParticipant.practice.eq(qPractice))
+                .where(qParticipant.member.`in`(memberIds))
+                .where(ltPracticeId(lastId))
+                .orderBy(qPractice.id.desc())
+                .distinct()
+                .limit(pageSize.toLong() + 1)
+                .fetch()
+
+        val hasNext = contents.size > pageSize
+        val resultContents = if (hasNext) contents.dropLast(1) else contents
+        val nextCursor = if (hasNext) resultContents.lastOrNull()?.id else null
+
+        return CursorResponse(
+            content = resultContents,
+            nextCursor = nextCursor,
+            hasNext = hasNext,
+        )
+    }
+
     override fun findAllByMemberAndPaging(
         memberId: Long,
         lastId: UUID?,
@@ -33,7 +90,42 @@ class PracticeRepositoryImpl(
 
         val hasNext = contents.size > pageSize
         val resultContents = if (hasNext) contents.dropLast(1) else contents
-        val nextCursor = resultContents.lastOrNull()?.id
+        val nextCursor = if (hasNext) resultContents.lastOrNull()?.id else null
+
+        return CursorResponse(
+            content = resultContents,
+            nextCursor = nextCursor,
+            hasNext = hasNext,
+        )
+    }
+
+    override fun searchByMemberAndKeywordAndPaging(
+        memberId: Long,
+        keyword: String,
+        lastId: UUID?,
+        pageSize: Int,
+    ): CursorResponse<Practice, UUID> {
+        val qPractice = QPractice.practice
+        val qParticipant = QPracticeParticipant.practiceParticipant
+        val qSong = QPracticeSong.practiceSong
+
+        val contents =
+            queryFactory
+                .selectFrom(qPractice)
+                .join(qParticipant)
+                .on(qParticipant.practice.eq(qPractice))
+                .join(qPractice.song, qSong)
+                .where(qParticipant.member.eq(memberId))
+                .where(qPractice.title.containsIgnoreCase(keyword).or(qSong.title.containsIgnoreCase(keyword)))
+                .where(ltPracticeId(lastId))
+                .orderBy(qPractice.id.desc())
+                .distinct()
+                .limit(pageSize.toLong() + 1)
+                .fetch()
+
+        val hasNext = contents.size > pageSize
+        val resultContents = if (hasNext) contents.dropLast(1) else contents
+        val nextCursor = if (hasNext) resultContents.lastOrNull()?.id else null
 
         return CursorResponse(
             content = resultContents,

--- a/src/main/kotlin/com/bandage/v1/domain/practice/repository/PracticeRepositoryImpl.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/repository/PracticeRepositoryImpl.kt
@@ -1,0 +1,46 @@
+package com.bandage.v1.domain.practice.repository
+
+import com.bandage.v1.domain.practice.model.Practice
+import com.bandage.v1.domain.practice.model.QPractice
+import com.bandage.v1.domain.practice.model.QPracticeParticipant
+import com.bandage.v1.global.common.response.CursorResponse
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.impl.JPAQueryFactory
+import java.util.UUID
+
+class PracticeRepositoryImpl(
+    private val queryFactory: JPAQueryFactory,
+) : PracticeRepositoryCustom {
+    override fun findAllByMemberAndPaging(
+        memberId: Long,
+        lastId: UUID?,
+        pageSize: Int,
+    ): CursorResponse<Practice, UUID> {
+        val qPractice = QPractice.practice
+        val qParticipant = QPracticeParticipant.practiceParticipant
+
+        val contents =
+            queryFactory
+                .selectFrom(qPractice)
+                .join(qParticipant)
+                .on(qParticipant.practice.eq(qPractice))
+                .where(qParticipant.member.eq(memberId))
+                .where(ltPracticeId(lastId))
+                .orderBy(qPractice.id.desc())
+                .distinct()
+                .limit(pageSize.toLong() + 1)
+                .fetch()
+
+        val hasNext = contents.size > pageSize
+        val resultContents = if (hasNext) contents.dropLast(1) else contents
+        val nextCursor = resultContents.lastOrNull()?.id
+
+        return CursorResponse(
+            content = resultContents,
+            nextCursor = nextCursor,
+            hasNext = hasNext,
+        )
+    }
+
+    private fun ltPracticeId(lastId: UUID?): BooleanExpression? = lastId?.let { QPractice.practice.id.lt(it) }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/practice/service/PracticeService.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/service/PracticeService.kt
@@ -1,17 +1,22 @@
 package com.bandage.v1.domain.practice.service
 
+import com.bandage.v1.domain.band.repository.BandMemberRepository
+import com.bandage.v1.domain.practice.dto.Song
 import com.bandage.v1.domain.practice.dto.req.PracticeCreateRequest
 import com.bandage.v1.domain.practice.dto.req.PracticeMemberAddRequest
 import com.bandage.v1.domain.practice.dto.req.PracticePagingQuery
 import com.bandage.v1.domain.practice.dto.req.PracticeScheduleUpdateRequest
+import com.bandage.v1.domain.practice.dto.req.PracticeSearchQuery
 import com.bandage.v1.domain.practice.dto.req.PracticeSessionCreateRequest
 import com.bandage.v1.domain.practice.dto.req.PracticeSongRefLinkUpsertRequest
+import com.bandage.v1.domain.practice.dto.req.PracticeSongUpdateRequest
 import com.bandage.v1.domain.practice.dto.req.PracticeVenueUpdateRequest
 import com.bandage.v1.domain.practice.dto.res.PracticeDetailResponse
 import com.bandage.v1.domain.practice.dto.res.PracticeListResponse
 import com.bandage.v1.domain.practice.dto.res.PracticeParticipantResponse
 import com.bandage.v1.domain.practice.dto.res.PracticeResponse
 import com.bandage.v1.domain.practice.dto.res.PracticeSessionResponse
+import com.bandage.v1.domain.practice.dto.res.PracticeSongResponse
 import com.bandage.v1.domain.practice.model.Practice
 import com.bandage.v1.domain.practice.model.PracticeParticipant
 import com.bandage.v1.domain.practice.model.PracticeSession
@@ -35,6 +40,7 @@ class PracticeService(
     private val practiceSessionRepository: PracticeSessionRepository,
     private val practiceParticipantRepository: PracticeParticipantRepository,
     private val practiceSongRepository: PracticeSongRepository,
+    private val bandMemberRepository: BandMemberRepository,
 ) {
     @Transactional
     fun createPractice(request: PracticeCreateRequest): PracticeResponse {
@@ -54,11 +60,50 @@ class PracticeService(
 
     fun getPracticeDetail(practiceId: UUID): PracticeDetailResponse = PracticeDetailResponse.of(getPractice(practiceId))
 
+    fun getPracticesByCursor(
+        bandId: UUID?,
+        query: PracticePagingQuery,
+    ): CursorResponse<PracticeListResponse, UUID> {
+        val result =
+            if (bandId != null) {
+                val memberIds = bandMemberRepository.findAllMemberIdsByBand(bandId)
+                if (memberIds.isEmpty()) {
+                    return CursorResponse(content = emptyList(), nextCursor = null, hasNext = false)
+                }
+                practiceRepository.findAllByMembersAndPaging(memberIds, query.lastId, query.pageSize)
+            } else {
+                practiceRepository.findAllByPaging(query.lastId, query.pageSize)
+            }
+        return CursorResponse(
+            content = result.content.map { PracticeListResponse.of(it) },
+            nextCursor = result.nextCursor,
+            hasNext = result.hasNext,
+        )
+    }
+
     fun getMyPracticesByCursor(
         memberId: Long,
         query: PracticePagingQuery,
     ): CursorResponse<PracticeListResponse, UUID> {
         val result = practiceRepository.findAllByMemberAndPaging(memberId, query.lastId, query.pageSize)
+        return CursorResponse(
+            content = result.content.map { PracticeListResponse.of(it) },
+            nextCursor = result.nextCursor,
+            hasNext = result.hasNext,
+        )
+    }
+
+    fun searchMyPracticesByCursor(
+        memberId: Long,
+        query: PracticeSearchQuery,
+    ): CursorResponse<PracticeListResponse, UUID> {
+        val result =
+            practiceRepository.searchByMemberAndKeywordAndPaging(
+                memberId = memberId,
+                keyword = query.keyword,
+                lastId = query.lastId,
+                pageSize = query.pageSize,
+            )
         return CursorResponse(
             content = result.content.map { PracticeListResponse.of(it) },
             nextCursor = result.nextCursor,
@@ -177,6 +222,94 @@ class PracticeService(
     fun deletePracticeSongRefLink(songId: UUID) {
         val song = getPracticeSong(songId)
         song.deleteRefLink()
+    }
+
+    // TODO: 외부 음원 검색 API / gRPC 연동으로 대체. 현재는 Tool 곡 mock 결과를 무조건 반환.
+    fun searchSongs(keyword: String): List<Song> =
+        listOf(
+            Song(
+                title = "Vicarious",
+                artist = "Tool",
+                album = "10,000 Days",
+                duration = 426,
+            ),
+            Song(
+                title = "Schism",
+                artist = "Tool",
+                album = "Lateralus",
+                duration = 407,
+            ),
+        )
+
+    @Transactional
+    fun createPracticeSong(
+        practiceId: UUID,
+        song: Song,
+    ): PracticeSongResponse {
+        val practice = getPractice(practiceId)
+        val newSong =
+            practiceSongRepository.save(
+                PracticeSong.create(
+                    title = song.title,
+                    artist = song.artist,
+                    album = song.album,
+                    duration = song.duration,
+                    refLink = song.refLink,
+                ),
+            )
+        practice.updateSong(newSong)
+        return PracticeSongResponse.of(newSong)
+    }
+
+    @Transactional
+    fun createPracticeSong(
+        practiceId: UUID,
+        title: String,
+        artist: String,
+        album: String,
+        duration: Int,
+        refLink: String?,
+    ): PracticeSongResponse =
+        createPracticeSong(
+            practiceId = practiceId,
+            song =
+                Song(
+                    title = title,
+                    artist = artist,
+                    album = album,
+                    duration = duration,
+                    refLink = refLink,
+                ),
+        )
+
+    @Transactional
+    fun updatePracticeSong(
+        songId: UUID,
+        request: PracticeSongUpdateRequest,
+    ): PracticeSongResponse {
+        val song = getPracticeSong(songId)
+        request.title?.let { song.updateTitle(it) }
+        request.artist?.let { song.updateArtist(it) }
+        request.album?.let { song.updateAlbum(it) }
+        request.duration?.let { song.updateDuration(it) }
+        request.refLink?.let { song.updateRefLink(it) }
+        return PracticeSongResponse.of(song)
+    }
+
+    @Transactional
+    fun upsertPracticeSong(
+        songId: UUID,
+        song: Song,
+    ): PracticeSongResponse {
+        val practiceSong = getPracticeSong(songId)
+        practiceSong.updateAll(
+            title = song.title,
+            artist = song.artist,
+            album = song.album,
+            duration = song.duration,
+            refLink = song.refLink,
+        )
+        return PracticeSongResponse.of(practiceSong)
     }
 
     // --- 내부 유틸리티 메서드 ---

--- a/src/main/kotlin/com/bandage/v1/domain/practice/service/PracticeService.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/service/PracticeService.kt
@@ -2,11 +2,13 @@ package com.bandage.v1.domain.practice.service
 
 import com.bandage.v1.domain.practice.dto.req.PracticeCreateRequest
 import com.bandage.v1.domain.practice.dto.req.PracticeMemberAddRequest
+import com.bandage.v1.domain.practice.dto.req.PracticePagingQuery
 import com.bandage.v1.domain.practice.dto.req.PracticeScheduleUpdateRequest
 import com.bandage.v1.domain.practice.dto.req.PracticeSessionCreateRequest
 import com.bandage.v1.domain.practice.dto.req.PracticeSongRefLinkUpsertRequest
 import com.bandage.v1.domain.practice.dto.req.PracticeVenueUpdateRequest
 import com.bandage.v1.domain.practice.dto.res.PracticeDetailResponse
+import com.bandage.v1.domain.practice.dto.res.PracticeListResponse
 import com.bandage.v1.domain.practice.dto.res.PracticeParticipantResponse
 import com.bandage.v1.domain.practice.dto.res.PracticeResponse
 import com.bandage.v1.domain.practice.dto.res.PracticeSessionResponse
@@ -18,6 +20,7 @@ import com.bandage.v1.domain.practice.repository.PracticeParticipantRepository
 import com.bandage.v1.domain.practice.repository.PracticeRepository
 import com.bandage.v1.domain.practice.repository.PracticeSessionRepository
 import com.bandage.v1.domain.practice.repository.PracticeSongRepository
+import com.bandage.v1.global.common.response.CursorResponse
 import com.bandage.v1.global.error.errorcode.ErrorCode
 import com.bandage.v1.global.error.exception.BusinessException
 import org.springframework.data.repository.findByIdOrNull
@@ -50,6 +53,18 @@ class PracticeService(
     }
 
     fun getPracticeDetail(practiceId: UUID): PracticeDetailResponse = PracticeDetailResponse.of(getPractice(practiceId))
+
+    fun getMyPracticesByCursor(
+        memberId: Long,
+        query: PracticePagingQuery,
+    ): CursorResponse<PracticeListResponse, UUID> {
+        val result = practiceRepository.findAllByMemberAndPaging(memberId, query.lastId, query.pageSize)
+        return CursorResponse(
+            content = result.content.map { PracticeListResponse.of(it) },
+            nextCursor = result.nextCursor,
+            hasNext = result.hasNext,
+        )
+    }
 
     @Transactional
     fun createSession(

--- a/src/main/kotlin/com/bandage/v1/global/common/response/ApiResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/global/common/response/ApiResponse.kt
@@ -1,11 +1,15 @@
 package com.bandage.v1.global.common.response
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import java.time.LocalDateTime
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class ApiResponse<T>(
     val success: Boolean,
     val message: String? = null,
+    val code: String? = null,
     val data: T? = null,
+    val fieldErrors: Map<String, String>? = null,
     val timestamp: LocalDateTime = LocalDateTime.now(),
 ) {
     companion object {
@@ -15,10 +19,16 @@ data class ApiResponse<T>(
                 data = data,
             )
 
-        fun error(message: String? = null): ApiResponse<Nothing> =
+        fun error(
+            message: String? = null,
+            code: String? = null,
+            fieldErrors: Map<String, String>? = null,
+        ): ApiResponse<Nothing> =
             ApiResponse(
                 success = false,
                 message = message,
+                code = code,
+                fieldErrors = fieldErrors,
             )
     }
 }

--- a/src/main/kotlin/com/bandage/v1/global/error/handler/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/bandage/v1/global/error/handler/GlobalExceptionHandler.kt
@@ -20,20 +20,31 @@ open class GlobalExceptionHandler {
         val errorCode = e.errorCode
         return ResponseEntity
             .status(errorCode.status)
-            .body(ApiResponse.error(errorCode.message))
+            .body(ApiResponse.error(message = errorCode.message, code = errorCode.name))
     }
 
     @ExceptionHandler(MethodArgumentNotValidException::class)
     protected fun handleMethodArgumentNotValidException(e: MethodArgumentNotValidException): ResponseEntity<ApiResponse<Nothing>> {
-        val message = e.bindingResult.fieldErrors[0].defaultMessage ?: "잘못된 요청입니다."
-        val response = ApiResponse.error(message)
+        val fieldErrors =
+            e.bindingResult.fieldErrors
+                .associate { it.field to (it.defaultMessage ?: "잘못된 입력값입니다.") }
+        val firstMessage = fieldErrors.values.firstOrNull() ?: ErrorCode.INVALID_INPUT_VALUE.message
+        val response =
+            ApiResponse.error(
+                message = firstMessage,
+                code = ErrorCode.INVALID_INPUT_VALUE.name,
+                fieldErrors = fieldErrors.takeIf { it.isNotEmpty() },
+            )
         return ResponseEntity(response, HttpStatus.BAD_REQUEST)
     }
 
     @ExceptionHandler(HttpMessageNotReadableException::class)
     protected fun handleHttpMessageNotReadableException(e: HttpMessageNotReadableException): ResponseEntity<ApiResponse<Nothing>> {
-        val message = e.message
-        val response = ApiResponse.error(message)
+        val response =
+            ApiResponse.error(
+                message = e.message,
+                code = ErrorCode.INVALID_INPUT_VALUE.name,
+            )
         return ResponseEntity(response, HttpStatus.BAD_REQUEST)
     }
 
@@ -42,7 +53,12 @@ open class GlobalExceptionHandler {
         val errorCode = ErrorCode.METHOD_NOT_ALLOWED
         return ResponseEntity
             .status(errorCode.status)
-            .body(ApiResponse.error("${errorCode.message} (요청 메서드: ${e.method})"))
+            .body(
+                ApiResponse.error(
+                    message = "${errorCode.message} (요청 메서드: ${e.method})",
+                    code = errorCode.name,
+                ),
+            )
     }
 
     @ExceptionHandler(NoResourceFoundException::class)
@@ -50,12 +66,13 @@ open class GlobalExceptionHandler {
         val errorCode = ErrorCode.RESOURCE_NOT_FOUND
         return ResponseEntity
             .status(errorCode.status)
-            .body(ApiResponse.error(errorCode.message))
+            .body(ApiResponse.error(message = errorCode.message, code = errorCode.name))
     }
 
     @ExceptionHandler(Exception::class)
     protected fun handleException(e: Exception): ResponseEntity<ApiResponse<Nothing>> {
-        val response = ApiResponse.error(ErrorCode.INTERNAL_SERVER_ERROR.message)
+        val errorCode = ErrorCode.INTERNAL_SERVER_ERROR
+        val response = ApiResponse.error(message = errorCode.message, code = errorCode.name)
         return ResponseEntity(response, HttpStatus.INTERNAL_SERVER_ERROR)
     }
 }

--- a/src/main/kotlin/com/bandage/v1/global/security/handler/JwtAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/com/bandage/v1/global/security/handler/JwtAuthenticationEntryPoint.kt
@@ -23,7 +23,7 @@ class JwtAuthenticationEntryPoint : AuthenticationEntryPoint {
         response.characterEncoding = Charsets.UTF_8.name()
         response.setHeader(HttpHeaders.WWW_AUTHENTICATE, """Bearer error="invalid_token"""")
         response.writer.write(
-            """{"success":false,"message":"${errorCode.message}","data":null,"timestamp":"${LocalDateTime.now()}"}""",
+            """{"success":false,"message":"${errorCode.message}","code":"${errorCode.name}","data":null,"timestamp":"${LocalDateTime.now()}"}""",
         )
     }
 }


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #61

📌 **작업 내용 및 특이사항**

### 신규 API
- 내 합주/밴드/공연 목록 페이징 조회: `GET /practices/me`, `GET /bands/me`, `GET /performances/me`
- 검색 API 3종: `GET /practices/me/search`, `GET /bands/search`, `GET /performances/search` — 키워드 부분 매칭(대소문자 무시)
- 합주 목록 조회: `GET /practices` (bandId 옵셔널 필터)
- 합주곡 API: `GET /practice-songs/search`(mock 응답), `POST /practice-songs`(필드 직접 입력 — 자작곡), `POST /practice-songs/from-song`(외부 Song 객체), `PATCH /practice-songs/{songId}`(부분 수정), `PUT /practice-songs/{songId}`(Song 객체 upsert)
  - 외부 시스템 곡 정보 전송용 `Song` DTO 신규 도입 (DB 엔티티 비관리). 검색 응답을 그대로 from-song / upsert 요청에 재사용 가능

### 프론트 E2E 검증 리포트 대응 (#1~#9)
| # | 항목 | 처리 |
|---|---|---|
| 1 | `BandCreateRequest.profileImg` non-null → optional | DTO `String?`로 변경 |
| 2 | `PerformanceUpdateRequest` 부분 업데이트 불가 | 모든 필드 nullable + 서비스 partial update (`?.let{}` + 기존값 보존) |
| 3 | `GET /api/v1/practices` 미구현 (405) | 신규 엔드포인트 + bandId 옵셔널 필터 |
| 4 | API_SPEC 인증 표기 정정 | 검토 결과 이미 정렬 — `/auth/login`, `/auth/refresh`, `/members/join` 외 모두 "인증 필요" |
| 5 | `CursorResponse.nextCursor` 일관성 | 5개 RepositoryImpl에서 `hasNext=false` 시 `nextCursor=null` |
| 6 | 인증/인가 응답 코드 분리 | `NOT_A_LEADER`/`NOT_A_PERFORMANCE_MANAGER`는 이미 `HttpStatus.FORBIDDEN` 매핑됨 — 검증 완료 |
| 7 | `ApiResponse.code` + `fieldErrors` | `ErrorCode` enum 이름을 `code`로 노출, 유효성 오류는 필드별 메시지 맵 동봉, `JwtAuthenticationEntryPoint`도 동기화 |
| 8 | `PerformanceDetailResponse` 요약 필드 | `bandIds`/`practiceIds` → `bands:[{bandId,bandName}]`/`practices:[{practiceId,title,startAt}]`로 확장 |
| 9 | `BandInfoResponse.myRole` (옵션 9-C) | `MyBandInfoResponse` 신규 — `GET /bands/me` 응답에 `myRole` 필드 포함 (QueryDSL Band+BandMember 조인) |

### API_SPEC.md
- §0 프론트 검증 리포트 대응 현황 표 추가
- 응답 스키마 설명에 `code`/`fieldErrors` 반영
- 변경 엔드포인트(3-1, 3-3-1, 4-1-2, 6-3, 6-4 등) 갱신

📚 **참고사항**

- 검증 리포트 위치: `bandage-fe/.taskmaster/reports/`
- 빌드: `./gradlew build` 통과
- 미해소(프론트 책임): `MemberInfoResponse.memberId` vs 프론트 기대 `id` — 백엔드는 도메인 prefix 컨벤션(`bandId`, `practiceId`, ...) 일관성을 위해 `memberId` 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)