### PR TITLE
feat: 선곡 회의 practiceWindow 필드 추가 (FE-API-063)

### DIFF
--- a/src/main/kotlin/com/bandage/v1/domain/setlist/dto/PracticeWindowDto.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/dto/PracticeWindowDto.kt
@@ -1,0 +1,25 @@
+package com.bandage.v1.domain.setlist.dto
+
+import com.bandage.v1.domain.setlist.model.PracticeWindow
+import com.fasterxml.jackson.annotation.JsonFormat
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDate
+
+@Schema(description = "선곡 회의 합주 가능 기간")
+data class PracticeWindowDto(
+    @field:NotNull
+    @JsonFormat(pattern = "yyyy-MM-dd", shape = JsonFormat.Shape.STRING)
+    @Schema(description = "기간 시작일", example = "2026-05-02")
+    val from: LocalDate,
+    @field:NotNull
+    @JsonFormat(pattern = "yyyy-MM-dd", shape = JsonFormat.Shape.STRING)
+    @Schema(description = "기간 종료일 (포함)", example = "2026-05-15")
+    val to: LocalDate,
+) {
+    fun toEntity(): PracticeWindow = PracticeWindow(from = from, to = to)
+
+    companion object {
+        fun of(window: PracticeWindow): PracticeWindowDto = PracticeWindowDto(from = window.from, to = window.to)
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/dto/req/SetlistMeetingCreateRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/dto/req/SetlistMeetingCreateRequest.kt
@@ -1,7 +1,9 @@
 package com.bandage.v1.domain.setlist.dto.req
 
+import com.bandage.v1.domain.setlist.dto.PracticeWindowDto
 import com.bandage.v1.domain.setlist.model.enums.MeetingPurpose
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 import java.util.UUID
@@ -24,4 +26,11 @@ data class SetlistMeetingCreateRequest(
     val managerId: Long,
     @Schema(description = "참여자 회원 ID 목록 (매니저 포함)")
     val participantUserIds: List<Long> = emptyList(),
+    @field:Valid
+    @Schema(
+        description =
+            "합주 가능 기간. purpose=GENERAL 일 때 필수, " +
+                "purpose=PERFORMANCE 일 때는 무시(BE가 today~performance.startAt-1d 로 자동 산출)",
+    )
+    val practiceWindow: PracticeWindowDto? = null,
 )

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/dto/res/SetlistMeetingDetailResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/dto/res/SetlistMeetingDetailResponse.kt
@@ -1,5 +1,6 @@
 package com.bandage.v1.domain.setlist.dto.res
 
+import com.bandage.v1.domain.setlist.dto.PracticeWindowDto
 import com.bandage.v1.domain.setlist.model.SetlistMeeting
 import com.bandage.v1.domain.setlist.model.enums.MeetingPurpose
 import io.swagger.v3.oas.annotations.media.Schema
@@ -15,6 +16,7 @@ data class SetlistMeetingDetailResponse(
     val performanceId: UUID?,
     val managerId: Long,
     val participantUserIds: List<Long>,
+    val practiceWindow: PracticeWindowDto,
     val lockedAt: LocalDateTime?,
     val createdAt: LocalDateTime?,
     val updatedAt: LocalDateTime?,
@@ -32,6 +34,7 @@ data class SetlistMeetingDetailResponse(
                 performanceId = m.performanceId,
                 managerId = m.managerId,
                 participantUserIds = participantUserIds,
+                practiceWindow = PracticeWindowDto.of(m.practiceWindow),
                 lockedAt = m.lockedAt,
                 createdAt = m.createdAt,
                 updatedAt = m.lastModifiedAt,

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/dto/res/SetlistMeetingResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/dto/res/SetlistMeetingResponse.kt
@@ -1,5 +1,6 @@
 package com.bandage.v1.domain.setlist.dto.res
 
+import com.bandage.v1.domain.setlist.dto.PracticeWindowDto
 import com.bandage.v1.domain.setlist.model.SetlistMeeting
 import com.bandage.v1.domain.setlist.model.enums.MeetingPurpose
 import io.swagger.v3.oas.annotations.media.Schema
@@ -14,6 +15,7 @@ data class SetlistMeetingResponse(
     val purpose: MeetingPurpose,
     val performanceId: UUID?,
     val managerId: Long,
+    val practiceWindow: PracticeWindowDto,
     val lockedAt: LocalDateTime?,
     val createdAt: LocalDateTime?,
     val updatedAt: LocalDateTime?,
@@ -27,6 +29,7 @@ data class SetlistMeetingResponse(
                 purpose = m.purpose,
                 performanceId = m.performanceId,
                 managerId = m.managerId,
+                practiceWindow = PracticeWindowDto.of(m.practiceWindow),
                 lockedAt = m.lockedAt,
                 createdAt = m.createdAt,
                 updatedAt = m.lastModifiedAt,

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/model/PracticeWindow.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/model/PracticeWindow.kt
@@ -1,0 +1,17 @@
+package com.bandage.v1.domain.setlist.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import java.time.LocalDate
+
+@Embeddable
+data class PracticeWindow(
+    @Column(name = "practice_window_from", nullable = false)
+    val from: LocalDate,
+    @Column(name = "practice_window_to", nullable = false)
+    val to: LocalDate,
+) {
+    init {
+        require(!from.isAfter(to)) { "practiceWindow.from must be on or before practiceWindow.to" }
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/model/SetlistMeeting.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/model/SetlistMeeting.kt
@@ -3,6 +3,7 @@ package com.bandage.v1.domain.setlist.model
 import com.bandage.v1.domain.setlist.model.enums.MeetingPurpose
 import com.bandage.v1.global.common.domain.BaseEntity
 import jakarta.persistence.Column
+import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
@@ -22,6 +23,7 @@ open class SetlistMeeting(
     purpose: MeetingPurpose,
     performanceId: UUID?,
     managerId: Long,
+    practiceWindow: PracticeWindow,
 ) : BaseEntity() {
     @Id
     @Column(name = "meeting_id")
@@ -50,6 +52,10 @@ open class SetlistMeeting(
     var managerId: Long = managerId
         protected set
 
+    @Embedded
+    var practiceWindow: PracticeWindow = practiceWindow
+        protected set
+
     @Column(name = "locked_at", nullable = true)
     var lockedAt: LocalDateTime? = null
         protected set
@@ -63,6 +69,7 @@ open class SetlistMeeting(
             purpose: MeetingPurpose,
             performanceId: UUID?,
             managerId: Long,
+            practiceWindow: PracticeWindow,
         ): SetlistMeeting =
             SetlistMeeting(
                 bandId = bandId,
@@ -70,6 +77,7 @@ open class SetlistMeeting(
                 purpose = purpose,
                 performanceId = performanceId,
                 managerId = managerId,
+                practiceWindow = practiceWindow,
             )
     }
 

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/service/SetlistMeetingService.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/service/SetlistMeetingService.kt
@@ -1,5 +1,6 @@
 package com.bandage.v1.domain.setlist.service
 
+import com.bandage.v1.domain.performance.repository.PerformanceRepository
 import com.bandage.v1.domain.setlist.dto.req.SetlistChatMessageCreateRequest
 import com.bandage.v1.domain.setlist.dto.req.SetlistConfirmationUpdateRequest
 import com.bandage.v1.domain.setlist.dto.req.SetlistItemCreateRequest
@@ -15,6 +16,7 @@ import com.bandage.v1.domain.setlist.dto.res.SetlistLockResponse
 import com.bandage.v1.domain.setlist.dto.res.SetlistLockSongMapping
 import com.bandage.v1.domain.setlist.dto.res.SetlistMeetingDetailResponse
 import com.bandage.v1.domain.setlist.dto.res.SetlistMeetingResponse
+import com.bandage.v1.domain.setlist.model.PracticeWindow
 import com.bandage.v1.domain.setlist.model.SetlistItem
 import com.bandage.v1.domain.setlist.model.SetlistItemApplicant
 import com.bandage.v1.domain.setlist.model.SetlistItemChatMessage
@@ -34,6 +36,7 @@ import com.bandage.v1.global.error.exception.BusinessException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
 import java.util.UUID
 
 @Service
@@ -45,18 +48,14 @@ class SetlistMeetingService(
     private val applicantRepository: SetlistItemApplicantRepository,
     private val confirmationRepository: SetlistItemConfirmationRepository,
     private val chatMessageRepository: SetlistItemChatMessageRepository,
+    private val performanceRepository: PerformanceRepository,
 ) {
     @Transactional
     fun createMeeting(
         memberId: Long,
         request: SetlistMeetingCreateRequest,
     ): SetlistMeetingResponse {
-        if (request.purpose == MeetingPurpose.PERFORMANCE) {
-            if (request.performanceId == null) throw BusinessException(ErrorCode.SETLIST_PERFORMANCE_REQUIRED)
-            if (meetingRepository.existsByPerformanceIdAndLockedAtIsNull(request.performanceId)) {
-                throw BusinessException(ErrorCode.SETLIST_PERFORMANCE_HAS_ACTIVE_MEETING)
-            }
-        }
+        val practiceWindow = resolvePracticeWindow(request)
         val participantIds = (request.participantUserIds + request.managerId + memberId).toSet()
         if (request.managerId !in participantIds) {
             throw BusinessException(ErrorCode.SETLIST_MANAGER_NOT_PARTICIPANT)
@@ -70,6 +69,7 @@ class SetlistMeetingService(
                     purpose = request.purpose,
                     performanceId = request.performanceId,
                     managerId = request.managerId,
+                    practiceWindow = practiceWindow,
                 ),
             )
         participantIds.forEach { uid ->
@@ -481,5 +481,31 @@ class SetlistMeetingService(
         if (item.sessions.none { it.sessionId == sessionId }) {
             throw BusinessException(ErrorCode.SETLIST_ITEM_SESSION_NOT_FOUND)
         }
+    }
+
+    private fun resolvePracticeWindow(request: SetlistMeetingCreateRequest): PracticeWindow {
+        if (request.purpose == MeetingPurpose.PERFORMANCE) {
+            if (request.performanceId == null) throw BusinessException(ErrorCode.SETLIST_PERFORMANCE_REQUIRED)
+            if (meetingRepository.existsByPerformanceIdAndLockedAtIsNull(request.performanceId)) {
+                throw BusinessException(ErrorCode.SETLIST_PERFORMANCE_HAS_ACTIVE_MEETING)
+            }
+            val performance =
+                performanceRepository.findByIdOrNull(request.performanceId)
+                    ?: throw BusinessException(ErrorCode.PERFORMANCE_NOT_FOUND)
+            val from = LocalDate.now()
+            val to =
+                performance.schedule.startAt
+                    .toLocalDate()
+                    .minusDays(1)
+            if (from.isAfter(to)) throw BusinessException(ErrorCode.SETLIST_PRACTICE_WINDOW_INVALID)
+            return PracticeWindow(from = from, to = to)
+        }
+        val window =
+            request.practiceWindow
+                ?: throw BusinessException(ErrorCode.SETLIST_PRACTICE_WINDOW_REQUIRED)
+        if (window.from.isAfter(window.to)) {
+            throw BusinessException(ErrorCode.SETLIST_PRACTICE_WINDOW_INVALID)
+        }
+        return window.toEntity()
     }
 }

--- a/src/main/kotlin/com/bandage/v1/global/error/errorcode/ErrorCode.kt
+++ b/src/main/kotlin/com/bandage/v1/global/error/errorcode/ErrorCode.kt
@@ -67,4 +67,6 @@ enum class ErrorCode(
     SETLIST_CHAT_MESSAGE_TOO_LONG(HttpStatus.BAD_REQUEST, "채팅 메시지는 500자를 초과할 수 없습니다."),
     SETLIST_PERFORMANCE_HAS_ACTIVE_MEETING(HttpStatus.CONFLICT, "해당 공연에는 이미 활성 선곡 회의가 존재합니다."),
     SETLIST_CANNOT_REMOVE_MANAGER(HttpStatus.BAD_REQUEST, "매니저는 회의 참여자에서 제거할 수 없습니다."),
+    SETLIST_PRACTICE_WINDOW_REQUIRED(HttpStatus.BAD_REQUEST, "purpose=GENERAL 인 회의는 practiceWindow 가 필수입니다."),
+    SETLIST_PRACTICE_WINDOW_INVALID(HttpStatus.BAD_REQUEST, "practiceWindow.from 은 to 보다 같거나 이전이어야 합니다."),
 }


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #68

📌 **작업 내용 및 특이사항**

`API_REQUIRED_0502.md` §3-2 (FE-API-063) 대응. FE Meeting 모델이 사용하는 `practiceWindow: { from, to }` 를 BE 에 추가.

### 엔티티 / VO
- `PracticeWindow` 임베디드 VO (practice_window_from / to NOT NULL, from ≤ to 검증)
- `SetlistMeeting` 에 `@Embedded practiceWindow` 컬럼 + 팩토리 시그니처 확장

### DTO
- `PracticeWindowDto`: 요청/응답 공용 DTO (yyyy-MM-dd 직렬화)
- `SetlistMeetingCreateRequest` 에 `practiceWindow: PracticeWindowDto?` 옵셔널 필드 추가
- `SetlistMeetingResponse` / `SetlistMeetingDetailResponse` 응답에 `practiceWindow` 포함

### 서비스 로직 — `SetlistMeetingService.resolvePracticeWindow`
- `purpose=PERFORMANCE` → BE 가 `today ~ performance.startAt-1d` 자동 산출 (`PerformanceRepository` 의존)
- `purpose=GENERAL` → `request.practiceWindow` 필수, 미제공 시 `SETLIST_PRACTICE_WINDOW_REQUIRED`
- 두 케이스 모두 `from > to` 면 `SETLIST_PRACTICE_WINDOW_INVALID`

### ErrorCode
- `SETLIST_PRACTICE_WINDOW_REQUIRED`
- `SETLIST_PRACTICE_WINDOW_INVALID`

📚 **참고사항**
- `API_REQUIRED_0502.md` §3 FE-API-063
- 베이스 브랜치 #65 머지 후 develop 기준으로 rebase, ErrorCode.kt 충돌 1건 해소