### PR TITLE
feat: 선곡 회의(Setlist Meeting) 도메인 신규 구현

### DIFF
--- a/API_SPEC.md
+++ b/API_SPEC.md
@@ -41,9 +41,17 @@ Base URL: `/api/v1`
 | 12 | 입력 검증 메시지 정제 (T3, T6) | API_ISSUE_REPORT §4-3 | ✅ 해소 | `HttpMessageNotReadableException` 핸들러가 `KotlinInvalidNullException`/`InvalidFormatException` 을 한국어 메시지 + `fieldErrors` 로 매핑 |
 | 13 | 과거 시각 startAt 검증 (T17) | API_ISSUE_REPORT §4-4 | ✅ 해소 | Practice/Performance 생성·수정·합주 일정 변경 DTO 의 `startAt` 에 `@Future` 적용 (4-1/4-8/6-1/6-4 참조) |
 
-### 미해소 / 프론트 책임
+### 추가 반영 (2026-04-27)
 
-- **`MemberInfoResponse.memberId` vs 프론트 기대 `id`** (MVP 통합 §3): 백엔드는 도메인 prefix 컨벤션(`bandId`, `practiceId`, `songId`, `bandMemberId`...)을 따르므로 `memberId` 유지. 프론트 타입을 `memberId`로 갱신 필요.
+| # | 이슈 | 출처 | 상태 | 비고 |
+|---|---|---|---|---|
+| 14 | `MemberInfoResponse.id` alias / `profileImg` 노출 | MVP 통합 §3 | ✅ 해소 | `id` 와 `memberId` 동시 노출 (alias), `profileImg` 필드 추가 (2-2 참조) |
+| 15 | `BandMemberInfoResponse` 에 회원 이름/프로필 이미지 포함 | FE-API-012 | ✅ 해소 | `name`, `profileImg` 추가 (3-4/3-5 참조) |
+| 16 | `BandApplicationInfoResponse` 에 신청자 정보 포함 | FE-API-013 | ✅ 해소 | `applicantName`, `applicantProfileImg`, `appliedAt` 추가 (3-7 참조) |
+| 17 | 회원 메트릭 (밴드 수 / 다가오는 합주·공연 수 / 세션 수) | FE-API-014 | ✅ 해소 | `GET /members/me/metrics` 신규 (2-5 참조). 네이밍은 Stat → Metrics 로 통일 |
+| 18 | 회원 검색 (이름/이메일 부분 일치) | FE-API-032 | ✅ 해소 | `GET /members/search?q=` 신규, 본인 제외, 최대 20건 (2-6 참조) |
+| 19 | 밴드 정보 수정 / 삭제 / 멤버 강퇴 / 역할 변경 | FE-API-022/023, §8-2 | ✅ 해소 | 3-12 ~ 3-15 참조 |
+| 20 | 공연 참여 밴드 일괄 추가/단건 제거 | FE-API-017 | ✅ 해소 | 6-9 / 6-10 참조 |
 
 ---
 
@@ -131,7 +139,18 @@ Base URL: `/api/v1`
 ### 2-2. 내 정보 조회
 - **GET** `/api/v1/members/me`
 - **인증 필요**
-- **Response**: (구현 예정 — 현재 `Unit` 반환)
+- **Response**: `MemberInfoResponse`
+  ```json
+  {
+    "id": 1,
+    "memberId": 1,
+    "email": "member@google.com",
+    "name": "홍길동",
+    "contact": "010-1234-5678",
+    "profileImg": "https://cdn/...jpg"
+  }
+  ```
+- **비고**: `id` 는 `memberId` 의 프론트 호환 alias 필드. `profileImg` 는 미설정 시 `null`.
 
 ---
 
@@ -153,6 +172,44 @@ Base URL: `/api/v1`
 - **DELETE** `/api/v1/members/me`
 - **인증 필요**
 - **비고**: 회원 정보 삭제(soft delete) 및 로그아웃 처리 (쿠키 만료)
+
+---
+
+### 2-5. 내 메트릭 조회
+- **GET** `/api/v1/members/me/metrics`
+- **인증 필요**
+- **Response**: `MemberMetricsResponse`
+  ```json
+  {
+    "bandCount": 3,
+    "upcomingPracticeCount": 2,
+    "upcomingPerformanceCount": 1,
+    "sessionCount": 5
+  }
+  ```
+- **비고**: 본인이 소속된 밴드 수, 본인이 참여한 다가오는 합주 수(`startAt > now`), 본인 소속 밴드의 다가오는 공연 수(`startAt > now`), 본인이 참여 중인 합주 세션 수. 도메인 간 의존(`Band`/`Practice`/`Performance`)이 있어 `MemberMetricsFacade` 에서 집계.
+
+---
+
+### 2-6. 회원 검색
+- **GET** `/api/v1/members/search`
+- **인증 필요**
+- **Query Parameters**
+  | 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+  |---------|------|------|--------|------|
+  | `q` | String | N | `""` | 검색 키워드 (이름 또는 이메일) |
+- **Response**: `List<MemberSearchItemResponse>`
+  ```json
+  [
+    {
+      "memberId": 1,
+      "name": "홍길동",
+      "email": "user@bandage.test",
+      "profileImg": "https://cdn/...jpg"
+    }
+  ]
+  ```
+- **비고**: 이름/이메일 부분 일치 (대소문자 구분 X). 본인은 결과에서 제외. 최대 20건.
 
 ---
 
@@ -255,15 +312,17 @@ Base URL: `/api/v1`
 - **GET** `/api/v1/bands/{bandId}/members/{bandMemberId}`
 - **인증 필요**
 - **Path Variables**: `bandId` (UUID), `bandMemberId` (UUID)
-- **Response**
+- **Response**: `BandMemberInfoResponse`
   ```json
   {
     "bandMemberId": "550e8400-e29b-41d4-a716-446655440000",
     "memberId": 1,
-    "role": "MEMBER"
+    "role": "MEMBER",
+    "name": "홍길동",
+    "profileImg": "https://cdn/...jpg"
   }
   ```
-- **비고**: `role` enum — `LEADER` | `ADMIN` | `MEMBER`
+- **비고**: `role` enum — `LEADER` | `ADMIN` | `MEMBER`. `name`/`profileImg` 는 회원 조회 후 매핑 (FE-API-012).
 
 ---
 
