### PR TITLE
feat: 선곡 회의 참여자 변경 API (FE-API-065)

### DIFF
--- a/src/main/kotlin/com/bandage/v1/domain/setlist/controller/SetlistMeetingController.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/controller/SetlistMeetingController.kt
@@ -8,6 +8,7 @@ import com.bandage.v1.domain.setlist.dto.req.SetlistItemUpdateRequest
 import com.bandage.v1.domain.setlist.dto.req.SetlistMeetingCreateRequest
 import com.bandage.v1.domain.setlist.dto.req.SetlistMeetingPagingQuery
 import com.bandage.v1.domain.setlist.dto.req.SetlistMeetingUpdateRequest
+import com.bandage.v1.domain.setlist.dto.req.SetlistParticipantsUpdateRequest
 import com.bandage.v1.domain.setlist.dto.res.SetlistChatMessageResponse
 import com.bandage.v1.domain.setlist.dto.res.SetlistItemResponse
 import com.bandage.v1.domain.setlist.dto.res.SetlistLockResponse
@@ -78,6 +79,15 @@ class SetlistMeetingController(
         setlistMeetingService.deleteMeeting(meetingId, memberId)
         return ApiResponse.success()
     }
+
+    @PatchMapping("/{meetingId}/participants")
+    @Operation(summary = "선곡 회의 참여자 변경", description = "매니저가 참여자를 추가/제거합니다. remove 멤버의 세션 지원/확정은 cascade 정리됩니다.")
+    fun updateParticipants(
+        @PathVariable meetingId: UUID,
+        @CurrentMemberId memberId: Long,
+        @Valid @RequestBody request: SetlistParticipantsUpdateRequest,
+    ): ApiResponse<SetlistMeetingDetailResponse> =
+        ApiResponse.success(setlistMeetingService.updateParticipants(meetingId, memberId, request))
 
     // -------- items --------
     @GetMapping("/{meetingId}/items")

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/dto/req/SetlistParticipantsUpdateRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/dto/req/SetlistParticipantsUpdateRequest.kt
@@ -1,0 +1,11 @@
+package com.bandage.v1.domain.setlist.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "선곡 회의 참여자 변경 요청")
+data class SetlistParticipantsUpdateRequest(
+    @Schema(description = "추가할 회원 ID 목록", example = "[1, 2, 3]")
+    val add: List<Long> = emptyList(),
+    @Schema(description = "제거할 회원 ID 목록", example = "[4, 5]")
+    val remove: List<Long> = emptyList(),
+)

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistItemApplicantRepository.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistItemApplicantRepository.kt
@@ -23,4 +23,9 @@ interface SetlistItemApplicantRepository : JpaRepository<SetlistItemApplicant, U
         sessionId: String,
         memberId: Long,
     ): Boolean
+
+    fun deleteAllByItemInAndMemberId(
+        items: List<SetlistItem>,
+        memberId: Long,
+    )
 }

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistItemConfirmationRepository.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistItemConfirmationRepository.kt
@@ -22,4 +22,9 @@ interface SetlistItemConfirmationRepository : JpaRepository<SetlistItemConfirmat
         item: SetlistItem,
         sessionId: String,
     ): Long
+
+    fun deleteAllByItemInAndMemberId(
+        items: List<SetlistItem>,
+        memberId: Long,
+    )
 }

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistMeetingMemberRepository.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistMeetingMemberRepository.kt
@@ -18,4 +18,9 @@ interface SetlistMeetingMemberRepository : JpaRepository<SetlistMeetingMember, U
     ): Boolean
 
     fun deleteByMeeting(meeting: SetlistMeeting)
+
+    fun findByMeetingAndMemberId(
+        meeting: SetlistMeeting,
+        memberId: Long,
+    ): SetlistMeetingMember?
 }

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/service/SetlistMeetingService.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/service/SetlistMeetingService.kt
@@ -8,6 +8,7 @@ import com.bandage.v1.domain.setlist.dto.req.SetlistItemUpdateRequest
 import com.bandage.v1.domain.setlist.dto.req.SetlistMeetingCreateRequest
 import com.bandage.v1.domain.setlist.dto.req.SetlistMeetingPagingQuery
 import com.bandage.v1.domain.setlist.dto.req.SetlistMeetingUpdateRequest
+import com.bandage.v1.domain.setlist.dto.req.SetlistParticipantsUpdateRequest
 import com.bandage.v1.domain.setlist.dto.res.SetlistChatMessageResponse
 import com.bandage.v1.domain.setlist.dto.res.SetlistItemResponse
 import com.bandage.v1.domain.setlist.dto.res.SetlistLockResponse
