### PR TITLE
Chore/api required followup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,7 @@ out/
 
 ### custom ###
 .env
+.claude
 .DS_Store
+set-env.sh
+API_*.md

--- a/API_SPEC.md
+++ b/API_SPEC.md
@@ -21,9 +21,9 @@ Base URL: `/api/v1`
 
 ---
 
-## 0. 프론트 검증 리포트 대응 현황 (2026-04-25)
+## 0. 프론트 검증 리포트 대응 현황 (2026-04-26)
 
-`bandage-fe/.taskmaster/reports/` 의 5개 검증 리포트에서 제기된 이슈에 대한 처리 현황입니다.
+`bandage-fe/.taskmaster/reports/` 의 5개 검증 리포트 + `API_ISSUE_REPORT.md` (mvp-1-fix-v3 Task 8) 에서 제기된 이슈에 대한 처리 현황입니다.
 
 | # | 이슈 | 출처 | 상태 | 비고 |
 |---|---|---|---|---|
@@ -36,6 +36,10 @@ Base URL: `/api/v1`
 | 7 | `ApiResponse`에 `code` / `fieldErrors` 추가 | Auth §D | ✅ 해소 | 본 문서 상단 응답 스키마 참조. `code`는 `ErrorCode` enum 이름. 유효성 오류 시 `fieldErrors` 맵 동봉 |
 | 8 | `PerformanceDetailResponse` 요약 필드 (밴드명/합주 제목) | Performance §3-D | ✅ 해소 | `bandIds`, `practiceIds` → `bands: [{bandId, bandName}]`, `practices: [{practiceId, title, startAt}]`로 확장 (6-3 참조) |
 | 9 | `GET /bands/me` 응답에 본인 역할 (`myRole`) 포함 | Band §3-D | ✅ 해소 (옵션 9-C) | 응답 항목 타입을 `MyBandInfoResponse`로 변경, `myRole: BandRole` 필드 추가 (3-3-1 참조) |
+| 10 | `PerformanceCreateRequest.bandIds` non-null 차단 (T6) | API_ISSUE_REPORT §4-1 | ✅ 해소 | `bandIds: List<UUID>? = null` 로 변경, 미전달 시 빈 배열로 보정 (6-1 참조) |
+| 11 | Practice ↔ PracticeSong 닭-달걀 (FE-API-020) | API_ISSUE_REPORT §4-2 | ✅ 해소 (§5-2 안 채택) | PracticeSong 생성 API의 `practiceId` 옵셔널화 → FE는 PracticeSong 선행 생성 후 응답 `songId` 를 `/practices` 에 전달 (5-2/5-3/4-1 참조) |
+| 12 | 입력 검증 메시지 정제 (T3, T6) | API_ISSUE_REPORT §4-3 | ✅ 해소 | `HttpMessageNotReadableException` 핸들러가 `KotlinInvalidNullException`/`InvalidFormatException` 을 한국어 메시지 + `fieldErrors` 로 매핑 |
+| 13 | 과거 시각 startAt 검증 (T17) | API_ISSUE_REPORT §4-4 | ✅ 해소 | Practice/Performance 생성·수정·합주 일정 변경 DTO 의 `startAt` 에 `@Future` 적용 (4-1/4-8/6-1/6-4 참조) |
 
 ### 미해소 / 프론트 책임
 
@@ -349,7 +353,8 @@ Base URL: `/api/v1`
   ```
   - `title`: optional
   - `venue`: optional
-  - `startAt` 형식: `yyyy-MM-dd HH:mm` (Asia/Seoul 기준)
+  - `song`: **UUID 만 허용** (PracticeSong ID). 검색 결과의 텍스트/임시 식별자는 받지 않음.
+  - `startAt` 형식: `yyyy-MM-dd HH:mm` (Asia/Seoul 기준). **현재 이후만 허용** (`@Future`); 과거 시각은 400 + `fieldErrors.startAt`.
 - **Response**
   ```json
   {
@@ -357,6 +362,9 @@ Base URL: `/api/v1`
     "practiceTitle": "TuNA 정기공연 1주차 합주"
   }
   ```
+- **합주 시작하기 마법사 호출 시퀀스 (FE-API-020)**: PracticeSong 을 먼저 생성한 후 응답의 `songId` 를 `song` 필드로 전달. Practice 와 PracticeSong 의 1:1 바인딩은 PracticeSong 생성 시점에 `practiceId` 를 함께 전달하거나 (선바인딩), 본 API 의 `song` 으로 후바인딩.
+  1. 외부 검색 결과 사용: `POST /practice-songs/from-song` (practiceId 생략) → `songId` 획득 → `POST /practices` 의 `song` 으로 전달
+  2. 자작곡 입력: `POST /practice-songs` (practiceId 생략) → `songId` 획득 → `POST /practices` 의 `song` 으로 전달
 
 ---
 
@@ -524,7 +532,7 @@ Base URL: `/api/v1`
     "durationMinutes": 90
   }
   ```
-  - `startAt` 형식: `yyyy-MM-dd HH:mm` (Asia/Seoul 기준)
+  - `startAt` 형식: `yyyy-MM-dd HH:mm` (Asia/Seoul 기준). **현재 이후만 허용** (`@Future`).
 
 ---
 
@@ -589,6 +597,7 @@ Base URL: `/api/v1`
     "refLink": null
   }
   ```
+  - `practiceId`: **optional**. 미제공 시 PracticeSong 만 생성하고 Practice 바인딩은 수행하지 않음 (마법사 시나리오에서 응답 `songId` 를 `POST /practices` 의 `song` 으로 전달).
   - `refLink`: optional
 - **Response**: `PracticeSongResponse`
   ```json
@@ -621,8 +630,9 @@ Base URL: `/api/v1`
     }
   }
   ```
+  - `practiceId`: **optional**. 미제공 시 PracticeSong 만 생성 (5-2와 동일 마법사 시나리오 지원).
 - **Response**: `PracticeSongResponse` (5-2와 동일 구조)
-- **비고**: 외부 시스템에서 받아온 Song 객체를 그대로 사용하여 합주곡을 생성. 생성된 합주곡은 `practiceId`의 합주에 1:1 바인딩. `song` 필드는 [5-1](#5-1-합주곡-검색-song) 응답의 항목을 재가공 없이 그대로 사용 가능.
+- **비고**: 외부 시스템에서 받아온 Song 객체를 그대로 사용하여 합주곡을 생성. `practiceId` 가 있으면 해당 합주에 1:1 바인딩, 없으면 응답 `songId` 를 [4-1](#4-1-합주-생성) 의 `song` 으로 전달하여 후바인딩. `song` 필드는 [5-1](#5-1-합주곡-검색-song) 응답의 항목을 재가공 없이 그대로 사용 가능.
 
 ---
 
@@ -698,9 +708,9 @@ Base URL: `/api/v1`
     "venue": "Club FF"
   }
   ```
-  - `bandIds`: optional (기본값 빈 배열)
+  - `bandIds`: optional (미전달/`null`/빈 배열 모두 허용 — 빈 배열로 보정)
   - `venue`: optional
-  - `startAt` 형식: `yyyy-MM-dd HH:mm` (Asia/Seoul 기준)
+  - `startAt` 형식: `yyyy-MM-dd HH:mm` (Asia/Seoul 기준). **현재 이후만 허용** (`@Future`); 과거 시각은 400 + `fieldErrors.startAt`.
 - **Response**
   ```json
   {
@@ -804,6 +814,7 @@ Base URL: `/api/v1`
   }
   ```
   - 모든 필드 optional. 미전달 필드는 기존 값 유지.
+  - `startAt`: 전달 시 **현재 이후만 허용** (`@Future`).
 
 ---
 