@@ -299,9 +358,13 @@ Base URL: `/api/v1`
   {
     "bandApplicationId": "550e8400-...",
     "memberId": 1,
-    "status": "PENDING"
+    "status": "PENDING",
+    "applicantName": "홍길동",
+    "applicantProfileImg": "https://cdn/...jpg",
+    "appliedAt": "2026-04-26T12:34:56"
   }
   ```
+- **비고**: `applicantName`/`applicantProfileImg` 는 신청자 회원 조회 후 매핑 (FE-API-013). `appliedAt` 은 신청 생성 시각.
 
 ---
 
@@ -321,11 +384,20 @@ Base URL: `/api/v1`
 
 ---
 
-### 3-10. 밴드 리더 권한 위임
+### 3-10. 밴드 멤버 역할 변경 / 리더 위임
 - **PATCH** `/api/v1/bands/{bandId}/members/{bandMemberId}/role`
 - **인증 필요** (리더)
 - **Path Variables**: `bandId` (UUID), `bandMemberId` (UUID)
-- **비고**: 현재 리더 권한을 지정 멤버에게 양도
+- **Request Body** (optional)
+  ```json
+  {
+    "role": "ADMIN"
+  }
+  ```
+  - `role` enum — `LEADER` | `ADMIN` | `MEMBER`
+- **비고**:
+  - body 미제공 또는 `role=LEADER` 면 **리더 권한 위임** 동작 (현재 리더가 지정 멤버에게 권한 양도)
+  - `role=ADMIN` / `role=MEMBER` 면 해당 역할로 변경
 
 ---
 
@@ -333,6 +405,44 @@ Base URL: `/api/v1`
 - **DELETE** `/api/v1/bands/{bandId}/members/me`
 - **인증 필요**
 - **Path Variable**: `bandId` (UUID)
+
+---
+
+### 3-12. 밴드 정보 수정
+- **PATCH** `/api/v1/bands/{bandId}`
+- **인증 필요** (리더)
+- **Path Variable**: `bandId` (UUID)
+- **Request Body** (모든 필드 optional, 전달된 필드만 갱신)
+  ```json
+  {
+    "name": "TuNA",
+    "description": "성균관대학교 락밴드입니다.",
+    "profileImg": "https://cdn/...jpg"
+  }
+  ```
+- **Response**: `BandResponse`
+  ```json
+  {
+    "bandId": "550e8400-e29b-41d4-a716-446655440000",
+    "bandName": "TuNA"
+  }
+  ```
+
+---
+
+### 3-13. 밴드 삭제
+- **DELETE** `/api/v1/bands/{bandId}`
+- **인증 필요** (리더)
+- **Path Variable**: `bandId` (UUID)
+- **비고**: 밴드 및 소속 멤버를 cascade soft-delete.
+
+---
+
+### 3-14. 밴드 멤버 강퇴
+- **DELETE** `/api/v1/bands/{bandId}/members/{bandMemberId}`
+- **인증 필요** (리더)
+- **Path Variables**: `bandId` (UUID), `bandMemberId` (UUID)
+- **비고**: 리더 자신은 강퇴 불가.
 
 ---
 
@@ -884,3 +994,332 @@ Base URL: `/api/v1`
 - **인증 필요** (PerformanceManager)
 - **Path Variable**: `performanceId` (UUID)
 - **비고**: 연관된 합주도 함께 삭제
+
+---
+
+### 6-9. 공연 참여 밴드 일괄 추가
+- **POST** `/api/v1/performances/{performanceId}/bands/batch`
+- **인증 필요** (PerformanceManager)
+- **Path Variable**: `performanceId` (UUID)
+- **Request Body**
+  ```json
+  {
+    "bandIds": [
+      "550e8400-e29b-41d4-a716-446655440000",
+      "550e8400-e29b-41d4-a716-446655440001"
+    ]
+  }
+  ```
+  - `bandIds`: not empty
+- **Response**: `List<PerformanceBandResponse>`
+  ```json
+  [
+    {
+      "performanceBandId": "550e8400-e29b-41d4-a716-446655440010",
+      "bandId": "550e8400-e29b-41d4-a716-446655440000"
+    }
+  ]
+  ```
+- **비고**: append 시맨틱. 이미 등록된 밴드는 무시하고 응답에서도 제외.
+
+---
+
+### 6-10. 공연 참여 밴드 단건 제거
+- **DELETE** `/api/v1/performances/{performanceId}/bands/{bandId}`
+- **인증 필요** (PerformanceManager)
+- **Path Variables**: `performanceId` (UUID), `bandId` (UUID)
+- **비고**: 공연에서 특정 참여 밴드 매핑을 제거 (밴드 자체는 삭제되지 않음).
+
+---
+
+## 7. 선곡 회의 (Setlist Meeting)
+
+> Base path: `/api/v1/setlist-meetings`. 모든 엔드포인트 인증 필요.
+>
+> 권한 모델
+> - **참여 멤버**: `SetlistMeetingMember` 에 등록된 사용자 또는 매니저
+> - **매니저**: `SetlistMeeting.managerId` 와 일치하는 사용자
+> - **잠금 상태(`lockedAt != null`) 제약**: 곡 생성/수정/삭제는 차단 (`SETLIST_MEETING_LOCKED`).
+>
+> 공통 응답 스키마
+>
+> `SetlistMeetingResponse`
+> ```json
+> {
+>   "meetingId": "uuid",
+>   "bandId": "uuid",
+>   "title": "여름 페스티벌 셋리스트 회의",
+>   "purpose": "PERFORMANCE",         // PERFORMANCE | GENERAL
+>   "performanceId": "uuid|null",
+>   "managerId": 1,
+>   "lockedAt": "2026-04-26T12:30:45|null",
+>   "createdAt": "...",
+>   "updatedAt": "..."
+> }
+> ```
+>
+> `SetlistItemResponse`
+> ```json
+> {
+>   "setlistItemId": "uuid",
+>   "meetingId": "uuid",
+>   "title": "Vicarious",
+>   "artist": "Tool",
+>   "album": "10,000 Days",
+>   "duration": "07:06",
+>   "proposerId": 1,
+>   "note": "폴리리듬 도입부…",
+>   "practiceSongId": "uuid|null",     // 매니저 잠금 시 매핑되는 합주곡 ID (cross-domain TODO)
+>   "sessions": [
+>     {
+>       "sessionId": "G",
+>       "label": "기타",
+>       "short": "G",
+>       "need": 1,
+>       "custom": false,
+>       "applicants": [2, 3],
+>       "confirmed": [2]
+>     }
+>   ],
+>   "createdAt": "...",
+>   "updatedAt": "..."
+> }
+> ```
+
+---
+
+### 7-1. 선곡 회의 생성
+- **POST** `/api/v1/setlist-meetings`
+- **인증 필요**
+- **Request Body**
+  ```json
+  {
+    "title": "여름 페스티벌 셋리스트 회의",
+    "purpose": "PERFORMANCE",
+    "performanceId": "550e8400-e29b-41d4-a716-446655440000",
+    "bandId": "550e8400-e29b-41d4-a716-446655440001",
+    "managerId": 1,
+    "participantUserIds": [1, 2, 3]
+  }
+  ```
+  - `title`, `purpose`, `bandId`, `managerId` 필수
+  - `purpose=PERFORMANCE` 일 때 `performanceId` 필수
+  - `managerId` 는 `participantUserIds` 또는 호출자 본인에 포함되어야 함 (자동 추가됨)
+- **Response**: `SetlistMeetingResponse`
+- **검증**
+  - `purpose=PERFORMANCE` + 동일 `performanceId` 활성 회의(`lockedAt=null`) 존재 → 409 `SETLIST_PERFORMANCE_HAS_ACTIVE_MEETING`
+  - 매니저 미참여 → 400 `SETLIST_MANAGER_NOT_PARTICIPANT`
+  - PERFORMANCE 인데 `performanceId` 누락 → 400 `SETLIST_PERFORMANCE_REQUIRED`
+
+---
+
+### 7-2. 내 선곡 회의 목록 조회 (커서 페이징)
+- **GET** `/api/v1/setlist-meetings/me?lastId=&pageSize=20`
+- **인증 필요**
+- **Query Parameters**
+  - `lastId` (UUID, optional): 직전 페이지 마지막 회의 ID
+  - `pageSize` (Int, default `20`, 1~100)
+- **Response**: `CursorResponse<SetlistMeetingResponse, UUID>`
+- **비고**: 본인이 참여(`SetlistMeetingMember`) 중인 회의만 조회.
+
+---
+
+### 7-3. 선곡 회의 단건 조회
+- **GET** `/api/v1/setlist-meetings/{meetingId}`
+- **인증 필요** (참여 멤버 또는 매니저)
+- **Response**: `SetlistMeetingDetailResponse`
+  ```json
+  {
+    "meetingId": "uuid",
+    "bandId": "uuid",
+    "title": "...",
+    "purpose": "GENERAL",
+    "performanceId": null,
+    "managerId": 1,
+    "participantUserIds": [1, 2, 3],
+    "lockedAt": null,
+    "createdAt": "...",
+    "updatedAt": "..."
+  }
+  ```
+- **에러**: 404 `SETLIST_MEETING_NOT_FOUND`, 403 `SETLIST_MEETING_FORBIDDEN`
+
+---
+
+### 7-4. 선곡 회의 수정
+- **PATCH** `/api/v1/setlist-meetings/{meetingId}`
+- **인증 필요** (Manager)
+- **Request Body**
+  ```json
+  {
+    "title": "...",
+    "managerId": 2
+  }
+  ```
+  - 모든 필드 nullable. `managerId` 변경 시 새 매니저는 참여자에 포함되어야 함.
+- **Response**: `SetlistMeetingResponse`
+- **에러**: 403 `SETLIST_MEETING_NOT_MANAGER`, 400 `SETLIST_MANAGER_NOT_PARTICIPANT`
+
+---
+
+### 7-5. 선곡 회의 삭제
+- **DELETE** `/api/v1/setlist-meetings/{meetingId}`
+- **인증 필요** (Manager)
+- **Response**: 204 (`ApiResponse.success()`, data=null)
+- **비고**: soft-delete (`deleted_at` 세팅).
+
+---
+
+### 7-6. 선곡 항목 목록 조회 (커서 페이징)
+- **GET** `/api/v1/setlist-meetings/{meetingId}/items?lastId=&pageSize=50`
+- **인증 필요** (참여 멤버)
+- **Query Parameters**: `lastId` (UUID), `pageSize` (1~200, default 50)
+- **Response**: `CursorResponse<SetlistItemResponse, UUID>` — 응답 항목에 sessions/applicants/confirmed 포함.
+
+---
+
+### 7-7. 선곡 항목 단건 조회
+- **GET** `/api/v1/setlist-meetings/{meetingId}/items/{itemId}`
+- **인증 필요** (참여 멤버)
+- **Response**: `SetlistItemResponse`
+
+---
+
+### 7-8. 선곡 항목 생성
+- **POST** `/api/v1/setlist-meetings/{meetingId}/items`
+- **인증 필요** (참여 멤버, 회의 진행 중)
+- **Request Body**
+  ```json
+  {
+    "title": "Vicarious",
+    "artist": "Tool",
+    "album": "10,000 Days",
+    "duration": "07:06",
+    "note": "폴리리듬 도입부…",
+    "sessions": [
+      { "sessionId": "V", "label": "보컬", "short": "V", "need": 1, "custom": false },
+      { "sessionId": "G", "label": "기타", "short": "G", "need": 2, "custom": false }
+    ]
+  }
+  ```
+- **Response**: 생성된 `SetlistItemResponse` (applicants/confirmed 빈 버킷)
+- **에러**: 409 `SETLIST_MEETING_LOCKED` (잠금 상태에서는 생성 불가)
+- **비고**: `proposerId` 는 토큰의 사용자 ID로 자동 매핑.
+
+---
+
+### 7-9. 선곡 항목 부분 수정
+- **PATCH** `/api/v1/setlist-meetings/{meetingId}/items/{itemId}`
+- **인증 필요** (곡 제안자 또는 매니저)
+- **Request Body**
+  ```json
+  {
+    "title": "...",
+    "artist": "...",
+    "album": "...",
+    "duration": "...",
+    "note": "...",
+    "sessions": [ /* 제공 시 새 세션 list 그대로 교체 */ ]
+  }
+  ```
+- **Response**: 갱신된 `SetlistItemResponse`
+- **비고**: `sessions` 변경 시 제거된 세션의 applicants/confirmed 는 cascade 정리.
+- **에러**: 409 `SETLIST_MEETING_LOCKED`, 403 `SETLIST_ITEM_FORBIDDEN`
+
+---
+
+### 7-10. 선곡 항목 삭제
+- **DELETE** `/api/v1/setlist-meetings/{meetingId}/items/{itemId}`
+- **인증 필요** (곡 제안자 또는 매니저)
+- **에러**: 409 `SETLIST_MEETING_LOCKED`, 403 `SETLIST_ITEM_FORBIDDEN`
+
+---
+
+### 7-11. 세션 지원
+- **POST** `/api/v1/setlist-meetings/{meetingId}/items/{itemId}/sessions/{sessionId}/applicants`
+- **인증 필요** (참여 멤버 본인)
+- **비고**: 본인을 해당 세션 지원자로 등록. 중복 지원은 멱등 200.
+- **에러**: 404 `SETLIST_ITEM_SESSION_NOT_FOUND`
+
+---
+
+### 7-12. 세션 지원 철회
+- **DELETE** `/api/v1/setlist-meetings/{meetingId}/items/{itemId}/sessions/{sessionId}/applicants/{userId}`
+- **인증 필요** (본인 — `userId` 가 토큰 사용자와 일치해야 함)
+- **비고**: cascade — 본인이 해당 세션 confirmed 에 있으면 함께 제거.
+- **에러**: 403 `SETLIST_ITEM_FORBIDDEN` (본인 외 철회 시도)
+
+---
+
+### 7-13. 세션 확정 / 해제 (매니저)
+- **PATCH** `/api/v1/setlist-meetings/{meetingId}/items/{itemId}/sessions/{sessionId}/confirmations`
+- **인증 필요** (Manager)
+- **Request Body**
+  ```json
+  {
+    "confirm":   [2, 3],
+    "unconfirm": [4]
+  }
+  ```
+- **Response**: 갱신된 `SetlistItemResponse`
+- **에러**: 400 `SETLIST_ITEM_SESSION_FULL` (정원 `need` 초과), 404 `SETLIST_ITEM_SESSION_NOT_FOUND`, 403 `SETLIST_MEETING_NOT_MANAGER`
+
+---
+
+### 7-14. 곡별 채팅 조회 (커서 페이징)
+- **GET** `/api/v1/setlist-meetings/{meetingId}/items/{itemId}/chat?lastId=&pageSize=50`
+- **인증 필요** (참여 멤버)
+- **Query Parameters**: `lastId` (UUID), `pageSize` (1~200, default 50)
+- **Response**: `CursorResponse<SetlistChatMessageResponse, UUID>` — 최신순.
+  ```json
+  {
+    "content": [
+      {
+        "messageId": "uuid",
+        "setlistItemId": "uuid",
+        "memberId": 1,
+        "message": "보컬 음역대 빡셈",
+        "createdAt": "..."
+      }
+    ],
+    "nextCursor": "uuid|null",
+    "hasNext": true
+  }
+  ```
+
+---
+
+### 7-15. 곡별 채팅 작성
+- **POST** `/api/v1/setlist-meetings/{meetingId}/items/{itemId}/chat`
+- **인증 필요** (참여 멤버)
+- **Request Body**
+  ```json
+  { "message": "보컬 음역대 빡셈" }
+  ```
+  - `message`: 1~500자
+- **Response**: 생성된 `SetlistChatMessageResponse`
+
+---
+
+### 7-16. 선곡 회의 잠금
+- **POST** `/api/v1/setlist-meetings/{meetingId}/lock`
+- **인증 필요** (Manager)
+- **Response**: `SetlistLockResponse`
+  ```json
+  {
+    "lockedAt": "2026-04-26T12:30:45",
+    "songs": [
+      { "setlistItemId": "uuid", "practiceSongId": "uuid|null" }
+    ]
+  }
+  ```
+- **에러**: 409 `SETLIST_MEETING_LOCKED` (이미 잠금 상태), 403 `SETLIST_MEETING_NOT_MANAGER`
+- **비고**: 합주곡 벌크 생성 + Performance.setlist 자동 등록은 cross-domain 후속(TODO) — 현재는 잠금 상태 전이만 수행하며 `practiceSongId` 는 매핑 전이면 null.
+
+---
+
+### 7-17. 선곡 회의 잠금 해제
+- **POST** `/api/v1/setlist-meetings/{meetingId}/unlock`
+- **인증 필요** (Manager)
+- **Response**: `SetlistMeetingResponse` (`lockedAt=null`)
+- **에러**: 409 `SETLIST_MEETING_NOT_LOCKED`, 403 `SETLIST_MEETING_NOT_MANAGER`

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/controller/SetlistMeetingController.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/controller/SetlistMeetingController.kt
@@ -1,0 +1,201 @@
+package com.bandage.v1.domain.setlist.controller
+
+import com.bandage.v1.domain.setlist.dto.req.SetlistChatMessageCreateRequest
+import com.bandage.v1.domain.setlist.dto.req.SetlistConfirmationUpdateRequest
+import com.bandage.v1.domain.setlist.dto.req.SetlistItemCreateRequest
+import com.bandage.v1.domain.setlist.dto.req.SetlistItemPagingQuery
+import com.bandage.v1.domain.setlist.dto.req.SetlistItemUpdateRequest
+import com.bandage.v1.domain.setlist.dto.req.SetlistMeetingCreateRequest
+import com.bandage.v1.domain.setlist.dto.req.SetlistMeetingPagingQuery
+import com.bandage.v1.domain.setlist.dto.req.SetlistMeetingUpdateRequest
+import com.bandage.v1.domain.setlist.dto.res.SetlistChatMessageResponse
+import com.bandage.v1.domain.setlist.dto.res.SetlistItemResponse
+import com.bandage.v1.domain.setlist.dto.res.SetlistLockResponse
+import com.bandage.v1.domain.setlist.dto.res.SetlistMeetingDetailResponse
+import com.bandage.v1.domain.setlist.dto.res.SetlistMeetingResponse
+import com.bandage.v1.domain.setlist.service.SetlistMeetingService
+import com.bandage.v1.global.common.constants.PathPrefix.PREFIX
+import com.bandage.v1.global.common.response.ApiResponse
+import com.bandage.v1.global.common.response.CursorResponse
+import com.bandage.v1.global.security.annotation.CurrentMemberId
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@Tag(name = "setlist-meetings", description = "선곡 회의 API")
+@RestController
+@RequestMapping("$PREFIX/setlist-meetings")
+class SetlistMeetingController(
+    private val setlistMeetingService: SetlistMeetingService,
+) {
+    @PostMapping
+    @Operation(summary = "선곡 회의 생성", description = "선곡 회의를 생성합니다.")
+    fun createMeeting(
+        @CurrentMemberId memberId: Long,
+        @Valid @RequestBody request: SetlistMeetingCreateRequest,
+    ): ApiResponse<SetlistMeetingResponse> = ApiResponse.success(setlistMeetingService.createMeeting(memberId, request))
+
+    @GetMapping("/me")
+    @Operation(summary = "내 선곡 회의 목록", description = "본인이 참여 중인 선곡 회의를 커서 기반으로 조회합니다.")
+    fun getMyMeetings(
+        @CurrentMemberId memberId: Long,
+        @Valid query: SetlistMeetingPagingQuery,
+    ): ApiResponse<CursorResponse<SetlistMeetingResponse, UUID>> = ApiResponse.success(setlistMeetingService.getMyMeetings(memberId, query))
+
+    @GetMapping("/{meetingId}")
+    @Operation(summary = "선곡 회의 단건 조회")
+    fun getMeeting(
+        @PathVariable meetingId: UUID,
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<SetlistMeetingDetailResponse> = ApiResponse.success(setlistMeetingService.getMeeting(meetingId, memberId))
+
+    @PatchMapping("/{meetingId}")
+    @Operation(summary = "선곡 회의 수정")
+    fun updateMeeting(
+        @PathVariable meetingId: UUID,
+        @CurrentMemberId memberId: Long,
+        @Valid @RequestBody request: SetlistMeetingUpdateRequest,
+    ): ApiResponse<SetlistMeetingResponse> = ApiResponse.success(setlistMeetingService.updateMeeting(meetingId, memberId, request))
+
+    @DeleteMapping("/{meetingId}")
+    @Operation(summary = "선곡 회의 삭제")
+    fun deleteMeeting(
+        @PathVariable meetingId: UUID,
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<Unit> {
+        setlistMeetingService.deleteMeeting(meetingId, memberId)
+        return ApiResponse.success()
+    }
+
+    // -------- items --------
+    @GetMapping("/{meetingId}/items")
+    @Operation(summary = "선곡 항목 목록 조회")
+    fun getItems(
+        @PathVariable meetingId: UUID,
+        @CurrentMemberId memberId: Long,
+        @Valid query: SetlistItemPagingQuery,
+    ): ApiResponse<CursorResponse<SetlistItemResponse, UUID>> =
+        ApiResponse.success(setlistMeetingService.getItems(meetingId, memberId, query))
+
+    @GetMapping("/{meetingId}/items/{itemId}")
+    @Operation(summary = "선곡 항목 단건 조회")
+    fun getItem(
+        @PathVariable meetingId: UUID,
+        @PathVariable itemId: UUID,
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<SetlistItemResponse> = ApiResponse.success(setlistMeetingService.getItem(meetingId, itemId, memberId))
+
+    @PostMapping("/{meetingId}/items")
+    @Operation(summary = "선곡 항목 생성")
+    fun createItem(
+        @PathVariable meetingId: UUID,
+        @CurrentMemberId memberId: Long,
+        @Valid @RequestBody request: SetlistItemCreateRequest,
+    ): ApiResponse<SetlistItemResponse> = ApiResponse.success(setlistMeetingService.createItem(meetingId, memberId, request))
+
+    @PatchMapping("/{meetingId}/items/{itemId}")
+    @Operation(summary = "선곡 항목 수정")
+    fun updateItem(
+        @PathVariable meetingId: UUID,
+        @PathVariable itemId: UUID,
+        @CurrentMemberId memberId: Long,
+        @Valid @RequestBody request: SetlistItemUpdateRequest,
+    ): ApiResponse<SetlistItemResponse> = ApiResponse.success(setlistMeetingService.updateItem(meetingId, itemId, memberId, request))
+
+    @DeleteMapping("/{meetingId}/items/{itemId}")
+    @Operation(summary = "선곡 항목 삭제")
+    fun deleteItem(
+        @PathVariable meetingId: UUID,
+        @PathVariable itemId: UUID,
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<Unit> {
+        setlistMeetingService.deleteItem(meetingId, itemId, memberId)
+        return ApiResponse.success()
+    }
+
+    // -------- session applicants --------
+    @PostMapping("/{meetingId}/items/{itemId}/sessions/{sessionId}/applicants")
+    @Operation(summary = "세션 지원", description = "본인을 세션 지원자로 등록합니다.")
+    fun applyForSession(
+        @PathVariable meetingId: UUID,
+        @PathVariable itemId: UUID,
+        @PathVariable sessionId: String,
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<Unit> {
+        setlistMeetingService.applyForSession(meetingId, itemId, sessionId, memberId)
+        return ApiResponse.success()
+    }
+
+    @DeleteMapping("/{meetingId}/items/{itemId}/sessions/{sessionId}/applicants/{userId}")
+    @Operation(summary = "세션 지원 철회", description = "본인의 세션 지원을 철회합니다.")
+    fun withdrawSessionApplication(
+        @PathVariable meetingId: UUID,
+        @PathVariable itemId: UUID,
+        @PathVariable sessionId: String,
+        @PathVariable userId: Long,
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<Unit> {
+        setlistMeetingService.withdrawSessionApplication(meetingId, itemId, sessionId, userId, memberId)
+        return ApiResponse.success()
+    }
+
+    @PatchMapping("/{meetingId}/items/{itemId}/sessions/{sessionId}/confirmations")
+    @Operation(summary = "세션 확정/해제", description = "매니저가 세션 참여자를 확정/해제 합니다.")
+    fun updateConfirmations(
+        @PathVariable meetingId: UUID,
+        @PathVariable itemId: UUID,
+        @PathVariable sessionId: String,
+        @CurrentMemberId memberId: Long,
+        @Valid @RequestBody request: SetlistConfirmationUpdateRequest,
+    ): ApiResponse<SetlistItemResponse> =
+        ApiResponse.success(setlistMeetingService.updateConfirmations(meetingId, itemId, sessionId, memberId, request))
+
+    // -------- chat --------
+    @GetMapping("/{meetingId}/items/{itemId}/chat")
+    @Operation(summary = "선곡 항목 채팅 조회")
+    fun getChatMessages(
+        @PathVariable meetingId: UUID,
+        @PathVariable itemId: UUID,
+        @CurrentMemberId memberId: Long,
+        @RequestParam(required = false) lastId: UUID?,
+        @RequestParam(defaultValue = "50") @Min(1) @Max(200) pageSize: Int,
+    ): ApiResponse<CursorResponse<SetlistChatMessageResponse, UUID>> =
+        ApiResponse.success(setlistMeetingService.getChatMessages(meetingId, itemId, memberId, lastId, pageSize))
+
+    @PostMapping("/{meetingId}/items/{itemId}/chat")
+    @Operation(summary = "선곡 항목 채팅 작성")
+    fun createChatMessage(
+        @PathVariable meetingId: UUID,
+        @PathVariable itemId: UUID,
+        @CurrentMemberId memberId: Long,
+        @Valid @RequestBody request: SetlistChatMessageCreateRequest,
+    ): ApiResponse<SetlistChatMessageResponse> =
+        ApiResponse.success(setlistMeetingService.createChatMessage(meetingId, itemId, memberId, request))
+
+    // -------- lock / unlock --------
+    @PostMapping("/{meetingId}/lock")
+    @Operation(summary = "선곡 회의 잠금", description = "매니저가 선곡 회의를 잠금 처리합니다.")
+    fun lockMeeting(
+        @PathVariable meetingId: UUID,
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<SetlistLockResponse> = ApiResponse.success(setlistMeetingService.lockMeeting(meetingId, memberId))
+
+    @PostMapping("/{meetingId}/unlock")
+    @Operation(summary = "선곡 회의 잠금 해제")
+    fun unlockMeeting(
+        @PathVariable meetingId: UUID,
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<SetlistMeetingResponse> = ApiResponse.success(setlistMeetingService.unlockMeeting(meetingId, memberId))
+}

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/dto/req/SessionDefDto.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/dto/req/SessionDefDto.kt
@@ -1,0 +1,26 @@
+package com.bandage.v1.domain.setlist.dto.req
+
+import com.bandage.v1.domain.setlist.model.SessionDef
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+
+@Schema(description = "세션 정의")
+data class SessionDefDto(
+    @field:NotBlank
+    @Schema(description = "세션 토큰", example = "G")
+    val sessionId: String,
+    @field:NotBlank
+    @Schema(description = "세션 이름", example = "기타")
+    val label: String,
+    @field:NotBlank
+    @Schema(description = "표시용 약어", example = "G")
+    val short: String,
+    @field:Min(1)
+    @Schema(description = "정원", example = "1")
+    val need: Int,
+    @Schema(description = "커스텀 세션 여부", example = "false")
+    val custom: Boolean = false,
+) {
+    fun toEntity(): SessionDef = SessionDef(sessionId = sessionId, label = label, short = short, need = need, custom = custom)
+}

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/dto/req/SetlistChatMessageCreateRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/dto/req/SetlistChatMessageCreateRequest.kt
@@ -1,0 +1,13 @@
+package com.bandage.v1.domain.setlist.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+@Schema(description = "선곡 항목 채팅 메시지 작성 요청")
+data class SetlistChatMessageCreateRequest(
+    @field:NotBlank
+    @field:Size(max = 500)
+    @Schema(description = "메시지 본문 (최대 500자)")
+    val message: String,
+)

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/dto/req/SetlistConfirmationUpdateRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/dto/req/SetlistConfirmationUpdateRequest.kt
@@ -1,0 +1,11 @@
+package com.bandage.v1.domain.setlist.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "세션 확정/해제 요청")
+data class SetlistConfirmationUpdateRequest(
+    @Schema(description = "확정할 사용자 ID")
+    val confirm: List<Long> = emptyList(),
+    @Schema(description = "확정 해제할 사용자 ID")
+    val unconfirm: List<Long> = emptyList(),
+)

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/dto/req/SetlistItemCreateRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/dto/req/SetlistItemCreateRequest.kt
@@ -1,0 +1,24 @@
+package com.bandage.v1.domain.setlist.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+
+@Schema(description = "선곡 항목 생성 요청")
+data class SetlistItemCreateRequest(
+    @field:NotBlank
+    @Schema(description = "곡 제목")
+    val title: String,
+    @field:NotBlank
+    @Schema(description = "아티스트")
+    val artist: String,
+    @Schema(description = "앨범")
+    val album: String?,
+    @Schema(description = "재생 시간(mm:ss)")
+    val duration: String?,
+    @Schema(description = "추천자 의견")
+    val note: String?,
+    @field:Valid
+    @Schema(description = "세션 정의 목록")
+    val sessions: List<SessionDefDto> = emptyList(),
+)

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/dto/req/SetlistItemPagingQuery.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/dto/req/SetlistItemPagingQuery.kt
@@ -1,0 +1,14 @@
+package com.bandage.v1.domain.setlist.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import java.util.UUID
+
+@Schema(description = "선곡 항목 목록 조회 쿼리")
+data class SetlistItemPagingQuery(
+    val lastId: UUID?,
+    @field:Min(1)
+    @field:Max(200)
+    val pageSize: Int = 50,
+)

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/dto/req/SetlistItemUpdateRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/dto/req/SetlistItemUpdateRequest.kt
@@ -1,0 +1,16 @@
+package com.bandage.v1.domain.setlist.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+
+@Schema(description = "선곡 항목 부분 수정 요청")
+data class SetlistItemUpdateRequest(
+    val title: String? = null,
+    val artist: String? = null,
+    val album: String? = null,
+    val duration: String? = null,
+    val note: String? = null,
+    @field:Valid
+    @Schema(description = "세션 정의 목록 (제공 시 전체 교체)")
+    val sessions: List<SessionDefDto>? = null,
+)

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/dto/req/SetlistMeetingCreateRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/dto/req/SetlistMeetingCreateRequest.kt
@@ -1,0 +1,27 @@
+package com.bandage.v1.domain.setlist.dto.req
+
+import com.bandage.v1.domain.setlist.model.enums.MeetingPurpose
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.util.UUID
+
+@Schema(description = "선곡 회의 생성 요청")
+data class SetlistMeetingCreateRequest(
+    @field:NotBlank
+    @Schema(description = "회의 제목", example = "여름 페스티벌 셋리스트 회의")
+    val title: String,
+    @field:NotNull
+    @Schema(description = "회의 목적", example = "PERFORMANCE")
+    val purpose: MeetingPurpose,
+    @Schema(description = "공연 ID (purpose=PERFORMANCE 일 때 필수)")
+    val performanceId: UUID?,
+    @field:NotNull
+    @Schema(description = "기준 밴드 ID")
+    val bandId: UUID,
+    @field:NotNull
+    @Schema(description = "매니저 회원 ID")
+    val managerId: Long,
+    @Schema(description = "참여자 회원 ID 목록 (매니저 포함)")
+    val participantUserIds: List<Long> = emptyList(),
+)

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/dto/req/SetlistMeetingPagingQuery.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/dto/req/SetlistMeetingPagingQuery.kt
@@ -1,0 +1,16 @@
+package com.bandage.v1.domain.setlist.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import java.util.UUID
+
+@Schema(description = "선곡 회의 목록 조회 쿼리")
+data class SetlistMeetingPagingQuery(
+    @Schema(description = "마지막으로 조회된 회의 ID (커서)")
+    val lastId: UUID?,
+    @field:Min(1)
+    @field:Max(100)
+    @Schema(description = "페이지 크기", example = "20")
+    val pageSize: Int = 20,
+)

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/dto/req/SetlistMeetingUpdateRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/dto/req/SetlistMeetingUpdateRequest.kt
@@ -1,0 +1,11 @@
+package com.bandage.v1.domain.setlist.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "선곡 회의 수정 요청")
+data class SetlistMeetingUpdateRequest(
+    @Schema(description = "회의 제목")
+    val title: String?,
+    @Schema(description = "변경할 매니저 회원 ID")
+    val managerId: Long?,
+)

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/dto/res/SessionDefResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/dto/res/SessionDefResponse.kt
@@ -1,0 +1,30 @@
+package com.bandage.v1.domain.setlist.dto.res
+
+import com.bandage.v1.domain.setlist.model.SessionDef
+
+data class SessionDefResponse(
+    val sessionId: String,
+    val label: String,
+    val short: String,
+    val need: Int,
+    val custom: Boolean,
+    val applicants: List<Long>,
+    val confirmed: List<Long>,
+) {
+    companion object {
+        fun of(
+            def: SessionDef,
+            applicants: List<Long>,
+            confirmed: List<Long>,
+        ): SessionDefResponse =
+            SessionDefResponse(
+                sessionId = def.sessionId,
+                label = def.label,
+                short = def.short,
+                need = def.need,
+                custom = def.custom,
+                applicants = applicants,
+                confirmed = confirmed,
+            )
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/dto/res/SetlistChatMessageResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/dto/res/SetlistChatMessageResponse.kt
@@ -1,0 +1,26 @@
+package com.bandage.v1.domain.setlist.dto.res
+
+import com.bandage.v1.domain.setlist.model.SetlistItemChatMessage
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Schema(description = "선곡 항목 채팅 메시지 응답")
+data class SetlistChatMessageResponse(
+    val messageId: UUID,
+    val setlistItemId: UUID,
+    val memberId: Long,
+    val message: String,
+    val createdAt: LocalDateTime?,
+) {
+    companion object {
+        fun of(c: SetlistItemChatMessage): SetlistChatMessageResponse =
+            SetlistChatMessageResponse(
+                messageId = c.id,
+                setlistItemId = c.item.id,
+                memberId = c.memberId,
+                message = c.message,
+                createdAt = c.createdAt,
+            )
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/dto/res/SetlistItemResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/dto/res/SetlistItemResponse.kt
@@ -1,0 +1,57 @@
+package com.bandage.v1.domain.setlist.dto.res
+
+import com.bandage.v1.domain.setlist.model.SetlistItem
+import com.bandage.v1.domain.setlist.model.SetlistItemApplicant
+import com.bandage.v1.domain.setlist.model.SetlistItemConfirmation
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Schema(description = "선곡 항목 응답")
+data class SetlistItemResponse(
+    val setlistItemId: UUID,
+    val meetingId: UUID,
+    val title: String,
+    val artist: String,
+    val album: String?,
+    val duration: String?,
+    val proposerId: Long,
+    val note: String?,
+    val practiceSongId: UUID?,
+    val sessions: List<SessionDefResponse>,
+    val createdAt: LocalDateTime?,
+    val updatedAt: LocalDateTime?,
+) {
+    companion object {
+        fun of(
+            item: SetlistItem,
+            applicants: List<SetlistItemApplicant>,
+            confirmations: List<SetlistItemConfirmation>,
+        ): SetlistItemResponse {
+            val applicantsBySession = applicants.groupBy { it.sessionId }
+            val confirmedBySession = confirmations.groupBy { it.sessionId }
+            val sessionResponses =
+                item.sessions.map { def ->
+                    SessionDefResponse.of(
+                        def = def,
+                        applicants = applicantsBySession[def.sessionId]?.map { it.memberId } ?: emptyList(),
+                        confirmed = confirmedBySession[def.sessionId]?.map { it.memberId } ?: emptyList(),
+                    )
+                }
+            return SetlistItemResponse(
+                setlistItemId = item.id,
+                meetingId = item.meeting.id,
+                title = item.title,
+                artist = item.artist,
+                album = item.album,
+                duration = item.duration,
+                proposerId = item.proposerId,
+                note = item.note,
+                practiceSongId = item.practiceSongId,
+                sessions = sessionResponses,
+                createdAt = item.createdAt,
+                updatedAt = item.lastModifiedAt,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/dto/res/SetlistLockResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/dto/res/SetlistLockResponse.kt
@@ -1,0 +1,17 @@
+package com.bandage.v1.domain.setlist.dto.res
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Schema(description = "선곡 회의 잠금 응답")
+data class SetlistLockResponse(
+    val lockedAt: LocalDateTime,
+    @Schema(description = "선곡 항목 - 합주곡 매핑")
+    val songs: List<SetlistLockSongMapping>,
+)
+
+data class SetlistLockSongMapping(
+    val setlistItemId: UUID,
+    val practiceSongId: UUID?,
+)

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/dto/res/SetlistMeetingDetailResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/dto/res/SetlistMeetingDetailResponse.kt
@@ -1,0 +1,40 @@
+package com.bandage.v1.domain.setlist.dto.res
+
+import com.bandage.v1.domain.setlist.model.SetlistMeeting
+import com.bandage.v1.domain.setlist.model.enums.MeetingPurpose
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Schema(description = "선곡 회의 상세 응답")
+data class SetlistMeetingDetailResponse(
+    val meetingId: UUID,
+    val bandId: UUID,
+    val title: String,
+    val purpose: MeetingPurpose,
+    val performanceId: UUID?,
+    val managerId: Long,
+    val participantUserIds: List<Long>,
+    val lockedAt: LocalDateTime?,
+    val createdAt: LocalDateTime?,
+    val updatedAt: LocalDateTime?,
+) {
+    companion object {
+        fun of(
+            m: SetlistMeeting,
+            participantUserIds: List<Long>,
+        ): SetlistMeetingDetailResponse =
+            SetlistMeetingDetailResponse(
+                meetingId = m.id,
+                bandId = m.bandId,
+                title = m.title,
+                purpose = m.purpose,
+                performanceId = m.performanceId,
+                managerId = m.managerId,
+                participantUserIds = participantUserIds,
+                lockedAt = m.lockedAt,
+                createdAt = m.createdAt,
+                updatedAt = m.lastModifiedAt,
+            )
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/dto/res/SetlistMeetingResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/dto/res/SetlistMeetingResponse.kt
@@ -1,0 +1,35 @@
+package com.bandage.v1.domain.setlist.dto.res
+
+import com.bandage.v1.domain.setlist.model.SetlistMeeting
+import com.bandage.v1.domain.setlist.model.enums.MeetingPurpose
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Schema(description = "선곡 회의 응답")
+data class SetlistMeetingResponse(
+    val meetingId: UUID,
+    val bandId: UUID,
+    val title: String,
+    val purpose: MeetingPurpose,
+    val performanceId: UUID?,
+    val managerId: Long,
+    val lockedAt: LocalDateTime?,
+    val createdAt: LocalDateTime?,
+    val updatedAt: LocalDateTime?,
+) {
+    companion object {
+        fun of(m: SetlistMeeting): SetlistMeetingResponse =
+            SetlistMeetingResponse(
+                meetingId = m.id,
+                bandId = m.bandId,
+                title = m.title,
+                purpose = m.purpose,
+                performanceId = m.performanceId,
+                managerId = m.managerId,
+                lockedAt = m.lockedAt,
+                createdAt = m.createdAt,
+                updatedAt = m.lastModifiedAt,
+            )
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/model/SessionDef.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/model/SessionDef.kt
@@ -1,0 +1,33 @@
+package com.bandage.v1.domain.setlist.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+
+@Embeddable
+class SessionDef(
+    sessionId: String,
+    label: String,
+    short: String,
+    need: Int,
+    custom: Boolean,
+) {
+    @Column(name = "session_id", nullable = false)
+    var sessionId: String = sessionId
+        protected set
+
+    @Column(name = "label", nullable = false)
+    var label: String = label
+        protected set
+
+    @Column(name = "session_short", nullable = false)
+    var short: String = short
+        protected set
+
+    @Column(name = "session_need", nullable = false)
+    var need: Int = need
+        protected set
+
+    @Column(name = "session_custom", nullable = false)
+    var custom: Boolean = custom
+        protected set
+}

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/model/SetlistItem.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/model/SetlistItem.kt
@@ -1,0 +1,121 @@
+package com.bandage.v1.domain.setlist.model
+
+import com.bandage.v1.global.common.domain.BaseEntity
+import jakarta.persistence.CollectionTable
+import jakarta.persistence.Column
+import jakarta.persistence.ElementCollection
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import org.hibernate.annotations.SQLRestriction
+import org.hibernate.annotations.UuidGenerator
+import java.util.UUID
+
+@Entity
+@Table(name = "p_setlist_item")
+@SQLRestriction("deleted_at IS NULL")
+open class SetlistItem(
+    meeting: SetlistMeeting,
+    title: String,
+    artist: String,
+    album: String?,
+    duration: String?,
+    proposerId: Long,
+    note: String?,
+) : BaseEntity() {
+    @Id
+    @Column(name = "setlist_item_id")
+    @UuidGenerator(style = UuidGenerator.Style.VERSION_7)
+    lateinit var id: UUID
+        protected set
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meeting_id", nullable = false)
+    val meeting: SetlistMeeting = meeting
+
+    @Column(name = "title", nullable = false)
+    var title: String = title
+        protected set
+
+    @Column(name = "artist", nullable = false)
+    var artist: String = artist
+        protected set
+
+    @Column(name = "album", nullable = true)
+    var album: String? = album
+        protected set
+
+    @Column(name = "duration", nullable = true)
+    var duration: String? = duration
+        protected set
+
+    @Column(name = "proposer_id", nullable = false)
+    val proposerId: Long = proposerId
+
+    @Column(name = "note", nullable = true, length = 1000)
+    var note: String? = note
+        protected set
+
+    @Column(name = "practice_song_id", nullable = true)
+    var practiceSongId: UUID? = null
+        protected set
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(
+        name = "p_setlist_item_session",
+        joinColumns = [JoinColumn(name = "setlist_item_id")],
+    )
+    private var _sessions: MutableList<SessionDef> = mutableListOf()
+
+    val sessions: List<SessionDef> get() = _sessions.toList()
+
+    companion object {
+        fun create(
+            meeting: SetlistMeeting,
+            title: String,
+            artist: String,
+            album: String?,
+            duration: String?,
+            proposerId: Long,
+            note: String?,
+            sessions: List<SessionDef>,
+        ): SetlistItem =
+            SetlistItem(
+                meeting = meeting,
+                title = title,
+                artist = artist,
+                album = album,
+                duration = duration,
+                proposerId = proposerId,
+                note = note,
+            ).apply {
+                _sessions.addAll(sessions)
+            }
+    }
+
+    fun updateMeta(
+        title: String?,
+        artist: String?,
+        album: String?,
+        duration: String?,
+        note: String?,
+    ) {
+        title?.let { this.title = it }
+        artist?.let { this.artist = it }
+        album?.let { this.album = it }
+        duration?.let { this.duration = it }
+        note?.let { this.note = it }
+    }
+
+    fun replaceSessions(newSessions: List<SessionDef>) {
+        this._sessions.clear()
+        this._sessions.addAll(newSessions)
+    }
+
+    fun assignPracticeSongId(practiceSongId: UUID) {
+        this.practiceSongId = practiceSongId
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/model/SetlistItemApplicant.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/model/SetlistItemApplicant.kt
@@ -1,0 +1,55 @@
+package com.bandage.v1.domain.setlist.model
+
+import com.bandage.v1.global.common.domain.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.SQLRestriction
+import org.hibernate.annotations.UuidGenerator
+import java.util.UUID
+
+@Entity
+@Table(
+    name = "p_setlist_item_applicant",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_setlist_item_applicant",
+            columnNames = ["setlist_item_id", "session_id", "member_id"],
+        ),
+    ],
+)
+@SQLRestriction("deleted_at IS NULL")
+open class SetlistItemApplicant(
+    item: SetlistItem,
+    sessionId: String,
+    memberId: Long,
+) : BaseEntity() {
+    @Id
+    @Column(name = "applicant_id")
+    @UuidGenerator(style = UuidGenerator.Style.VERSION_7)
+    lateinit var id: UUID
+        protected set
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "setlist_item_id", nullable = false)
+    val item: SetlistItem = item
+
+    @Column(name = "session_id", nullable = false)
+    val sessionId: String = sessionId
+
+    @Column(name = "member_id", nullable = false)
+    val memberId: Long = memberId
+
+    companion object {
+        fun create(
+            item: SetlistItem,
+            sessionId: String,
+            memberId: Long,
+        ): SetlistItemApplicant = SetlistItemApplicant(item = item, sessionId = sessionId, memberId = memberId)
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/model/SetlistItemChatMessage.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/model/SetlistItemChatMessage.kt
@@ -1,0 +1,47 @@
+package com.bandage.v1.domain.setlist.model
+
+import com.bandage.v1.global.common.domain.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import org.hibernate.annotations.SQLRestriction
+import org.hibernate.annotations.UuidGenerator
+import java.util.UUID
+
+@Entity
+@Table(name = "p_setlist_item_chat_message")
+@SQLRestriction("deleted_at IS NULL")
+open class SetlistItemChatMessage(
+    item: SetlistItem,
+    memberId: Long,
+    message: String,
+) : BaseEntity() {
+    @Id
+    @Column(name = "message_id")
+    @UuidGenerator(style = UuidGenerator.Style.VERSION_7)
+    lateinit var id: UUID
+        protected set
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "setlist_item_id", nullable = false)
+    val item: SetlistItem = item
+
+    @Column(name = "member_id", nullable = false)
+    val memberId: Long = memberId
+
+    @Column(name = "message", nullable = false, length = 500)
+    var message: String = message
+        protected set
+
+    companion object {
+        fun create(
+            item: SetlistItem,
+            memberId: Long,
+            message: String,
+        ): SetlistItemChatMessage = SetlistItemChatMessage(item = item, memberId = memberId, message = message)
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/model/SetlistItemConfirmation.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/model/SetlistItemConfirmation.kt
@@ -1,0 +1,66 @@
+package com.bandage.v1.domain.setlist.model
+
+import com.bandage.v1.global.common.domain.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.SQLRestriction
+import org.hibernate.annotations.UuidGenerator
+import java.util.UUID
+
+@Entity
+@Table(
+    name = "p_setlist_item_confirmation",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_setlist_item_confirmation",
+            columnNames = ["setlist_item_id", "session_id", "member_id"],
+        ),
+    ],
+)
+@SQLRestriction("deleted_at IS NULL")
+open class SetlistItemConfirmation(
+    item: SetlistItem,
+    sessionId: String,
+    memberId: Long,
+    confirmedBy: Long,
+) : BaseEntity() {
+    @Id
+    @Column(name = "confirmation_id")
+    @UuidGenerator(style = UuidGenerator.Style.VERSION_7)
+    lateinit var id: UUID
+        protected set
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "setlist_item_id", nullable = false)
+    val item: SetlistItem = item
+
+    @Column(name = "session_id", nullable = false)
+    val sessionId: String = sessionId
+
+    @Column(name = "member_id", nullable = false)
+    val memberId: Long = memberId
+
+    @Column(name = "confirmed_by", nullable = false)
+    val confirmedBy: Long = confirmedBy
+
+    companion object {
+        fun create(
+            item: SetlistItem,
+            sessionId: String,
+            memberId: Long,
+            confirmedBy: Long,
+        ): SetlistItemConfirmation =
+            SetlistItemConfirmation(
+                item = item,
+                sessionId = sessionId,
+                memberId = memberId,
+                confirmedBy = confirmedBy,
+            )
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/model/SetlistMeeting.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/model/SetlistMeeting.kt
@@ -1,0 +1,91 @@
+package com.bandage.v1.domain.setlist.model
+
+import com.bandage.v1.domain.setlist.model.enums.MeetingPurpose
+import com.bandage.v1.global.common.domain.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.SQLRestriction
+import org.hibernate.annotations.UuidGenerator
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Entity
+@Table(name = "p_setlist_meeting")
+@SQLRestriction("deleted_at IS NULL")
+open class SetlistMeeting(
+    bandId: UUID,
+    title: String,
+    purpose: MeetingPurpose,
+    performanceId: UUID?,
+    managerId: Long,
+) : BaseEntity() {
+    @Id
+    @Column(name = "meeting_id")
+    @UuidGenerator(style = UuidGenerator.Style.VERSION_7)
+    lateinit var id: UUID
+        protected set
+
+    @Column(name = "band_id", nullable = false)
+    var bandId: UUID = bandId
+        protected set
+
+    @Column(name = "title", nullable = false)
+    var title: String = title
+        protected set
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "purpose", nullable = false)
+    var purpose: MeetingPurpose = purpose
+        protected set
+
+    @Column(name = "performance_id", nullable = true)
+    var performanceId: UUID? = performanceId
+        protected set
+
+    @Column(name = "manager_id", nullable = false)
+    var managerId: Long = managerId
+        protected set
+
+    @Column(name = "locked_at", nullable = true)
+    var lockedAt: LocalDateTime? = null
+        protected set
+
+    val isLocked: Boolean get() = lockedAt != null
+
+    companion object {
+        fun create(
+            bandId: UUID,
+            title: String,
+            purpose: MeetingPurpose,
+            performanceId: UUID?,
+            managerId: Long,
+        ): SetlistMeeting =
+            SetlistMeeting(
+                bandId = bandId,
+                title = title,
+                purpose = purpose,
+                performanceId = performanceId,
+                managerId = managerId,
+            )
+    }
+
+    fun updateTitle(newTitle: String) {
+        this.title = newTitle
+    }
+
+    fun changeManager(newManagerId: Long) {
+        this.managerId = newManagerId
+    }
+
+    fun lock() {
+        this.lockedAt = LocalDateTime.now()
+    }
+
+    fun unlock() {
+        this.lockedAt = null
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/model/SetlistMeetingMember.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/model/SetlistMeetingMember.kt
@@ -1,0 +1,45 @@
+package com.bandage.v1.domain.setlist.model
+
+import com.bandage.v1.global.common.domain.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.SQLRestriction
+import org.hibernate.annotations.UuidGenerator
+import java.util.UUID
+
+@Entity
+@Table(
+    name = "p_setlist_meeting_member",
+    uniqueConstraints = [UniqueConstraint(name = "uk_setlist_meeting_member", columnNames = ["meeting_id", "member_id"])],
+)
+@SQLRestriction("deleted_at IS NULL")
+open class SetlistMeetingMember(
+    meeting: SetlistMeeting,
+    memberId: Long,
+) : BaseEntity() {
+    @Id
+    @Column(name = "meeting_member_id")
+    @UuidGenerator(style = UuidGenerator.Style.VERSION_7)
+    lateinit var id: UUID
+        protected set
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meeting_id", nullable = false)
+    val meeting: SetlistMeeting = meeting
+
+    @Column(name = "member_id", nullable = false)
+    val memberId: Long = memberId
+
+    companion object {
+        fun create(
+            meeting: SetlistMeeting,
+            memberId: Long,
+        ): SetlistMeetingMember = SetlistMeetingMember(meeting = meeting, memberId = memberId)
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/model/enums/MeetingPurpose.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/model/enums/MeetingPurpose.kt
@@ -1,0 +1,6 @@
+package com.bandage.v1.domain.setlist.model.enums
+
+enum class MeetingPurpose {
+    PERFORMANCE,
+    GENERAL,
+}

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistItemApplicantRepository.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistItemApplicantRepository.kt
@@ -1,0 +1,26 @@
+package com.bandage.v1.domain.setlist.repository
+
+import com.bandage.v1.domain.setlist.model.SetlistItem
+import com.bandage.v1.domain.setlist.model.SetlistItemApplicant
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface SetlistItemApplicantRepository : JpaRepository<SetlistItemApplicant, UUID> {
+    fun findAllByItem(item: SetlistItem): List<SetlistItemApplicant>
+
+    fun findAllByItemIn(items: List<SetlistItem>): List<SetlistItemApplicant>
+
+    fun findByItemAndSessionIdAndMemberId(
+        item: SetlistItem,
+        sessionId: String,
+        memberId: Long,
+    ): SetlistItemApplicant?
+
+    fun existsByItemAndSessionIdAndMemberId(
+        item: SetlistItem,
+        sessionId: String,
+        memberId: Long,
+    ): Boolean
+}

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistItemChatMessageRepository.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistItemChatMessageRepository.kt
@@ -1,0 +1,11 @@
+package com.bandage.v1.domain.setlist.repository
+
+import com.bandage.v1.domain.setlist.model.SetlistItemChatMessage
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface SetlistItemChatMessageRepository :
+    JpaRepository<SetlistItemChatMessage, UUID>,
+    SetlistItemChatMessageRepositoryCustom

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistItemChatMessageRepositoryCustom.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistItemChatMessageRepositoryCustom.kt
@@ -1,0 +1,13 @@
+package com.bandage.v1.domain.setlist.repository
+
+import com.bandage.v1.domain.setlist.model.SetlistItemChatMessage
+import com.bandage.v1.global.common.response.CursorResponse
+import java.util.UUID
+
+interface SetlistItemChatMessageRepositoryCustom {
+    fun findAllByItemAndPaging(
+        itemId: UUID,
+        lastId: UUID?,
+        pageSize: Int,
+    ): CursorResponse<SetlistItemChatMessage, UUID>
+}

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistItemChatMessageRepositoryImpl.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistItemChatMessageRepositoryImpl.kt
@@ -1,0 +1,37 @@
+package com.bandage.v1.domain.setlist.repository
+
+import com.bandage.v1.domain.setlist.model.QSetlistItemChatMessage
+import com.bandage.v1.domain.setlist.model.SetlistItemChatMessage
+import com.bandage.v1.global.common.response.CursorResponse
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.impl.JPAQueryFactory
+import java.util.UUID
+
+class SetlistItemChatMessageRepositoryImpl(
+    private val queryFactory: JPAQueryFactory,
+) : SetlistItemChatMessageRepositoryCustom {
+    override fun findAllByItemAndPaging(
+        itemId: UUID,
+        lastId: UUID?,
+        pageSize: Int,
+    ): CursorResponse<SetlistItemChatMessage, UUID> {
+        val qChat = QSetlistItemChatMessage.setlistItemChatMessage
+
+        val contents =
+            queryFactory
+                .selectFrom(qChat)
+                .where(qChat.item.id.eq(itemId))
+                .where(ltChatId(lastId))
+                .orderBy(qChat.id.desc())
+                .limit(pageSize.toLong() + 1)
+                .fetch()
+
+        val hasNext = contents.size > pageSize
+        val resultContents = if (hasNext) contents.dropLast(1) else contents
+        val nextCursor = if (hasNext) resultContents.lastOrNull()?.id else null
+
+        return CursorResponse(content = resultContents, nextCursor = nextCursor, hasNext = hasNext)
+    }
+
+    private fun ltChatId(lastId: UUID?): BooleanExpression? = lastId?.let { QSetlistItemChatMessage.setlistItemChatMessage.id.lt(it) }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistItemConfirmationRepository.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistItemConfirmationRepository.kt
@@ -1,0 +1,25 @@
+package com.bandage.v1.domain.setlist.repository
+
+import com.bandage.v1.domain.setlist.model.SetlistItem
+import com.bandage.v1.domain.setlist.model.SetlistItemConfirmation
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface SetlistItemConfirmationRepository : JpaRepository<SetlistItemConfirmation, UUID> {
+    fun findAllByItem(item: SetlistItem): List<SetlistItemConfirmation>
+
+    fun findAllByItemIn(items: List<SetlistItem>): List<SetlistItemConfirmation>
+
+    fun findByItemAndSessionIdAndMemberId(
+        item: SetlistItem,
+        sessionId: String,
+        memberId: Long,
+    ): SetlistItemConfirmation?
+
+    fun countByItemAndSessionId(
+        item: SetlistItem,
+        sessionId: String,
+    ): Long
+}

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistItemRepository.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistItemRepository.kt
@@ -1,0 +1,14 @@
+package com.bandage.v1.domain.setlist.repository
+
+import com.bandage.v1.domain.setlist.model.SetlistItem
+import com.bandage.v1.domain.setlist.model.SetlistMeeting
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface SetlistItemRepository :
+    JpaRepository<SetlistItem, UUID>,
+    SetlistItemRepositoryCustom {
+    fun findAllByMeeting(meeting: SetlistMeeting): List<SetlistItem>
+}

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistItemRepositoryCustom.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistItemRepositoryCustom.kt
@@ -1,0 +1,13 @@
+package com.bandage.v1.domain.setlist.repository
+
+import com.bandage.v1.domain.setlist.model.SetlistItem
+import com.bandage.v1.global.common.response.CursorResponse
+import java.util.UUID
+
+interface SetlistItemRepositoryCustom {
+    fun findAllByMeetingAndPaging(
+        meetingId: UUID,
+        lastId: UUID?,
+        pageSize: Int,
+    ): CursorResponse<SetlistItem, UUID>
+}

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistItemRepositoryImpl.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistItemRepositoryImpl.kt
@@ -1,0 +1,37 @@
+package com.bandage.v1.domain.setlist.repository
+
+import com.bandage.v1.domain.setlist.model.QSetlistItem
+import com.bandage.v1.domain.setlist.model.SetlistItem
+import com.bandage.v1.global.common.response.CursorResponse
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.impl.JPAQueryFactory
+import java.util.UUID
+
+class SetlistItemRepositoryImpl(
+    private val queryFactory: JPAQueryFactory,
+) : SetlistItemRepositoryCustom {
+    override fun findAllByMeetingAndPaging(
+        meetingId: UUID,
+        lastId: UUID?,
+        pageSize: Int,
+    ): CursorResponse<SetlistItem, UUID> {
+        val qItem = QSetlistItem.setlistItem
+
+        val contents =
+            queryFactory
+                .selectFrom(qItem)
+                .where(qItem.meeting.id.eq(meetingId))
+                .where(ltItemId(lastId))
+                .orderBy(qItem.id.asc())
+                .limit(pageSize.toLong() + 1)
+                .fetch()
+
+        val hasNext = contents.size > pageSize
+        val resultContents = if (hasNext) contents.dropLast(1) else contents
+        val nextCursor = if (hasNext) resultContents.lastOrNull()?.id else null
+
+        return CursorResponse(content = resultContents, nextCursor = nextCursor, hasNext = hasNext)
+    }
+
+    private fun ltItemId(lastId: UUID?): BooleanExpression? = lastId?.let { QSetlistItem.setlistItem.id.gt(it) }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistMeetingMemberRepository.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistMeetingMemberRepository.kt
@@ -1,0 +1,21 @@
+package com.bandage.v1.domain.setlist.repository
+
+import com.bandage.v1.domain.setlist.model.SetlistMeeting
+import com.bandage.v1.domain.setlist.model.SetlistMeetingMember
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface SetlistMeetingMemberRepository : JpaRepository<SetlistMeetingMember, UUID> {
+    fun findAllByMeeting(meeting: SetlistMeeting): List<SetlistMeetingMember>
+
+    fun findAllByMeetingId(meetingId: UUID): List<SetlistMeetingMember>
+
+    fun existsByMeetingAndMemberId(
+        meeting: SetlistMeeting,
+        memberId: Long,
+    ): Boolean
+
+    fun deleteByMeeting(meeting: SetlistMeeting)
+}

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistMeetingRepository.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistMeetingRepository.kt
@@ -1,0 +1,13 @@
+package com.bandage.v1.domain.setlist.repository
+
+import com.bandage.v1.domain.setlist.model.SetlistMeeting
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface SetlistMeetingRepository :
+    JpaRepository<SetlistMeeting, UUID>,
+    SetlistMeetingRepositoryCustom {
+    fun existsByPerformanceIdAndLockedAtIsNull(performanceId: UUID): Boolean
+}

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistMeetingRepositoryCustom.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistMeetingRepositoryCustom.kt
@@ -1,0 +1,13 @@
+package com.bandage.v1.domain.setlist.repository
+
+import com.bandage.v1.domain.setlist.model.SetlistMeeting
+import com.bandage.v1.global.common.response.CursorResponse
+import java.util.UUID
+
+interface SetlistMeetingRepositoryCustom {
+    fun findAllByMemberAndPaging(
+        memberId: Long,
+        lastId: UUID?,
+        pageSize: Int,
+    ): CursorResponse<SetlistMeeting, UUID>
+}

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistMeetingRepositoryImpl.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistMeetingRepositoryImpl.kt
@@ -1,0 +1,42 @@
+package com.bandage.v1.domain.setlist.repository
+
+import com.bandage.v1.domain.setlist.model.QSetlistMeeting
+import com.bandage.v1.domain.setlist.model.QSetlistMeetingMember
+import com.bandage.v1.domain.setlist.model.SetlistMeeting
+import com.bandage.v1.global.common.response.CursorResponse
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.impl.JPAQueryFactory
+import java.util.UUID
+
+class SetlistMeetingRepositoryImpl(
+    private val queryFactory: JPAQueryFactory,
+) : SetlistMeetingRepositoryCustom {
+    override fun findAllByMemberAndPaging(
+        memberId: Long,
+        lastId: UUID?,
+        pageSize: Int,
+    ): CursorResponse<SetlistMeeting, UUID> {
+        val qMeeting = QSetlistMeeting.setlistMeeting
+        val qMember = QSetlistMeetingMember.setlistMeetingMember
+
+        val contents =
+            queryFactory
+                .selectFrom(qMeeting)
+                .join(qMember)
+                .on(qMember.meeting.eq(qMeeting))
+                .where(qMember.memberId.eq(memberId))
+                .where(ltMeetingId(lastId))
+                .orderBy(qMeeting.id.desc())
+                .distinct()
+                .limit(pageSize.toLong() + 1)
+                .fetch()
+
+        val hasNext = contents.size > pageSize
+        val resultContents = if (hasNext) contents.dropLast(1) else contents
+        val nextCursor = if (hasNext) resultContents.lastOrNull()?.id else null
+
+        return CursorResponse(content = resultContents, nextCursor = nextCursor, hasNext = hasNext)
+    }
+
+    private fun ltMeetingId(lastId: UUID?): BooleanExpression? = lastId?.let { QSetlistMeeting.setlistMeeting.id.lt(it) }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/service/SetlistMeetingService.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/service/SetlistMeetingService.kt
@@ -1,0 +1,443 @@
+package com.bandage.v1.domain.setlist.service
+
+import com.bandage.v1.domain.setlist.dto.req.SetlistChatMessageCreateRequest
+import com.bandage.v1.domain.setlist.dto.req.SetlistConfirmationUpdateRequest
+import com.bandage.v1.domain.setlist.dto.req.SetlistItemCreateRequest
+import com.bandage.v1.domain.setlist.dto.req.SetlistItemPagingQuery
+import com.bandage.v1.domain.setlist.dto.req.SetlistItemUpdateRequest
+import com.bandage.v1.domain.setlist.dto.req.SetlistMeetingCreateRequest
+import com.bandage.v1.domain.setlist.dto.req.SetlistMeetingPagingQuery
+import com.bandage.v1.domain.setlist.dto.req.SetlistMeetingUpdateRequest
+import com.bandage.v1.domain.setlist.dto.res.SetlistChatMessageResponse
+import com.bandage.v1.domain.setlist.dto.res.SetlistItemResponse
+import com.bandage.v1.domain.setlist.dto.res.SetlistLockResponse
+import com.bandage.v1.domain.setlist.dto.res.SetlistLockSongMapping
+import com.bandage.v1.domain.setlist.dto.res.SetlistMeetingDetailResponse
+import com.bandage.v1.domain.setlist.dto.res.SetlistMeetingResponse
+import com.bandage.v1.domain.setlist.model.SetlistItem
+import com.bandage.v1.domain.setlist.model.SetlistItemApplicant
+import com.bandage.v1.domain.setlist.model.SetlistItemChatMessage
+import com.bandage.v1.domain.setlist.model.SetlistItemConfirmation
+import com.bandage.v1.domain.setlist.model.SetlistMeeting
+import com.bandage.v1.domain.setlist.model.SetlistMeetingMember
+import com.bandage.v1.domain.setlist.model.enums.MeetingPurpose
+import com.bandage.v1.domain.setlist.repository.SetlistItemApplicantRepository
+import com.bandage.v1.domain.setlist.repository.SetlistItemChatMessageRepository
+import com.bandage.v1.domain.setlist.repository.SetlistItemConfirmationRepository
+import com.bandage.v1.domain.setlist.repository.SetlistItemRepository
+import com.bandage.v1.domain.setlist.repository.SetlistMeetingMemberRepository
+import com.bandage.v1.domain.setlist.repository.SetlistMeetingRepository
+import com.bandage.v1.global.common.response.CursorResponse
+import com.bandage.v1.global.error.errorcode.ErrorCode
+import com.bandage.v1.global.error.exception.BusinessException
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+@Transactional(readOnly = true)
+class SetlistMeetingService(
+    private val meetingRepository: SetlistMeetingRepository,
+    private val meetingMemberRepository: SetlistMeetingMemberRepository,
+    private val itemRepository: SetlistItemRepository,
+    private val applicantRepository: SetlistItemApplicantRepository,
+    private val confirmationRepository: SetlistItemConfirmationRepository,
+    private val chatMessageRepository: SetlistItemChatMessageRepository,
+) {
+    @Transactional
+    fun createMeeting(
+        memberId: Long,
+        request: SetlistMeetingCreateRequest,
+    ): SetlistMeetingResponse {
+        if (request.purpose == MeetingPurpose.PERFORMANCE) {
+            if (request.performanceId == null) throw BusinessException(ErrorCode.SETLIST_PERFORMANCE_REQUIRED)
+            if (meetingRepository.existsByPerformanceIdAndLockedAtIsNull(request.performanceId)) {
+                throw BusinessException(ErrorCode.SETLIST_PERFORMANCE_HAS_ACTIVE_MEETING)
+            }
+        }
+        val participantIds = (request.participantUserIds + request.managerId + memberId).toSet()
+        if (request.managerId !in participantIds) {
+            throw BusinessException(ErrorCode.SETLIST_MANAGER_NOT_PARTICIPANT)
+        }
+
+        val meeting =
+            meetingRepository.save(
+                SetlistMeeting.create(
+                    bandId = request.bandId,
+                    title = request.title,
+                    purpose = request.purpose,
+                    performanceId = request.performanceId,
+                    managerId = request.managerId,
+                ),
+            )
+        participantIds.forEach { uid ->
+            meetingMemberRepository.save(SetlistMeetingMember.create(meeting = meeting, memberId = uid))
+        }
+        return SetlistMeetingResponse.of(meeting)
+    }
+
+    fun getMeeting(
+        meetingId: UUID,
+        memberId: Long,
+    ): SetlistMeetingDetailResponse {
+        val meeting = getMeetingOrThrow(meetingId)
+        val members = meetingMemberRepository.findAllByMeeting(meeting)
+        validateAccess(meeting, members, memberId)
+        return SetlistMeetingDetailResponse.of(meeting, members.map { it.memberId })
+    }
+
+    fun getMyMeetings(
+        memberId: Long,
+        query: SetlistMeetingPagingQuery,
+    ): CursorResponse<SetlistMeetingResponse, UUID> {
+        val result = meetingRepository.findAllByMemberAndPaging(memberId, query.lastId, query.pageSize)
+        return CursorResponse(
+            content = result.content.map { SetlistMeetingResponse.of(it) },
+            nextCursor = result.nextCursor,
+            hasNext = result.hasNext,
+        )
+    }
+
+    @Transactional
+    fun updateMeeting(
+        meetingId: UUID,
+        memberId: Long,
+        request: SetlistMeetingUpdateRequest,
+    ): SetlistMeetingResponse {
+        val meeting = getMeetingOrThrow(meetingId)
+        validateManager(meeting, memberId)
+        request.title?.let { meeting.updateTitle(it) }
+        request.managerId?.let { newManagerId ->
+            val members = meetingMemberRepository.findAllByMeeting(meeting)
+            if (members.none { it.memberId == newManagerId }) {
+                throw BusinessException(ErrorCode.SETLIST_MANAGER_NOT_PARTICIPANT)
+            }
+            meeting.changeManager(newManagerId)
+        }
+        return SetlistMeetingResponse.of(meeting)
+    }
+
+    @Transactional
+    fun deleteMeeting(
+        meetingId: UUID,
+        memberId: Long,
+    ) {
+        val meeting = getMeetingOrThrow(meetingId)
+        validateManager(meeting, memberId)
+        meeting.markAsDeleted(memberId)
+    }
+
+    // -------- items --------
+    @Transactional
+    fun createItem(
+        meetingId: UUID,
+        memberId: Long,
+        request: SetlistItemCreateRequest,
+    ): SetlistItemResponse {
+        val meeting = getMeetingOrThrow(meetingId)
+        validateAccess(meeting, memberId)
+        if (meeting.isLocked) throw BusinessException(ErrorCode.SETLIST_MEETING_LOCKED)
+
+        val item =
+            itemRepository.save(
+                SetlistItem.create(
+                    meeting = meeting,
+                    title = request.title,
+                    artist = request.artist,
+                    album = request.album,
+                    duration = request.duration,
+                    proposerId = memberId,
+                    note = request.note,
+                    sessions = request.sessions.map { it.toEntity() },
+                ),
+            )
+        return SetlistItemResponse.of(item, emptyList(), emptyList())
+    }
+
+    fun getItems(
+        meetingId: UUID,
+        memberId: Long,
+        query: SetlistItemPagingQuery,
+    ): CursorResponse<SetlistItemResponse, UUID> {
+        val meeting = getMeetingOrThrow(meetingId)
+        validateAccess(meeting, memberId)
+        val result = itemRepository.findAllByMeetingAndPaging(meetingId, query.lastId, query.pageSize)
+        if (result.content.isEmpty()) {
+            return CursorResponse(content = emptyList(), nextCursor = null, hasNext = false)
+        }
+        val applicants = applicantRepository.findAllByItemIn(result.content).groupBy { it.item.id }
+        val confirmations = confirmationRepository.findAllByItemIn(result.content).groupBy { it.item.id }
+        val content =
+            result.content.map { item ->
+                SetlistItemResponse.of(
+                    item = item,
+                    applicants = applicants[item.id] ?: emptyList(),
+                    confirmations = confirmations[item.id] ?: emptyList(),
+                )
+            }
+        return CursorResponse(content = content, nextCursor = result.nextCursor, hasNext = result.hasNext)
+    }
+
+    fun getItem(
+        meetingId: UUID,
+        itemId: UUID,
+        memberId: Long,
+    ): SetlistItemResponse {
+        val meeting = getMeetingOrThrow(meetingId)
+        validateAccess(meeting, memberId)
+        val item = getItemOrThrow(meeting, itemId)
+        return SetlistItemResponse.of(
+            item = item,
+            applicants = applicantRepository.findAllByItem(item),
+            confirmations = confirmationRepository.findAllByItem(item),
+        )
+    }
+
+    @Transactional
+    fun updateItem(
+        meetingId: UUID,
+        itemId: UUID,
+        memberId: Long,
+        request: SetlistItemUpdateRequest,
+    ): SetlistItemResponse {
+        val meeting = getMeetingOrThrow(meetingId)
+        validateAccess(meeting, memberId)
+        if (meeting.isLocked) throw BusinessException(ErrorCode.SETLIST_MEETING_LOCKED)
+        val item = getItemOrThrow(meeting, itemId)
+        if (item.proposerId != memberId && meeting.managerId != memberId) {
+            throw BusinessException(ErrorCode.SETLIST_ITEM_FORBIDDEN)
+        }
+        item.updateMeta(request.title, request.artist, request.album, request.duration, request.note)
+        request.sessions?.let { sessions ->
+            val newDefs = sessions.map { it.toEntity() }
+            val newSessionIds = newDefs.map { it.sessionId }.toSet()
+            // cascade — 제거된 세션의 applicant/confirmation 정리
+            val applicants = applicantRepository.findAllByItem(item)
+            val confirmations = confirmationRepository.findAllByItem(item)
+            applicants.filter { it.sessionId !in newSessionIds }.forEach { applicantRepository.delete(it) }
+            confirmations.filter { it.sessionId !in newSessionIds }.forEach { confirmationRepository.delete(it) }
+            item.replaceSessions(newDefs)
+        }
+        return SetlistItemResponse.of(
+            item = item,
+            applicants = applicantRepository.findAllByItem(item),
+            confirmations = confirmationRepository.findAllByItem(item),
+        )
+    }
+
+    @Transactional
+    fun deleteItem(
+        meetingId: UUID,
+        itemId: UUID,
+        memberId: Long,
+    ) {
+        val meeting = getMeetingOrThrow(meetingId)
+        validateAccess(meeting, memberId)
+        if (meeting.isLocked) throw BusinessException(ErrorCode.SETLIST_MEETING_LOCKED)
+        val item = getItemOrThrow(meeting, itemId)
+        if (item.proposerId != memberId && meeting.managerId != memberId) {
+            throw BusinessException(ErrorCode.SETLIST_ITEM_FORBIDDEN)
+        }
+        item.markAsDeleted(memberId)
+    }
+
+    // -------- applicants --------
+    @Transactional
+    fun applyForSession(
+        meetingId: UUID,
+        itemId: UUID,
+        sessionId: String,
+        memberId: Long,
+    ) {
+        val meeting = getMeetingOrThrow(meetingId)
+        validateAccess(meeting, memberId)
+        val item = getItemOrThrow(meeting, itemId)
+        validateSessionExists(item, sessionId)
+        if (applicantRepository.existsByItemAndSessionIdAndMemberId(item, sessionId, memberId)) return
+        applicantRepository.save(SetlistItemApplicant.create(item = item, sessionId = sessionId, memberId = memberId))
+    }
+
+    @Transactional
+    fun withdrawSessionApplication(
+        meetingId: UUID,
+        itemId: UUID,
+        sessionId: String,
+        targetMemberId: Long,
+        memberId: Long,
+    ) {
+        if (targetMemberId != memberId) {
+            throw BusinessException(ErrorCode.SETLIST_ITEM_FORBIDDEN)
+        }
+        val meeting = getMeetingOrThrow(meetingId)
+        validateAccess(meeting, memberId)
+        val item = getItemOrThrow(meeting, itemId)
+        applicantRepository.findByItemAndSessionIdAndMemberId(item, sessionId, memberId)?.let {
+            applicantRepository.delete(it)
+        }
+        // cascade — 확정도 함께 제거
+        confirmationRepository.findByItemAndSessionIdAndMemberId(item, sessionId, memberId)?.let {
+            confirmationRepository.delete(it)
+        }
+    }
+
+    // -------- confirmations --------
+    @Transactional
+    fun updateConfirmations(
+        meetingId: UUID,
+        itemId: UUID,
+        sessionId: String,
+        memberId: Long,
+        request: SetlistConfirmationUpdateRequest,
+    ): SetlistItemResponse {
+        val meeting = getMeetingOrThrow(meetingId)
+        validateManager(meeting, memberId)
+        val item = getItemOrThrow(meeting, itemId)
+        val sessionDef =
+            item.sessions.firstOrNull { it.sessionId == sessionId }
+                ?: throw BusinessException(ErrorCode.SETLIST_ITEM_SESSION_NOT_FOUND)
+
+        request.unconfirm.forEach { uid ->
+            confirmationRepository.findByItemAndSessionIdAndMemberId(item, sessionId, uid)?.let {
+                confirmationRepository.delete(it)
+            }
+        }
+        val currentCount = confirmationRepository.countByItemAndSessionId(item, sessionId).toInt()
+        val toAdd =
+            request.confirm.filter { uid ->
+                confirmationRepository.findByItemAndSessionIdAndMemberId(item, sessionId, uid) == null
+            }
+        if (currentCount + toAdd.size > sessionDef.need) {
+            throw BusinessException(ErrorCode.SETLIST_ITEM_SESSION_FULL)
+        }
+        toAdd.forEach { uid ->
+            confirmationRepository.save(
+                SetlistItemConfirmation.create(item = item, sessionId = sessionId, memberId = uid, confirmedBy = memberId),
+            )
+        }
+        return SetlistItemResponse.of(
+            item = item,
+            applicants = applicantRepository.findAllByItem(item),
+            confirmations = confirmationRepository.findAllByItem(item),
+        )
+    }
+
+    // -------- chat --------
+    fun getChatMessages(
+        meetingId: UUID,
+        itemId: UUID,
+        memberId: Long,
+        lastId: UUID?,
+        pageSize: Int,
+    ): CursorResponse<SetlistChatMessageResponse, UUID> {
+        val meeting = getMeetingOrThrow(meetingId)
+        validateAccess(meeting, memberId)
+        val item = getItemOrThrow(meeting, itemId)
+        val result = chatMessageRepository.findAllByItemAndPaging(item.id, lastId, pageSize)
+        return CursorResponse(
+            content = result.content.map { SetlistChatMessageResponse.of(it) },
+            nextCursor = result.nextCursor,
+            hasNext = result.hasNext,
+        )
+    }
+
+    @Transactional
+    fun createChatMessage(
+        meetingId: UUID,
+        itemId: UUID,
+        memberId: Long,
+        request: SetlistChatMessageCreateRequest,
+    ): SetlistChatMessageResponse {
+        val meeting = getMeetingOrThrow(meetingId)
+        validateAccess(meeting, memberId)
+        val item = getItemOrThrow(meeting, itemId)
+        val msg =
+            chatMessageRepository.save(
+                SetlistItemChatMessage.create(item = item, memberId = memberId, message = request.message),
+            )
+        return SetlistChatMessageResponse.of(msg)
+    }
+
+    // -------- lock / unlock --------
+    @Transactional
+    fun lockMeeting(
+        meetingId: UUID,
+        memberId: Long,
+    ): SetlistLockResponse {
+        val meeting = getMeetingOrThrow(meetingId)
+        validateManager(meeting, memberId)
+        if (meeting.isLocked) throw BusinessException(ErrorCode.SETLIST_MEETING_LOCKED)
+        meeting.lock()
+        // TODO: PracticeSong 벌크 생성 + Performance.setlist 자동 등록 (cross-domain)
+        val items = itemRepository.findAllByMeeting(meeting)
+        return SetlistLockResponse(
+            lockedAt = meeting.lockedAt!!,
+            songs = items.map { SetlistLockSongMapping(setlistItemId = it.id, practiceSongId = it.practiceSongId) },
+        )
+    }
+
+    @Transactional
+    fun unlockMeeting(
+        meetingId: UUID,
+        memberId: Long,
+    ): SetlistMeetingResponse {
+        val meeting = getMeetingOrThrow(meetingId)
+        validateManager(meeting, memberId)
+        if (!meeting.isLocked) throw BusinessException(ErrorCode.SETLIST_MEETING_NOT_LOCKED)
+        meeting.unlock()
+        return SetlistMeetingResponse.of(meeting)
+    }
+
+    // -------- internal --------
+    private fun getMeetingOrThrow(meetingId: UUID): SetlistMeeting =
+        meetingRepository.findByIdOrNull(meetingId)
+            ?: throw BusinessException(ErrorCode.SETLIST_MEETING_NOT_FOUND)
+
+    private fun getItemOrThrow(
+        meeting: SetlistMeeting,
+        itemId: UUID,
+    ): SetlistItem {
+        val item =
+            itemRepository.findByIdOrNull(itemId)
+                ?: throw BusinessException(ErrorCode.SETLIST_ITEM_NOT_FOUND)
+        if (item.meeting.id != meeting.id) throw BusinessException(ErrorCode.SETLIST_ITEM_NOT_FOUND)
+        return item
+    }
+
+    private fun validateAccess(
+        meeting: SetlistMeeting,
+        memberId: Long,
+    ) {
+        if (meeting.managerId == memberId) return
+        if (!meetingMemberRepository.existsByMeetingAndMemberId(meeting, memberId)) {
+            throw BusinessException(ErrorCode.SETLIST_MEETING_FORBIDDEN)
+        }
+    }
+
+    private fun validateAccess(
+        meeting: SetlistMeeting,
+        members: List<SetlistMeetingMember>,
+        memberId: Long,
+    ) {
+        if (meeting.managerId == memberId) return
+        if (members.none { it.memberId == memberId }) {
+            throw BusinessException(ErrorCode.SETLIST_MEETING_FORBIDDEN)
+        }
+    }
+
+    private fun validateManager(
+        meeting: SetlistMeeting,
+        memberId: Long,
+    ) {
+        if (meeting.managerId != memberId) throw BusinessException(ErrorCode.SETLIST_MEETING_NOT_MANAGER)
+    }
+
+    private fun validateSessionExists(
+        item: SetlistItem,
+        sessionId: String,
+    ) {
+        if (item.sessions.none { it.sessionId == sessionId }) {
+            throw BusinessException(ErrorCode.SETLIST_ITEM_SESSION_NOT_FOUND)
+        }
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/global/error/errorcode/ErrorCode.kt
+++ b/src/main/kotlin/com/bandage/v1/global/error/errorcode/ErrorCode.kt
@@ -51,4 +51,19 @@ enum class ErrorCode(
     PERFORMANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 공연 정보를 찾을 수 없습니다."),
     NOT_A_PERFORMANCE_MANAGER(HttpStatus.FORBIDDEN, "공연 매니저만 수행할 수 있는 작업입니다."),
     PERFORMANCE_PRACTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "공연에 등록된 합주 정보를 찾을 수 없습니다."),
+
+    // setlist meeting
+    SETLIST_MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 선곡 회의 정보를 찾을 수 없습니다."),
+    SETLIST_MEETING_FORBIDDEN(HttpStatus.FORBIDDEN, "선곡 회의에 접근할 권한이 없습니다."),
+    SETLIST_MEETING_NOT_MANAGER(HttpStatus.FORBIDDEN, "선곡 회의 매니저만 수행할 수 있는 작업입니다."),
+    SETLIST_MEETING_LOCKED(HttpStatus.CONFLICT, "잠금 상태의 선곡 회의입니다."),
+    SETLIST_MEETING_NOT_LOCKED(HttpStatus.CONFLICT, "잠금 상태가 아닌 선곡 회의입니다."),
+    SETLIST_MANAGER_NOT_PARTICIPANT(HttpStatus.BAD_REQUEST, "매니저는 참여 멤버에 포함되어야 합니다."),
+    SETLIST_PERFORMANCE_REQUIRED(HttpStatus.BAD_REQUEST, "공연 모드 회의에는 performanceId가 필요합니다."),
+    SETLIST_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 선곡 항목 정보를 찾을 수 없습니다."),
+    SETLIST_ITEM_FORBIDDEN(HttpStatus.FORBIDDEN, "선곡 항목을 수정할 권한이 없습니다."),
+    SETLIST_ITEM_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 선곡 항목 세션을 찾을 수 없습니다."),
+    SETLIST_ITEM_SESSION_FULL(HttpStatus.BAD_REQUEST, "세션 정원을 초과했습니다."),
+    SETLIST_CHAT_MESSAGE_TOO_LONG(HttpStatus.BAD_REQUEST, "채팅 메시지는 500자를 초과할 수 없습니다."),
+    SETLIST_PERFORMANCE_HAS_ACTIVE_MEETING(HttpStatus.CONFLICT, "해당 공연에는 이미 활성 선곡 회의가 존재합니다."),
 }


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #65

📌 **작업 내용 및 특이사항**

선곡 회의(Setlist Meeting) 도메인을 신규 구현합니다. `API_REQUIRED_2.md` 의 Phase 1 범위(§1-3-1~17, §7) 전체.

### 모델 (fbb1e35)
- `SetlistMeeting` 애그리거트 루트 (UUIDv7, lock/unlock 상태)
- `SetlistMeetingMember` 참여 멤버 매핑 (meeting_id + member_id unique)
- `SetlistItem`(곡) + `SessionDef`(@ElementCollection 으로 세션 정의)
- `SetlistItemApplicant` / `SetlistItemConfirmation`: (item, sessionId, member) 단위 unique 제약
- `SetlistItemChatMessage`: 곡별 채팅 (500자 제한)
- `MeetingPurpose` enum (PERFORMANCE / GENERAL)
- ErrorCode 에 setlist 도메인 에러 코드 추가

### API (c923487)
- `SetlistMeetingService` + `SetlistMeetingController`: `/api/v1/setlist-meetings` 하위 18개 엔드포인트
  - 회의 CRUD (§1-3-1~5)
  - 선곡 항목(Item) CRUD + 세션 cascade 정리 (§1-3-6~10)
  - 세션 지원/철회 (§1-3-11~12), 세션 확정/해제 매니저 권한 (§1-3-13)
  - 곡별 채팅 커서 페이징 + 작성 (§1-3-14~15)
  - 회의 잠금/잠금 해제 — 매니저 권한, 상태 전이 (§1-3-16~17)
- QueryDSL 커서 기반 페이징 Repository (SetlistMeeting / Item / ChatMessage)
- 권한 검증: 매니저, 참여 멤버, 곡 제안자 + 잠금 상태 차단

### 문서 (040fd5a)
- API_SPEC.md §7 추가

📚 **참고사항**

- 잠금 시 합주곡 벌크 생성 / Performance.setlist 자동 등록은 cross-domain 작업으로 별도 이슈 #67 에서 처리합니다.
- 본 PR 머지 후 #67 / #68 / #69 PR 이 순차로 develop 에 머지될 예정입니다.