@@ -126,6 +127,47 @@ class SetlistMeetingService(
         val meeting = getMeetingOrThrow(meetingId)
         validateManager(meeting, memberId)
         meeting.markAsDeleted(memberId)
+    }
+
+    @Transactional
+    fun updateParticipants(
+        meetingId: UUID,
+        memberId: Long,
+        request: SetlistParticipantsUpdateRequest,
+    ): SetlistMeetingDetailResponse {
+        val meeting = getMeetingOrThrow(meetingId)
+        validateManager(meeting, memberId)
+
+        val addIds = request.add.toSet()
+        val removeIds = request.remove.toSet()
+        if (meeting.managerId in removeIds) {
+            throw BusinessException(ErrorCode.SETLIST_CANNOT_REMOVE_MANAGER)
+        }
+        val intersection = addIds intersect removeIds
+        if (intersection.isNotEmpty()) {
+            throw BusinessException(ErrorCode.SETLIST_MANAGER_NOT_PARTICIPANT)
+        }
+
+        // remove cascade: applicants/confirmations
+        if (removeIds.isNotEmpty()) {
+            val items = itemRepository.findAllByMeeting(meeting)
+            removeIds.forEach { uid ->
+                meetingMemberRepository.findByMeetingAndMemberId(meeting, uid)?.let { meetingMemberRepository.delete(it) }
+                if (items.isNotEmpty()) {
+                    applicantRepository.deleteAllByItemInAndMemberId(items, uid)
+                    confirmationRepository.deleteAllByItemInAndMemberId(items, uid)
+                }
+            }
+        }
+        // add (idempotent)
+        addIds.forEach { uid ->
+            if (!meetingMemberRepository.existsByMeetingAndMemberId(meeting, uid)) {
+                meetingMemberRepository.save(SetlistMeetingMember.create(meeting = meeting, memberId = uid))
+            }
+        }
+
+        val members = meetingMemberRepository.findAllByMeeting(meeting)
+        return SetlistMeetingDetailResponse.of(meeting, members.map { it.memberId })
     }
 
     // -------- items --------

--- a/src/main/kotlin/com/bandage/v1/global/error/errorcode/ErrorCode.kt
+++ b/src/main/kotlin/com/bandage/v1/global/error/errorcode/ErrorCode.kt
@@ -66,4 +66,5 @@ enum class ErrorCode(
     SETLIST_ITEM_SESSION_FULL(HttpStatus.BAD_REQUEST, "세션 정원을 초과했습니다."),
     SETLIST_CHAT_MESSAGE_TOO_LONG(HttpStatus.BAD_REQUEST, "채팅 메시지는 500자를 초과할 수 없습니다."),
     SETLIST_PERFORMANCE_HAS_ACTIVE_MEETING(HttpStatus.CONFLICT, "해당 공연에는 이미 활성 선곡 회의가 존재합니다."),
+    SETLIST_CANNOT_REMOVE_MANAGER(HttpStatus.BAD_REQUEST, "매니저는 회의 참여자에서 제거할 수 없습니다."),
 }


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #69

📌 **작업 내용 및 특이사항**

`API_REQUIRED_0502.md` §3-3 (FE-API-065) 대응. 회의 참여자를 사후에 추가/제거하는 API.

### 변경 사항
- `PATCH /api/v1/setlist-meetings/{meetingId}/participants` 신규 엔드포인트 (매니저 권한)
- `SetlistParticipantsUpdateRequest { add: List<Long>, remove: List<Long> }` DTO 추가
- `SetlistMeetingService.updateParticipants`
  - add: 멤버 upsert (idempotent)
  - remove: 멤버 제거 + cascade
    - `SetlistItemApplicant` 일괄 제거
    - `SetlistItemConfirmation` 일괄 제거
  - 매니저 제거 차단 → `SETLIST_CANNOT_REMOVE_MANAGER`
  - add ∩ remove 교집합 차단
- Repository 메서드 추가
  - `SetlistMeetingMemberRepository.findByMeetingAndMemberId`
  - `SetlistItemApplicantRepository.deleteAllByItemInAndMemberId`
  - `SetlistItemConfirmationRepository.deleteAllByItemInAndMemberId`
- 응답: 갱신된 `SetlistMeetingDetailResponse`

### 결정 필요 (이슈 본문 참고)
- 잠금된 회의에서 참여자 변경 허용 여부 — 현재 허용으로 구현됨

📚 **참고사항**
- `API_REQUIRED_0502.md` §3 FE-API-065
- (Schedule_Coordination 도메인 도입 시) `MemberSchedule` 도 cascade 대상 — 별도 이슈에서 처리