@@ -823,6 +834,7 @@ Base URL: `/api/v1`
   ```
   - `title`: optional (미입력 시 곡 제목으로 대체)
   - `venue`: optional
+  - `startAt`: **현재 이후만 허용** (`@Future`).
 - **Response**
   ```json
   {

--- a/src/main/kotlin/com/bandage/v1/domain/band/controller/BandController.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/band/controller/BandController.kt
@@ -141,7 +141,7 @@ class BandController(
         summary = "밴드 멤버 역할 변경 / 리더 위임 API",
         description =
             "리더가 멤버 역할을 변경합니다. body 가 비어 있거나 role=LEADER 면 리더 권한 위임으로 동작하고, " +
-                "role=ADMIN/MEMBER 면 해당 역할로 변경합니다 (FE-API-002 / 8-2).",
+                "role=ADMIN/MEMBER 면 해당 역할로 변경합니다.",
     )
     fun delegateLeader(
         @PathVariable bandId: UUID,
@@ -159,7 +159,7 @@ class BandController(
     }
 
     @PatchMapping("/{bandId}")
-    @Operation(summary = "밴드 정보 수정 API (FE-API-022)", description = "밴드 이름/설명/프로필 이미지 부분 수정. 리더만 가능.")
+    @Operation(summary = "밴드 정보 수정 API", description = "밴드 이름/설명/프로필 이미지 부분 수정. 리더만 가능.")
     fun updateBand(
         @PathVariable bandId: UUID,
         @Valid @RequestBody request: BandUpdateRequest,
@@ -167,7 +167,7 @@ class BandController(
     ): ApiResponse<BandResponse> = ApiResponse.success(bandService.updateBand(bandId, request, memberId))
 
     @DeleteMapping("/{bandId}")
-    @Operation(summary = "밴드 삭제 API (FE-API-023)", description = "밴드를 소프트 삭제합니다. 리더만 가능.")
+    @Operation(summary = "밴드 삭제 API", description = "밴드를 소프트 삭제합니다. 리더만 가능.")
     fun deleteBand(
         @PathVariable bandId: UUID,
         @CurrentMemberId memberId: Long,
@@ -177,7 +177,7 @@ class BandController(
     }
 
     @DeleteMapping("/{bandId}/members/{bandMemberId}")
-    @Operation(summary = "밴드 멤버 강퇴 API (FE-API-002 / 8-2)", description = "리더가 특정 멤버를 강퇴합니다. 리더 자신은 강퇴 불가.")
+    @Operation(summary = "밴드 멤버 강퇴 API", description = "리더가 특정 멤버를 강퇴합니다. 리더 자신은 강퇴 불가.")
     fun kickMember(
         @PathVariable bandId: UUID,
         @PathVariable bandMemberId: UUID,

--- a/src/main/kotlin/com/bandage/v1/domain/band/controller/BandController.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/band/controller/BandController.kt
@@ -2,8 +2,10 @@ package com.bandage.v1.domain.band.controller
 
 import com.bandage.v1.domain.band.dto.req.BandApplicationPagingQuery
 import com.bandage.v1.domain.band.dto.req.BandCreateRequest
+import com.bandage.v1.domain.band.dto.req.BandMemberRoleUpdateRequest
 import com.bandage.v1.domain.band.dto.req.BandPagingQuery
 import com.bandage.v1.domain.band.dto.req.BandSearchQuery
+import com.bandage.v1.domain.band.dto.req.BandUpdateRequest
 import com.bandage.v1.domain.band.dto.res.BandApplicationInfoResponse
 import com.bandage.v1.domain.band.dto.res.BandInfoResponse
 import com.bandage.v1.domain.band.dto.res.BandMemberInfoResponse
@@ -135,13 +137,53 @@ class BandController(
     }
 
     @PatchMapping("/{bandId}/members/{bandMemberId}/role")
-    @Operation(summary = "밴드 리더 권한 위임 API", description = "현재 리더가 지정한 멤버에게 리더 권한을 양도합니다.")
+    @Operation(
+        summary = "밴드 멤버 역할 변경 / 리더 위임 API",
+        description =
+            "리더가 멤버 역할을 변경합니다. body 가 비어 있거나 role=LEADER 면 리더 권한 위임으로 동작하고, " +
+                "role=ADMIN/MEMBER 면 해당 역할로 변경합니다 (FE-API-002 / 8-2).",
+    )
     fun delegateLeader(
         @PathVariable bandId: UUID,
         @PathVariable bandMemberId: UUID,
         @CurrentMemberId memberId: Long,
+        @RequestBody(required = false) request: BandMemberRoleUpdateRequest?,
     ): ApiResponse<Unit> {
-        bandService.changeLeader(bandId, bandMemberId, memberId)
+        val targetRole = request?.role
+        if (targetRole == null || targetRole == com.bandage.v1.domain.band.model.enums.BandRole.LEADER) {
+            bandService.changeLeader(bandId, bandMemberId, memberId)
+        } else {
+            bandService.changeMemberRole(bandId, bandMemberId, memberId, BandMemberRoleUpdateRequest(targetRole))
+        }
+        return ApiResponse.success()
+    }
+
+    @PatchMapping("/{bandId}")
+    @Operation(summary = "밴드 정보 수정 API (FE-API-022)", description = "밴드 이름/설명/프로필 이미지 부분 수정. 리더만 가능.")
+    fun updateBand(
+        @PathVariable bandId: UUID,
+        @Valid @RequestBody request: BandUpdateRequest,
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<BandResponse> = ApiResponse.success(bandService.updateBand(bandId, request, memberId))
+
+    @DeleteMapping("/{bandId}")
+    @Operation(summary = "밴드 삭제 API (FE-API-023)", description = "밴드를 소프트 삭제합니다. 리더만 가능.")
+    fun deleteBand(
+        @PathVariable bandId: UUID,
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<Unit> {
+        bandService.deleteBand(bandId, memberId)
+        return ApiResponse.success()
+    }
+
+    @DeleteMapping("/{bandId}/members/{bandMemberId}")
+    @Operation(summary = "밴드 멤버 강퇴 API (FE-API-002 / 8-2)", description = "리더가 특정 멤버를 강퇴합니다. 리더 자신은 강퇴 불가.")
+    fun kickMember(
+        @PathVariable bandId: UUID,
+        @PathVariable bandMemberId: UUID,
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<Unit> {
+        bandService.kickMember(bandId, bandMemberId, memberId)
         return ApiResponse.success()
     }
 

--- a/src/main/kotlin/com/bandage/v1/domain/band/dto/req/BandMemberRoleUpdateRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/band/dto/req/BandMemberRoleUpdateRequest.kt
@@ -1,0 +1,12 @@
+package com.bandage.v1.domain.band.dto.req
+
+import com.bandage.v1.domain.band.model.enums.BandRole
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
+
+@Schema(description = "밴드 멤버 역할 변경 요청")
+data class BandMemberRoleUpdateRequest(
+    @field:NotNull
+    @Schema(description = "변경할 역할 (ADMIN | MEMBER). LEADER 위임은 별도 API 사용", example = "ADMIN")
+    val role: BandRole,
+)

--- a/src/main/kotlin/com/bandage/v1/domain/band/dto/req/BandUpdateRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/band/dto/req/BandUpdateRequest.kt
@@ -1,0 +1,13 @@
+package com.bandage.v1.domain.band.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "밴드 정보 수정 요청 (부분 수정)")
+data class BandUpdateRequest(
+    @Schema(description = "밴드 이름", example = "TuNA")
+    val name: String? = null,
+    @Schema(description = "밴드 상세 설명", example = "성균관대학교 락밴드입니다.")
+    val description: String? = null,
+    @Schema(description = "프로필 이미지 URL", example = "https://cdn/...jpg")
+    val profileImg: String? = null,
+)

--- a/src/main/kotlin/com/bandage/v1/domain/band/dto/res/BandApplicationInfoResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/band/dto/res/BandApplicationInfoResponse.kt
@@ -14,11 +14,11 @@ data class BandApplicationInfoResponse(
     val memberId: Long,
     @Schema(description = "가입 신청 처리 상태", example = "PENDING")
     val status: ApplicationStatus,
-    @Schema(description = "신청자 이름 (FE-API-013)", example = "홍길동")
+    @Schema(description = "신청자 이름", example = "홍길동")
     val applicantName: String? = null,
     @Schema(description = "신청자 프로필 이미지 URL", example = "https://cdn/...jpg")
     val applicantProfileImg: String? = null,
-    @Schema(description = "신청 일시 (FE-API-013)", example = "2026-04-26T12:34:56")
+    @Schema(description = "신청 일시", example = "2026-04-26T12:34:56")
     val appliedAt: LocalDateTime? = null,
 ) {
     companion object {

--- a/src/main/kotlin/com/bandage/v1/domain/band/dto/res/BandApplicationInfoResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/band/dto/res/BandApplicationInfoResponse.kt
@@ -3,6 +3,7 @@ package com.bandage.v1.domain.band.dto.res
 import com.bandage.v1.domain.band.model.BandApplication
 import com.bandage.v1.domain.band.model.enums.ApplicationStatus
 import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
 import java.util.UUID
 
 @Schema(description = "밴드 가입 신청 단건 조회 응답")
@@ -13,6 +14,12 @@ data class BandApplicationInfoResponse(
     val memberId: Long,
     @Schema(description = "가입 신청 처리 상태", example = "PENDING")
     val status: ApplicationStatus,
+    @Schema(description = "신청자 이름 (FE-API-013)", example = "홍길동")
+    val applicantName: String? = null,
+    @Schema(description = "신청자 프로필 이미지 URL", example = "https://cdn/...jpg")
+    val applicantProfileImg: String? = null,
+    @Schema(description = "신청 일시 (FE-API-013)", example = "2026-04-26T12:34:56")
+    val appliedAt: LocalDateTime? = null,
 ) {
     companion object {
         fun of(application: BandApplication): BandApplicationInfoResponse =
@@ -20,6 +27,21 @@ data class BandApplicationInfoResponse(
                 bandApplicationId = application.id,
                 memberId = application.member,
                 status = application.status,
+                appliedAt = application.createdAt,
+            )
+
+        fun of(
+            application: BandApplication,
+            applicantName: String?,
+            applicantProfileImg: String?,
+        ): BandApplicationInfoResponse =
+            BandApplicationInfoResponse(
+                bandApplicationId = application.id,
+                memberId = application.member,
+                status = application.status,
+                applicantName = applicantName,
+                applicantProfileImg = applicantProfileImg,
+                appliedAt = application.createdAt,
             )
     }
 }

--- a/src/main/kotlin/com/bandage/v1/domain/band/dto/res/BandMemberInfoResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/band/dto/res/BandMemberInfoResponse.kt
@@ -13,7 +13,7 @@ data class BandMemberInfoResponse(
     val memberId: Long,
     @Schema(description = "밴드 멤버 역할", example = "MEMBER")
     val role: BandRole,
-    @Schema(description = "회원 이름 (FE-API-012, 멤버 미존재 시 null)", example = "홍길동")
+    @Schema(description = "회원 이름", example = "홍길동")
     val name: String? = null,
     @Schema(description = "회원 프로필 이미지 URL", example = "https://cdn/...jpg")
     val profileImg: String? = null,

--- a/src/main/kotlin/com/bandage/v1/domain/band/dto/res/BandMemberInfoResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/band/dto/res/BandMemberInfoResponse.kt
@@ -13,6 +13,10 @@ data class BandMemberInfoResponse(
     val memberId: Long,
     @Schema(description = "밴드 멤버 역할", example = "MEMBER")
     val role: BandRole,
+    @Schema(description = "회원 이름 (FE-API-012, 멤버 미존재 시 null)", example = "홍길동")
+    val name: String? = null,
+    @Schema(description = "회원 프로필 이미지 URL", example = "https://cdn/...jpg")
+    val profileImg: String? = null,
 ) {
     companion object {
         fun of(bandMember: BandMember): BandMemberInfoResponse =
@@ -20,6 +24,19 @@ data class BandMemberInfoResponse(
                 bandMemberId = bandMember.id,
                 memberId = bandMember.member,
                 role = bandMember.role,
+            )
+
+        fun of(
+            bandMember: BandMember,
+            memberName: String?,
+            profileImg: String?,
+        ): BandMemberInfoResponse =
+            BandMemberInfoResponse(
+                bandMemberId = bandMember.id,
+                memberId = bandMember.member,
+                role = bandMember.role,
+                name = memberName,
+                profileImg = profileImg,
             )
     }
 }

--- a/src/main/kotlin/com/bandage/v1/domain/band/model/Band.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/band/model/Band.kt
@@ -58,7 +58,19 @@ open class Band(
         this.memberCnt++
     }
 
+    fun decreaseMemberCnt() {
+        if (this.memberCnt > 0) this.memberCnt--
+    }
+
     fun updateImg(newImg: String) {
         this.profileImg = newImg
+    }
+
+    fun updateName(newName: String) {
+        this.name = newName
+    }
+
+    fun updateDescription(newDescription: String?) {
+        this.description = newDescription
     }
 }

--- a/src/main/kotlin/com/bandage/v1/domain/band/model/BandMember.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/band/model/BandMember.kt
@@ -60,4 +60,10 @@ open class BandMember(
         require(this.role == BandRole.LEADER)
         this.role = BandRole.MEMBER
     }
+
+    fun changeRole(newRole: BandRole) {
+        require(this.role != BandRole.LEADER) { "리더의 역할 변경은 위임 API 를 사용해야 합니다." }
+        require(newRole != BandRole.LEADER) { "리더로의 승격은 위임 API 를 사용해야 합니다." }
+        this.role = newRole
+    }
 }

--- a/src/main/kotlin/com/bandage/v1/domain/band/repository/BandMemberRepository.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/band/repository/BandMemberRepository.kt
@@ -56,4 +56,8 @@ interface BandMemberRepository :
     ): Int
 
     fun countByBand(band: Band): Int
+
+    fun findAllByBand(band: Band): List<BandMember>
+
+    fun countByMember(member: Long): Long
 }

--- a/src/main/kotlin/com/bandage/v1/domain/band/service/BandService.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/band/service/BandService.kt
@@ -2,8 +2,10 @@ package com.bandage.v1.domain.band.service
 
 import com.bandage.v1.domain.band.dto.req.BandApplicationPagingQuery
 import com.bandage.v1.domain.band.dto.req.BandCreateRequest
+import com.bandage.v1.domain.band.dto.req.BandMemberRoleUpdateRequest
 import com.bandage.v1.domain.band.dto.req.BandPagingQuery
 import com.bandage.v1.domain.band.dto.req.BandSearchQuery
+import com.bandage.v1.domain.band.dto.req.BandUpdateRequest
 import com.bandage.v1.domain.band.dto.res.BandApplicationInfoResponse
 import com.bandage.v1.domain.band.dto.res.BandInfoResponse
 import com.bandage.v1.domain.band.dto.res.BandMemberInfoResponse
@@ -17,6 +19,7 @@ import com.bandage.v1.domain.band.model.enums.BandRole
 import com.bandage.v1.domain.band.repository.BandApplicationRepository
 import com.bandage.v1.domain.band.repository.BandMemberRepository
 import com.bandage.v1.domain.band.repository.BandRepository
+import com.bandage.v1.domain.member.repository.MemberRepository
 import com.bandage.v1.global.common.response.CursorResponse
 import com.bandage.v1.global.error.errorcode.ErrorCode
 import com.bandage.v1.global.error.exception.BusinessException
@@ -31,6 +34,7 @@ class BandService(
     private val bandRepository: BandRepository,
     private val applicationRepository: BandApplicationRepository,
     private val bandMemberRepository: BandMemberRepository,
+    private val memberRepository: MemberRepository,
 ) {
     // TODO: profileImg multi-part 처리 구현
     @Transactional
@@ -105,10 +109,11 @@ class BandService(
         )
     }
 
-    fun getOnlyOneBandMember(bandMemberId: UUID): BandMemberInfoResponse =
-        BandMemberInfoResponse.of(
-            getBandMemberById(bandMemberId),
-        )
+    fun getOnlyOneBandMember(bandMemberId: UUID): BandMemberInfoResponse {
+        val bm = getBandMemberById(bandMemberId)
+        val member = memberRepository.findById(bm.member).orElse(null)
+        return BandMemberInfoResponse.of(bm, member?.name, null)
+    }
 
     fun getBandMembersByCursor(
         query: BandPagingQuery,
@@ -116,8 +121,9 @@ class BandService(
     ): CursorResponse<BandMemberInfoResponse, UUID> {
         val band = getBand(bandId)
         val result = bandMemberRepository.findAllByPaging(query.lastId, query.pageSize, band)
+        val nameMap = memberNameMap(result.content.map { it.member })
         return CursorResponse(
-            content = result.content.map { BandMemberInfoResponse.of(it) },
+            content = result.content.map { BandMemberInfoResponse.of(it, nameMap[it.member], null) },
             nextCursor = result.nextCursor,
             hasNext = result.hasNext,
         )
@@ -131,12 +137,20 @@ class BandService(
         val band = getBand(bandId)
         validateMemberIsBandLeader(band, memberId)
         val result = applicationRepository.findAllByPaging(query.lastId, query.pageSize, query.status, band)
+        val nameMap = memberNameMap(result.content.map { it.member })
         return CursorResponse(
-            content = result.content.map { BandApplicationInfoResponse.of(it) },
+            content = result.content.map { BandApplicationInfoResponse.of(it, nameMap[it.member], null) },
             nextCursor = result.nextCursor,
             hasNext = result.hasNext,
         )
     }
+
+    private fun memberNameMap(memberIds: List<Long>): Map<Long, String> =
+        if (memberIds.isEmpty()) {
+            emptyMap()
+        } else {
+            memberRepository.findAllById(memberIds.distinct()).associate { it.id to it.name }
+        }
 
     @Transactional
     fun withdrawBandApplication(
@@ -184,6 +198,79 @@ class BandService(
             to = newLeader,
         )
         validateOnlyOneLeader(band)
+    }
+
+    @Transactional
+    fun updateBand(
+        bandId: UUID,
+        request: BandUpdateRequest,
+        memberId: Long,
+    ): BandResponse {
+        val band = getBand(bandId)
+        validateMemberIsBandLeader(band, memberId)
+        var changed = false
+        request.name
+            ?.takeIf { it.isNotBlank() && it != band.name }
+            ?.let {
+                if (bandRepository.existsByName(it)) throw BusinessException(ErrorCode.DUPLICATE_BAND_NAME)
+                band.updateName(it)
+                changed = true
+            }
+        request.description
+            ?.takeIf { it != band.description }
+            ?.let {
+                band.updateDescription(it)
+                changed = true
+            }
+        request.profileImg
+            ?.takeIf { it != band.profileImg }
+            ?.let {
+                band.updateImg(it)
+                changed = true
+            }
+        if (!changed) throw BusinessException(ErrorCode.NO_CHANGE)
+        return BandResponse.of(band)
+    }
+
+    @Transactional
+    fun deleteBand(
+        bandId: UUID,
+        memberId: Long,
+    ) {
+        val band = getBand(bandId)
+        validateMemberIsBandLeader(band, memberId)
+        bandMemberRepository.findAllByBand(band).forEach { it.markAsDeleted(memberId) }
+        band.markAsDeleted(memberId)
+    }
+
+    @Transactional
+    fun kickMember(
+        bandId: UUID,
+        bandMemberId: UUID,
+        leaderMemberId: Long,
+    ) {
+        val band = getBand(bandId)
+        validateMemberIsBandLeader(band, leaderMemberId)
+        val target = getBandMemberById(bandMemberId)
+        if (target.band.id != band.id) throw BusinessException(ErrorCode.BAND_MEMBER_NOT_FOUND)
+        if (target.role == BandRole.LEADER) throw BusinessException(ErrorCode.LEADER_CANNOT_LEAVE)
+        target.markAsDeleted(leaderMemberId)
+        band.decreaseMemberCnt()
+    }
+
+    @Transactional
+    fun changeMemberRole(
+        bandId: UUID,
+        bandMemberId: UUID,
+        leaderMemberId: Long,
+        request: BandMemberRoleUpdateRequest,
+    ) {
+        val band = getBand(bandId)
+        validateMemberIsBandLeader(band, leaderMemberId)
+        val target = getBandMemberById(bandMemberId)
+        if (target.band.id != band.id) throw BusinessException(ErrorCode.BAND_MEMBER_NOT_FOUND)
+        if (target.role == request.role) throw BusinessException(ErrorCode.NO_CHANGE)
+        target.changeRole(request.role)
     }
 
     @Transactional

--- a/src/main/kotlin/com/bandage/v1/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/member/controller/MemberController.kt
@@ -2,10 +2,11 @@ package com.bandage.v1.domain.member.controller
 
 import com.bandage.v1.domain.member.dto.req.MemberInfoUpdateRequest
 import com.bandage.v1.domain.member.dto.res.MemberInfoResponse
+import com.bandage.v1.domain.member.dto.res.MemberMetricsResponse
 import com.bandage.v1.domain.member.dto.res.MemberSearchItemResponse
-import com.bandage.v1.domain.member.dto.res.MemberStatsResponse
 import com.bandage.v1.domain.member.service.MemberService
 import com.bandage.v1.facade.MemberJoinFacade
+import com.bandage.v1.facade.MemberMetricsFacade
 import com.bandage.v1.facade.MemberWithdrawFacade
 import com.bandage.v1.facade.dto.MemberJoinRequest
 import com.bandage.v1.facade.dto.MemberResponse
@@ -34,6 +35,7 @@ class MemberController(
     private val memberService: MemberService,
     private val memberJoinFacade: MemberJoinFacade,
     private val memberWithdrawFacade: MemberWithdrawFacade,
+    private val memberMetricsFacade: MemberMetricsFacade,
 ) {
     @PostMapping("/join")
     @Operation(summary = "회원 가입 API", description = "신규 회원을 생성합니다.")
@@ -63,15 +65,15 @@ class MemberController(
         return ApiResponse.success()
     }
 
-    @GetMapping("/me/stats")
-    @Operation(summary = "회원 통계 조회 API (FE-API-014)", description = "본인의 밴드 수, 다가오는 합주/공연 수, 합주 세션 수를 조회합니다.")
+    @GetMapping("/me/metrics")
+    @Operation(summary = "회원 메트릭 조회 API", description = "본인의 밴드 수, 다가오는 합주/공연 수, 합주 세션 수를 조회합니다.")
     fun getMemberStats(
         @CurrentMemberId memberId: Long,
-    ): ApiResponse<MemberStatsResponse> = ApiResponse.success(memberService.getMemberStats(memberId))
+    ): ApiResponse<MemberMetricsResponse> = ApiResponse.success(memberMetricsFacade.getMemberMetrics(memberId))
 
     @GetMapping("/search")
     @Operation(
-        summary = "회원 검색 API (FE-API-032)",
+        summary = "회원 검색 API",
         description = "이름/이메일 부분 일치 검색. 최대 20건. 본인은 결과에서 제외.",
     )
     fun searchMembers(

--- a/src/main/kotlin/com/bandage/v1/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/member/controller/MemberController.kt
@@ -2,6 +2,8 @@ package com.bandage.v1.domain.member.controller
 
 import com.bandage.v1.domain.member.dto.req.MemberInfoUpdateRequest
 import com.bandage.v1.domain.member.dto.res.MemberInfoResponse
+import com.bandage.v1.domain.member.dto.res.MemberSearchItemResponse
+import com.bandage.v1.domain.member.dto.res.MemberStatsResponse
 import com.bandage.v1.domain.member.service.MemberService
 import com.bandage.v1.facade.MemberJoinFacade
 import com.bandage.v1.facade.MemberWithdrawFacade
@@ -22,6 +24,7 @@ import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @Tag(name = "members", description = "회원 API")
@@ -59,6 +62,22 @@ class MemberController(
         memberService.updateMemberInfo(request, memberId)
         return ApiResponse.success()
     }
+
+    @GetMapping("/me/stats")
+    @Operation(summary = "회원 통계 조회 API (FE-API-014)", description = "본인의 밴드 수, 다가오는 합주/공연 수, 합주 세션 수를 조회합니다.")
+    fun getMemberStats(
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<MemberStatsResponse> = ApiResponse.success(memberService.getMemberStats(memberId))
+
+    @GetMapping("/search")
+    @Operation(
+        summary = "회원 검색 API (FE-API-032)",
+        description = "이름/이메일 부분 일치 검색. 최대 20건. 본인은 결과에서 제외.",
+    )
+    fun searchMembers(
+        @RequestParam(name = "q", required = false, defaultValue = "") q: String,
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<List<MemberSearchItemResponse>> = ApiResponse.success(memberService.searchMembers(q, memberId))
 
     @DeleteMapping("/me")
     @Operation(summary = "회원 탈퇴 API", description = "회원 정보를 삭제하고 로그아웃 처리합니다.")

--- a/src/main/kotlin/com/bandage/v1/domain/member/dto/res/MemberInfoResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/member/dto/res/MemberInfoResponse.kt
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "회원 정보 조회 응답")
 data class MemberInfoResponse(
+    @Schema(description = "회원 고유 식별자 (Long) — 프론트 호환용 alias", example = "1")
+    val id: Long,
     @Schema(description = "회원 고유 식별자 (Long)", example = "1")
     val memberId: Long,
     @Schema(description = "회원 이메일", example = "member@google.com")
@@ -13,14 +15,18 @@ data class MemberInfoResponse(
     val name: String,
     @Schema(description = "회원 연락처", example = "010-7707-5859")
     val contact: String,
+    @Schema(description = "프로필 이미지 URL (없으면 null)", example = "https://cdn/...jpg")
+    val profileImg: String? = null,
 ) {
     companion object {
         fun of(member: Member): MemberInfoResponse =
             MemberInfoResponse(
+                id = member.id,
                 memberId = member.id,
                 email = member.email,
                 name = member.name,
                 contact = member.contact,
+                profileImg = null,
             )
     }
 }

--- a/src/main/kotlin/com/bandage/v1/domain/member/dto/res/MemberMetricsResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/member/dto/res/MemberMetricsResponse.kt
@@ -2,8 +2,8 @@ package com.bandage.v1.domain.member.dto.res
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "회원 통계 응답 (FE-API-014)")
-data class MemberStatsResponse(
+@Schema(description = "회원 메트릭 응답")
+data class MemberMetricsResponse(
     @Schema(description = "본인이 소속된 밴드 수", example = "3")
     val bandCount: Long,
     @Schema(description = "본인이 참여한 다가오는 합주 수 (startAt > now)", example = "2")

--- a/src/main/kotlin/com/bandage/v1/domain/member/dto/res/MemberSearchItemResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/member/dto/res/MemberSearchItemResponse.kt
@@ -1,0 +1,26 @@
+package com.bandage.v1.domain.member.dto.res
+
+import com.bandage.v1.domain.member.model.Member
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "회원 검색 결과 아이템 (FE-API-032)")
+data class MemberSearchItemResponse(
+    @Schema(description = "회원 고유 식별자 (Long)", example = "1")
+    val memberId: Long,
+    @Schema(description = "회원 이름", example = "홍길동")
+    val name: String,
+    @Schema(description = "회원 이메일", example = "user@bandage.test")
+    val email: String,
+    @Schema(description = "프로필 이미지 URL", example = "https://cdn/...jpg")
+    val profileImg: String? = null,
+) {
+    companion object {
+        fun of(member: Member): MemberSearchItemResponse =
+            MemberSearchItemResponse(
+                memberId = member.id,
+                name = member.name,
+                email = member.email,
+                profileImg = null,
+            )
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/member/dto/res/MemberSearchItemResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/member/dto/res/MemberSearchItemResponse.kt
@@ -3,7 +3,7 @@ package com.bandage.v1.domain.member.dto.res
 import com.bandage.v1.domain.member.model.Member
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "회원 검색 결과 아이템 (FE-API-032)")
+@Schema(description = "회원 검색 결과 아이템")
 data class MemberSearchItemResponse(
     @Schema(description = "회원 고유 식별자 (Long)", example = "1")
     val memberId: Long,

--- a/src/main/kotlin/com/bandage/v1/domain/member/dto/res/MemberStatsResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/member/dto/res/MemberStatsResponse.kt
@@ -1,0 +1,15 @@
+package com.bandage.v1.domain.member.dto.res
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "회원 통계 응답 (FE-API-014)")
+data class MemberStatsResponse(
+    @Schema(description = "본인이 소속된 밴드 수", example = "3")
+    val bandCount: Long,
+    @Schema(description = "본인이 참여한 다가오는 합주 수 (startAt > now)", example = "2")
+    val upcomingPracticeCount: Long,
+    @Schema(description = "본인 밴드의 다가오는 공연 수 (startAt > now)", example = "1")
+    val upcomingPerformanceCount: Long,
+    @Schema(description = "본인이 참여 중인 합주 세션 수", example = "5")
+    val sessionCount: Long,
+)

--- a/src/main/kotlin/com/bandage/v1/domain/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/member/repository/MemberRepository.kt
@@ -7,4 +7,9 @@ import org.springframework.stereotype.Repository
 @Repository
 interface MemberRepository : JpaRepository<Member, Long> {
     fun existsByEmail(email: String): Boolean
+
+    fun findTop20ByNameContainingIgnoreCaseOrEmailContainingIgnoreCase(
+        name: String,
+        email: String,
+    ): List<Member>
 }

--- a/src/main/kotlin/com/bandage/v1/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/member/service/MemberService.kt
@@ -1,20 +1,29 @@
 package com.bandage.v1.domain.member.service
 
+import com.bandage.v1.domain.band.repository.BandMemberRepository
 import com.bandage.v1.domain.member.dto.req.MemberCreateRequest
 import com.bandage.v1.domain.member.dto.req.MemberInfoUpdateRequest
 import com.bandage.v1.domain.member.dto.res.MemberInfoResponse
+import com.bandage.v1.domain.member.dto.res.MemberSearchItemResponse
+import com.bandage.v1.domain.member.dto.res.MemberStatsResponse
 import com.bandage.v1.domain.member.model.Member
 import com.bandage.v1.domain.member.repository.MemberRepository
+import com.bandage.v1.domain.performance.repository.PerformanceRepository
+import com.bandage.v1.domain.practice.repository.PracticeParticipantRepository
 import com.bandage.v1.global.error.errorcode.ErrorCode
 import com.bandage.v1.global.error.exception.BusinessException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 @Service
 @Transactional(readOnly = true)
 class MemberService(
     private val memberRepository: MemberRepository,
+    private val bandMemberRepository: BandMemberRepository,
+    private val practiceParticipantRepository: PracticeParticipantRepository,
+    private val performanceRepository: PerformanceRepository,
 ) {
     @Transactional
     fun createMember(request: MemberCreateRequest): Member {
@@ -66,6 +75,31 @@ class MemberService(
         if (!isChanged) {
             throw BusinessException(ErrorCode.NO_CHANGE)
         }
+    }
+
+    fun getMemberStats(memberId: Long): MemberStatsResponse {
+        val now = LocalDateTime.now()
+        val bandIds = bandMemberRepository.findAllBandIdsByMember(memberId)
+        val upcomingPerformanceCount =
+            if (bandIds.isEmpty()) 0L else performanceRepository.countUpcomingByBandIds(bandIds, now)
+        return MemberStatsResponse(
+            bandCount = bandMemberRepository.countByMember(memberId),
+            upcomingPracticeCount = practiceParticipantRepository.countUpcomingPracticesByMember(memberId, now),
+            upcomingPerformanceCount = upcomingPerformanceCount,
+            sessionCount = practiceParticipantRepository.countSessionsByMember(memberId),
+        )
+    }
+
+    fun searchMembers(
+        keyword: String,
+        excludeMemberId: Long?,
+    ): List<MemberSearchItemResponse> {
+        val q = keyword.trim()
+        if (q.isEmpty()) return emptyList()
+        return memberRepository
+            .findTop20ByNameContainingIgnoreCaseOrEmailContainingIgnoreCase(q, q)
+            .filter { excludeMemberId == null || it.id != excludeMemberId }
+            .map(MemberSearchItemResponse::of)
     }
 
     private fun isMemberAlreadyExists(request: MemberCreateRequest) {

--- a/src/main/kotlin/com/bandage/v1/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/member/service/MemberService.kt
@@ -5,7 +5,6 @@ import com.bandage.v1.domain.member.dto.req.MemberCreateRequest
 import com.bandage.v1.domain.member.dto.req.MemberInfoUpdateRequest
 import com.bandage.v1.domain.member.dto.res.MemberInfoResponse
 import com.bandage.v1.domain.member.dto.res.MemberSearchItemResponse
-import com.bandage.v1.domain.member.dto.res.MemberStatsResponse
 import com.bandage.v1.domain.member.model.Member
 import com.bandage.v1.domain.member.repository.MemberRepository
 import com.bandage.v1.domain.performance.repository.PerformanceRepository
@@ -15,7 +14,6 @@ import com.bandage.v1.global.error.exception.BusinessException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDateTime
 
 @Service
 @Transactional(readOnly = true)
@@ -75,19 +73,6 @@ class MemberService(
         if (!isChanged) {
             throw BusinessException(ErrorCode.NO_CHANGE)
         }
-    }
-
-    fun getMemberStats(memberId: Long): MemberStatsResponse {
-        val now = LocalDateTime.now()
-        val bandIds = bandMemberRepository.findAllBandIdsByMember(memberId)
-        val upcomingPerformanceCount =
-            if (bandIds.isEmpty()) 0L else performanceRepository.countUpcomingByBandIds(bandIds, now)
-        return MemberStatsResponse(
-            bandCount = bandMemberRepository.countByMember(memberId),
-            upcomingPracticeCount = practiceParticipantRepository.countUpcomingPracticesByMember(memberId, now),
-            upcomingPerformanceCount = upcomingPerformanceCount,
-            sessionCount = practiceParticipantRepository.countSessionsByMember(memberId),
-        )
     }
 
     fun searchMembers(

--- a/src/main/kotlin/com/bandage/v1/domain/performance/controller/PerformanceController.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/controller/PerformanceController.kt
@@ -91,7 +91,7 @@ class PerformanceController(
     }
 
     @PostMapping("/{performanceId}/practices")
-    @Operation(summary = "공연 합주곡 추가 API (신규 생성)", description = "빈 합주를 즉시 생성하여 공연에 추가합니다. PerformanceManager만 수행할 수 있습니다.")
+    @Operation(summary = "공연 합주곡 추가 API", description = "빈 합주를 즉시 생성하여 공연에 추가합니다. PerformanceManager만 수행할 수 있습니다.")
     fun addNewPractice(
         @PathVariable performanceId: UUID,
         @Valid @RequestBody request: PerformancePracticeCreateRequest,
@@ -120,7 +120,7 @@ class PerformanceController(
 
     @PostMapping("/{performanceId}/bands/batch")
     @Operation(
-        summary = "공연 참여 밴드 일괄 추가 API (FE-API-017)",
+        summary = "공연 참여 밴드 일괄 추가 API",
         description = "공연에 참여 밴드를 append 시맨틱으로 다중 추가합니다. PerformanceManager만 가능. 이미 등록된 밴드는 응답에서 제외.",
     )
     fun addBands(
@@ -130,7 +130,7 @@ class PerformanceController(
     ): ApiResponse<List<PerformanceBandResponse>> = ApiResponse.success(performanceService.addBands(performanceId, request, memberId))
 
     @DeleteMapping("/{performanceId}/bands/{bandId}")
-    @Operation(summary = "공연 참여 밴드 단건 제거 API (FE-API-017)", description = "공연에서 특정 참여 밴드를 제거합니다. PerformanceManager만 가능.")
+    @Operation(summary = "공연 참여 밴드 단건 제거 API", description = "공연에서 특정 참여 밴드를 제거합니다. PerformanceManager만 가능.")
     fun removeBand(
         @PathVariable performanceId: UUID,
         @PathVariable bandId: UUID,

--- a/src/main/kotlin/com/bandage/v1/domain/performance/controller/PerformanceController.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/controller/PerformanceController.kt
@@ -1,11 +1,13 @@
 package com.bandage.v1.domain.performance.controller
 
+import com.bandage.v1.domain.performance.dto.req.PerformanceBandAddRequest
 import com.bandage.v1.domain.performance.dto.req.PerformanceCreateRequest
 import com.bandage.v1.domain.performance.dto.req.PerformancePagingQuery
 import com.bandage.v1.domain.performance.dto.req.PerformancePracticeAddRequest
 import com.bandage.v1.domain.performance.dto.req.PerformancePracticeCreateRequest
 import com.bandage.v1.domain.performance.dto.req.PerformanceSearchQuery
 import com.bandage.v1.domain.performance.dto.req.PerformanceUpdateRequest
+import com.bandage.v1.domain.performance.dto.res.PerformanceBandResponse
 import com.bandage.v1.domain.performance.dto.res.PerformanceDetailResponse
 import com.bandage.v1.domain.performance.dto.res.PerformanceListResponse
 import com.bandage.v1.domain.performance.dto.res.PerformancePracticeResponse
@@ -113,6 +115,28 @@ class PerformanceController(
         @CurrentMemberId memberId: Long,
     ): ApiResponse<Unit> {
         performanceService.removePractice(performanceId, practiceId, memberId)
+        return ApiResponse.success()
+    }
+
+    @PostMapping("/{performanceId}/bands/batch")
+    @Operation(
+        summary = "공연 참여 밴드 일괄 추가 API (FE-API-017)",
+        description = "공연에 참여 밴드를 append 시맨틱으로 다중 추가합니다. PerformanceManager만 가능. 이미 등록된 밴드는 응답에서 제외.",
+    )
+    fun addBands(
+        @PathVariable performanceId: UUID,
+        @Valid @RequestBody request: PerformanceBandAddRequest,
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<List<PerformanceBandResponse>> = ApiResponse.success(performanceService.addBands(performanceId, request, memberId))
+
+    @DeleteMapping("/{performanceId}/bands/{bandId}")
+    @Operation(summary = "공연 참여 밴드 단건 제거 API (FE-API-017)", description = "공연에서 특정 참여 밴드를 제거합니다. PerformanceManager만 가능.")
+    fun removeBand(
+        @PathVariable performanceId: UUID,
+        @PathVariable bandId: UUID,
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<Unit> {
+        performanceService.removeBand(performanceId, bandId, memberId)
         return ApiResponse.success()
     }
 

--- a/src/main/kotlin/com/bandage/v1/domain/performance/dto/req/PerformanceBandAddRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/dto/req/PerformanceBandAddRequest.kt
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotEmpty
 import java.util.UUID
 
-@Schema(description = "공연 참여 밴드 일괄 추가 요청 (FE-API-017)")
+@Schema(description = "공연 참여 밴드 일괄 추가 요청")
 data class PerformanceBandAddRequest(
     @field:NotEmpty
     @Schema(description = "추가할 밴드 ID 목록 (append 시맨틱)", example = "[\"550e8400-e29b-41d4-a716-446655440000\"]")

--- a/src/main/kotlin/com/bandage/v1/domain/performance/dto/req/PerformanceBandAddRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/dto/req/PerformanceBandAddRequest.kt
@@ -1,0 +1,12 @@
+package com.bandage.v1.domain.performance.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotEmpty
+import java.util.UUID
+
+@Schema(description = "공연 참여 밴드 일괄 추가 요청 (FE-API-017)")
+data class PerformanceBandAddRequest(
+    @field:NotEmpty
+    @Schema(description = "추가할 밴드 ID 목록 (append 시맨틱)", example = "[\"550e8400-e29b-41d4-a716-446655440000\"]")
+    val bandIds: List<UUID>,
+)

--- a/src/main/kotlin/com/bandage/v1/domain/performance/dto/req/PerformanceCreateRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/dto/req/PerformanceCreateRequest.kt
@@ -2,6 +2,7 @@ package com.bandage.v1.domain.performance.dto.req
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Future
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
 import java.time.LocalDateTime
@@ -12,10 +13,11 @@ data class PerformanceCreateRequest(
     @NotBlank
     @Schema(description = "공연 제목", example = "TuNA 정기공연")
     val title: String,
-    @Schema(description = "참여 밴드 아이디 목록", example = "[\"550e8400-e29b-41d4-a716-446655440000\"]")
-    val bandIds: List<UUID> = emptyList(),
+    @Schema(description = "참여 밴드 아이디 목록 (optional, 미전달/null 시 빈 배열로 처리)", example = "[\"550e8400-e29b-41d4-a716-446655440000\"]")
+    val bandIds: List<UUID>? = null,
+    @field:Future(message = "공연 시작 시간은 현재 이후여야 합니다.")
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm", shape = JsonFormat.Shape.STRING, timezone = "Asia/Seoul")
-    @Schema(description = "공연 시작 시간", example = "2026-06-15 18:00")
+    @Schema(description = "공연 시작 시간 (현재 이후만 허용)", example = "2026-06-15 18:00")
     val startAt: LocalDateTime,
     @field:Min(1)
     @Schema(description = "공연 시간 (분)", example = "120")

--- a/src/main/kotlin/com/bandage/v1/domain/performance/dto/req/PerformancePracticeCreateRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/dto/req/PerformancePracticeCreateRequest.kt
@@ -2,6 +2,7 @@ package com.bandage.v1.domain.performance.dto.req
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Future
 import jakarta.validation.constraints.Min
 import java.time.LocalDateTime
 import java.util.UUID
@@ -12,8 +13,9 @@ data class PerformancePracticeCreateRequest(
     val title: String?,
     @Schema(description = "합주곡 아이디", example = "550e8400-e29b-41d4-a716-446655440000")
     val songId: UUID,
+    @field:Future(message = "합주 시작 시간은 현재 이후여야 합니다.")
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm", shape = JsonFormat.Shape.STRING, timezone = "Asia/Seoul")
-    @Schema(description = "합주 시작 시간", example = "2026-06-01 18:00")
+    @Schema(description = "합주 시작 시간 (현재 이후만 허용)", example = "2026-06-01 18:00")
     val startAt: LocalDateTime,
     @field:Min(1)
     @Schema(description = "합주 시간 (분)", example = "60")

--- a/src/main/kotlin/com/bandage/v1/domain/performance/dto/req/PerformanceUpdateRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/dto/req/PerformanceUpdateRequest.kt
@@ -2,6 +2,7 @@ package com.bandage.v1.domain.performance.dto.req
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Future
 import jakarta.validation.constraints.Min
 import java.time.LocalDateTime
 
@@ -9,8 +10,9 @@ import java.time.LocalDateTime
 data class PerformanceUpdateRequest(
     @Schema(description = "공연 제목", example = "TuNA 정기공연 (수정)")
     val title: String? = null,
+    @field:Future(message = "공연 시작 시간은 현재 이후여야 합니다.")
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm", shape = JsonFormat.Shape.STRING, timezone = "Asia/Seoul")
-    @Schema(description = "공연 시작 시간", example = "2026-06-15 19:00")
+    @Schema(description = "공연 시작 시간 (현재 이후만 허용)", example = "2026-06-15 19:00")
     val startAt: LocalDateTime? = null,
     @field:Min(1)
     @Schema(description = "공연 시간 (분)", example = "90")

--- a/src/main/kotlin/com/bandage/v1/domain/performance/dto/res/PerformanceBandResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/dto/res/PerformanceBandResponse.kt
@@ -4,7 +4,7 @@ import com.bandage.v1.domain.performance.model.PerformanceBand
 import io.swagger.v3.oas.annotations.media.Schema
 import java.util.UUID
 
-@Schema(description = "공연 참여 밴드 매핑 응답 (FE-API-017)")
+@Schema(description = "공연 참여 밴드 매핑 응답")
 data class PerformanceBandResponse(
     @Schema(description = "PerformanceBand 매핑 ID", example = "550e8400-e29b-41d4-a716-446655440000")
     val performanceBandId: UUID,

--- a/src/main/kotlin/com/bandage/v1/domain/performance/dto/res/PerformanceBandResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/dto/res/PerformanceBandResponse.kt
@@ -1,0 +1,21 @@
+package com.bandage.v1.domain.performance.dto.res
+
+import com.bandage.v1.domain.performance.model.PerformanceBand
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.UUID
+
+@Schema(description = "공연 참여 밴드 매핑 응답 (FE-API-017)")
+data class PerformanceBandResponse(
+    @Schema(description = "PerformanceBand 매핑 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+    val performanceBandId: UUID,
+    @Schema(description = "Band ID", example = "550e8400-e29b-41d4-a716-446655440000")
+    val bandId: UUID,
+) {
+    companion object {
+        fun of(pb: PerformanceBand): PerformanceBandResponse =
+            PerformanceBandResponse(
+                performanceBandId = pb.id,
+                bandId = pb.bandId,
+            )
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/performance/repository/PerformanceBandRepository.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/repository/PerformanceBandRepository.kt
@@ -1,9 +1,20 @@
 package com.bandage.v1.domain.performance.repository
 
+import com.bandage.v1.domain.performance.model.Performance
 import com.bandage.v1.domain.performance.model.PerformanceBand
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import java.util.UUID
 
 @Repository
-interface PerformanceBandRepository : JpaRepository<PerformanceBand, UUID>
+interface PerformanceBandRepository : JpaRepository<PerformanceBand, UUID> {
+    fun existsByPerformanceAndBandId(
+        performance: Performance,
+        bandId: UUID,
+    ): Boolean
+
+    fun findByPerformanceAndBandId(
+        performance: Performance,
+        bandId: UUID,
+    ): PerformanceBand?
+}

--- a/src/main/kotlin/com/bandage/v1/domain/performance/repository/PerformanceRepository.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/repository/PerformanceRepository.kt
@@ -2,10 +2,23 @@ package com.bandage.v1.domain.performance.repository
 
 import com.bandage.v1.domain.performance.model.Performance
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 import java.util.UUID
 
 @Repository
 interface PerformanceRepository :
     JpaRepository<Performance, UUID>,
-    PerformanceRepositoryCustom
+    PerformanceRepositoryCustom {
+    @Query(
+        "SELECT COUNT(DISTINCT pb.performance.id) FROM PerformanceBand pb " +
+            "WHERE pb.bandId IN :bandIds AND pb.performance.schedule.startAt > :now " +
+            "AND pb.performance.deletedAt IS NULL",
+    )
+    fun countUpcomingByBandIds(
+        @Param("bandIds") bandIds: Collection<UUID>,
+        @Param("now") now: LocalDateTime,
+    ): Long
+}

--- a/src/main/kotlin/com/bandage/v1/domain/performance/service/PerformanceService.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/service/PerformanceService.kt
@@ -2,11 +2,13 @@ package com.bandage.v1.domain.performance.service
 
 import com.bandage.v1.domain.band.repository.BandMemberRepository
 import com.bandage.v1.domain.band.repository.BandRepository
+import com.bandage.v1.domain.performance.dto.req.PerformanceBandAddRequest
 import com.bandage.v1.domain.performance.dto.req.PerformanceCreateRequest
 import com.bandage.v1.domain.performance.dto.req.PerformancePagingQuery
 import com.bandage.v1.domain.performance.dto.req.PerformancePracticeAddRequest
 import com.bandage.v1.domain.performance.dto.req.PerformanceSearchQuery
 import com.bandage.v1.domain.performance.dto.req.PerformanceUpdateRequest
+import com.bandage.v1.domain.performance.dto.res.PerformanceBandResponse
 import com.bandage.v1.domain.performance.dto.res.PerformanceDetailResponse
 import com.bandage.v1.domain.performance.dto.res.PerformanceListResponse
 import com.bandage.v1.domain.performance.dto.res.PerformancePracticeResponse
@@ -54,7 +56,7 @@ class PerformanceService(
                     venue = request.venue,
                 ),
             )
-        request.bandIds.forEach { bandId ->
+        (request.bandIds ?: emptyList()).forEach { bandId ->
             performanceBandRepository.save(PerformanceBand.create(performance = performance, bandId = bandId))
         }
         performanceManagerRepository.save(PerformanceManager.create(performance = performance, member = memberId))
@@ -162,6 +164,36 @@ class PerformanceService(
             performancePracticeRepository.findByPerformanceAndPracticeId(performance, practiceId)
                 ?: throw BusinessException(ErrorCode.PERFORMANCE_PRACTICE_NOT_FOUND)
         performancePracticeRepository.delete(performancePractice)
+    }
+
+    @Transactional
+    fun addBands(
+        performanceId: UUID,
+        request: PerformanceBandAddRequest,
+        memberId: Long,
+    ): List<PerformanceBandResponse> {
+        val performance = getPerformance(performanceId)
+        validateIsManager(performance, memberId)
+        return request.bandIds.distinct().mapNotNull { bandId ->
+            if (performanceBandRepository.existsByPerformanceAndBandId(performance, bandId)) return@mapNotNull null
+            if (!bandRepository.existsById(bandId)) throw BusinessException(ErrorCode.BAND_NOT_FOUND)
+            val pb = performanceBandRepository.save(PerformanceBand.create(performance = performance, bandId = bandId))
+            PerformanceBandResponse.of(pb)
+        }
+    }
+
+    @Transactional
+    fun removeBand(
+        performanceId: UUID,
+        bandId: UUID,
+        memberId: Long,
+    ) {
+        val performance = getPerformance(performanceId)
+        validateIsManager(performance, memberId)
+        val pb =
+            performanceBandRepository.findByPerformanceAndBandId(performance, bandId)
+                ?: throw BusinessException(ErrorCode.BAND_NOT_FOUND)
+        performanceBandRepository.delete(pb)
     }
 
     @Transactional

--- a/src/main/kotlin/com/bandage/v1/domain/practice/dto/req/PracticeCreateRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/dto/req/PracticeCreateRequest.kt
@@ -2,6 +2,8 @@ package com.bandage.v1.domain.practice.dto.req
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Future
+import jakarta.validation.constraints.Min
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -11,11 +13,13 @@ data class PracticeCreateRequest(
     val title: String?,
     @Schema(description = "합주곡 아이디", example = "550e8400-e29b-41d4-a716-446655440000")
     val song: UUID,
-    @Schema(description = "합주 타이틀", example = "TuNA")
+    @Schema(description = "합주 장소", example = "홍대 스튜디오")
     val venue: String?,
+    @field:Future(message = "합주 시작 시간은 현재 이후여야 합니다.")
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm", shape = JsonFormat.Shape.STRING, timezone = "Asia/Seoul")
-    @Schema(description = "합주 시작 시간", example = "2026-03-15 18:00")
+    @Schema(description = "합주 시작 시간 (현재 이후만 허용)", example = "2026-03-15 18:00")
     val startAt: LocalDateTime,
+    @field:Min(1)
     @Schema(description = "합주 시간 (분)", example = "60")
     val durationMinutes: Int,
 )

--- a/src/main/kotlin/com/bandage/v1/domain/practice/dto/req/PracticeScheduleUpdateRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/dto/req/PracticeScheduleUpdateRequest.kt
@@ -2,13 +2,15 @@ package com.bandage.v1.domain.practice.dto.req
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Future
 import jakarta.validation.constraints.Min
 import java.time.LocalDateTime
 
 @Schema(description = "합주 일정 변경 요청")
 data class PracticeScheduleUpdateRequest(
+    @field:Future(message = "합주 시작 시간은 현재 이후여야 합니다.")
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm", shape = JsonFormat.Shape.STRING, timezone = "Asia/Seoul")
-    @Schema(description = "합주 시작 시간", example = "2026-03-15 18:00")
+    @Schema(description = "합주 시작 시간 (현재 이후만 허용)", example = "2026-03-15 18:00")
     val startAt: LocalDateTime,
     @field:Min(1)
     @Schema(description = "합주 시간 (분)", example = "90")

--- a/src/main/kotlin/com/bandage/v1/domain/practice/dto/req/PracticeSongCreateFromSongRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/dto/req/PracticeSongCreateFromSongRequest.kt
@@ -7,8 +7,11 @@ import java.util.UUID
 
 @Schema(description = "합주곡 생성 요청 (Song 객체 사용 — 외부 시스템에서 받아온 실제 음원 정보를 그대로 등록)")
 data class PracticeSongCreateFromSongRequest(
-    @Schema(description = "합주 ID (1:1 바인딩 대상)", example = "550e8400-e29b-41d4-a716-446655440000")
-    val practiceId: UUID,
+    @Schema(
+        description = "합주 ID (optional, 1:1 바인딩 대상). 미제공 시 PracticeSong 만 생성하고 Practice 바인딩은 수행하지 않음.",
+        example = "550e8400-e29b-41d4-a716-446655440000",
+    )
+    val practiceId: UUID? = null,
     @field:Valid
     @Schema(description = "외부 시스템 곡 정보")
     val song: Song,

--- a/src/main/kotlin/com/bandage/v1/domain/practice/dto/req/PracticeSongCreateRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/dto/req/PracticeSongCreateRequest.kt
@@ -7,8 +7,11 @@ import java.util.UUID
 
 @Schema(description = "합주곡 생성 요청 (필드 직접 입력 — 자작곡 등 외부 API 연동이 필요 없는 곡 등록용)")
 data class PracticeSongCreateRequest(
-    @Schema(description = "합주 ID (1:1 바인딩 대상)", example = "550e8400-e29b-41d4-a716-446655440000")
-    val practiceId: UUID,
+    @Schema(
+        description = "합주 ID (optional, 1:1 바인딩 대상). 미제공 시 PracticeSong 만 생성하고 Practice 바인딩은 수행하지 않음.",
+        example = "550e8400-e29b-41d4-a716-446655440000",
+    )
+    val practiceId: UUID? = null,
     @field:NotBlank
     @Schema(description = "곡 제목", example = "자작곡 No.1")
     val title: String,

--- a/src/main/kotlin/com/bandage/v1/domain/practice/repository/PracticeParticipantRepository.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/repository/PracticeParticipantRepository.kt
@@ -3,7 +3,10 @@ package com.bandage.v1.domain.practice.repository
 import com.bandage.v1.domain.practice.model.Practice
 import com.bandage.v1.domain.practice.model.PracticeParticipant
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 import java.util.UUID
 
 @Repository
@@ -17,4 +20,21 @@ interface PracticeParticipantRepository : JpaRepository<PracticeParticipant, UUI
         practice: Practice,
         member: Long,
     ): Boolean
+
+    @Query(
+        "SELECT COUNT(pp) FROM PracticeParticipant pp " +
+            "WHERE pp.member = :memberId AND pp.practice.schedule.startAt > :now",
+    )
+    fun countUpcomingPracticesByMember(
+        @Param("memberId") memberId: Long,
+        @Param("now") now: LocalDateTime,
+    ): Long
+
+    @Query(
+        "SELECT COUNT(ps) FROM PracticeSession ps " +
+            "WHERE ps.participant IS NOT NULL AND ps.participant.member = :memberId",
+    )
+    fun countSessionsByMember(
+        @Param("memberId") memberId: Long,
+    ): Long
 }

--- a/src/main/kotlin/com/bandage/v1/domain/practice/service/PracticeService.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/practice/service/PracticeService.kt
@@ -243,10 +243,9 @@ class PracticeService(
 
     @Transactional
     fun createPracticeSong(
-        practiceId: UUID,
+        practiceId: UUID?,
         song: Song,
     ): PracticeSongResponse {
-        val practice = getPractice(practiceId)
         val newSong =
             practiceSongRepository.save(
                 PracticeSong.create(
@@ -257,13 +256,16 @@ class PracticeService(
                     refLink = song.refLink,
                 ),
             )
-        practice.updateSong(newSong)
+        practiceId?.let {
+            val practice = getPractice(it)
+            practice.updateSong(newSong)
+        }
         return PracticeSongResponse.of(newSong)
     }
 
     @Transactional
     fun createPracticeSong(
-        practiceId: UUID,
+        practiceId: UUID?,
         title: String,
         artist: String,
         album: String,

--- a/src/main/kotlin/com/bandage/v1/facade/MemberMetricsFacade.kt
+++ b/src/main/kotlin/com/bandage/v1/facade/MemberMetricsFacade.kt
@@ -1,0 +1,30 @@
+package com.bandage.v1.facade
+
+import com.bandage.v1.domain.band.repository.BandMemberRepository
+import com.bandage.v1.domain.member.dto.res.MemberMetricsResponse
+import com.bandage.v1.domain.performance.repository.PerformanceRepository
+import com.bandage.v1.domain.practice.repository.PracticeParticipantRepository
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+@Service
+class MemberMetricsFacade(
+    private val bandMemberRepository: BandMemberRepository,
+    private val practiceParticipantRepository: PracticeParticipantRepository,
+    private val performanceRepository: PerformanceRepository,
+) {
+    @Transactional
+    fun getMemberMetrics(memberId: Long): MemberMetricsResponse {
+        val now = LocalDateTime.now()
+        val bandIds = bandMemberRepository.findAllBandIdsByMember(memberId)
+        val upcomingPerformanceCount =
+            if (bandIds.isEmpty()) 0L else performanceRepository.countUpcomingByBandIds(bandIds, now)
+        return MemberMetricsResponse(
+            bandCount = bandMemberRepository.countByMember(memberId),
+            upcomingPracticeCount = practiceParticipantRepository.countUpcomingPracticesByMember(memberId, now),
+            upcomingPerformanceCount = upcomingPerformanceCount,
+            sessionCount = practiceParticipantRepository.countSessionsByMember(memberId),
+        )
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/global/error/handler/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/bandage/v1/global/error/handler/GlobalExceptionHandler.kt
@@ -4,6 +4,9 @@ import com.bandage.v1.global.common.response.ApiResponse
 import com.bandage.v1.global.error.errorcode.ErrorCode
 import com.bandage.v1.global.error.exception.BusinessException
 import com.bandage.v1.global.error.exception.Exception
+import com.fasterxml.jackson.databind.exc.InvalidFormatException
+import com.fasterxml.jackson.databind.exc.MismatchedInputException
+import com.fasterxml.jackson.module.kotlin.KotlinInvalidNullException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
@@ -40,13 +43,35 @@ open class GlobalExceptionHandler {
 
     @ExceptionHandler(HttpMessageNotReadableException::class)
     protected fun handleHttpMessageNotReadableException(e: HttpMessageNotReadableException): ResponseEntity<ApiResponse<Nothing>> {
+        val (message, fieldErrors) =
+            when (val cause = e.cause) {
+                is KotlinInvalidNullException -> {
+                    val field = cause.kotlinPropertyName.takeIf { it != "UNKNOWN" } ?: cause.path.firstFieldName()
+                    val msg = "필수 필드가 누락되었습니다."
+                    msg to (field?.let { mapOf(it to msg) })
+                }
+                is InvalidFormatException -> {
+                    val field = cause.path.firstFieldName()
+                    val msg = "올바르지 않은 입력 형식입니다."
+                    msg to (field?.let { mapOf(it to msg) })
+                }
+                is MismatchedInputException -> {
+                    val field = cause.path.firstFieldName()
+                    val msg = ErrorCode.INVALID_INPUT_VALUE.message
+                    msg to (field?.let { mapOf(it to msg) })
+                }
+                else -> ErrorCode.INVALID_INPUT_VALUE.message to null
+            }
         val response =
             ApiResponse.error(
-                message = e.message,
+                message = message,
                 code = ErrorCode.INVALID_INPUT_VALUE.name,
+                fieldErrors = fieldErrors,
             )
         return ResponseEntity(response, HttpStatus.BAD_REQUEST)
     }
+
+    private fun List<com.fasterxml.jackson.databind.JsonMappingException.Reference>.firstFieldName(): String? = firstOrNull()?.fieldName
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException::class)
     protected fun handleMethodNotSupported(e: HttpRequestMethodNotSupportedException): ResponseEntity<ApiResponse<Nothing>> {


### PR DESCRIPTION
## 🛠️ Issue Number

📌 **작업 내용 및 특이사항**

 FE API 연동 시 변경 사항 반영
-  MemberInfoResponse: id alias 필드 추가, profileImg 필드 노출 (§3)
- BandMemberInfoResponse: name/profileImg 필드 추가 (FE-API-012), service 에서 멤버 조회 후 매핑
- BandApplicationInfoResponse: applicantName/applicantProfileImg/appliedAt 추가 (FE-API-013)
- 밴드 정보 수정 API: PATCH /api/v1/bands/{bandId} (FE-API-022) — 리더만, 부분 수정
- 밴드 삭제 API: DELETE /api/v1/bands/{bandId} (FE-API-023) — 리더만, 멤버 cascade soft-delete
- 밴드 멤버 강퇴 API: DELETE /api/v1/bands/{bandId}/members/{bandMemberId} (§8-2) — 리더만
- 밴드 멤버 역할 변경 API: PATCH /api/v1/bands/{bandId}/members/{bandMemberId}/role (§8-2)
  · body 미제공 또는 role=LEADER 면 기존 리더 위임 동작 유지
  · role=ADMIN/MEMBER 면 신규 역할 변경 동작 (BandMember.changeRole)
- 회원 통계 API: GET /api/v1/members/me/stats (FE-API-014) — bandCount/upcomingPracticeCount/upcomingPerformanceCount/sessionCount
  · PracticeParticipantRepository.countUpcomingPracticesByMember/countSessionsByMember (JPQL)
  · PerformanceRepository.countUpcomingByBandIds (JPQL via PerformanceBand)
- 회원 검색 API: GET /api/v1/members/search?q= (FE-API-032) — 이름/이메일 부분 일치 + 본인 제외, 최대 20건
- 공연 참여 밴드 일괄 추가 API: POST /api/v1/performances/{performanceId}/bands/batch (FE-API-017) — append 시맨틱, 중복 무시
- 공연 참여 밴드 단건 제거 API: DELETE /api/v1/performances/{performanceId}/bands/{bandId} (FE-API-017)
- 신규 DTO: BandUpdateRequest, BandMemberRoleUpdateRequest, MemberStatsResponse, MemberSearchItemResponse, PerformanceBandAddRequest, PerformanceBandResponse
- 엔티티 변경: Band.updateName/updateDescription/decreaseMemberCnt, BandMember.changeRole



📚 **참고사항**
