### PR TITLE
feat: 선곡 회의 lock 크로스 도메인 — PracticeSong 벌크 생성/갱신 (FE-API-064)

### DIFF
--- a/src/main/kotlin/com/bandage/v1/domain/setlist/controller/SetlistMeetingController.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/controller/SetlistMeetingController.kt
@@ -15,6 +15,7 @@ import com.bandage.v1.domain.setlist.dto.res.SetlistLockResponse
 import com.bandage.v1.domain.setlist.dto.res.SetlistMeetingDetailResponse
 import com.bandage.v1.domain.setlist.dto.res.SetlistMeetingResponse
 import com.bandage.v1.domain.setlist.service.SetlistMeetingService
+import com.bandage.v1.facade.SetlistLockFacade
 import com.bandage.v1.global.common.constants.PathPrefix.PREFIX
 import com.bandage.v1.global.common.response.ApiResponse
 import com.bandage.v1.global.common.response.CursorResponse
@@ -40,6 +41,7 @@ import java.util.UUID
 @RequestMapping("$PREFIX/setlist-meetings")
 class SetlistMeetingController(
     private val setlistMeetingService: SetlistMeetingService,
+    private val setlistLockFacade: SetlistLockFacade,
 ) {
     @PostMapping
     @Operation(summary = "선곡 회의 생성", description = "선곡 회의를 생성합니다.")
@@ -196,11 +198,14 @@ class SetlistMeetingController(
 
     // -------- lock / unlock --------
     @PostMapping("/{meetingId}/lock")
-    @Operation(summary = "선곡 회의 잠금", description = "매니저가 선곡 회의를 잠금 처리합니다.")
+    @Operation(
+        summary = "선곡 회의 잠금",
+        description = "매니저가 선곡 회의를 잠금 처리합니다. 잠금 시 PracticeSong 을 항목별로 일괄 생성/갱신합니다.",
+    )
     fun lockMeeting(
         @PathVariable meetingId: UUID,
         @CurrentMemberId memberId: Long,
-    ): ApiResponse<SetlistLockResponse> = ApiResponse.success(setlistMeetingService.lockMeeting(meetingId, memberId))
+    ): ApiResponse<SetlistLockResponse> = ApiResponse.success(setlistLockFacade.lockMeeting(meetingId, memberId))
 
     @PostMapping("/{meetingId}/unlock")
     @Operation(summary = "선곡 회의 잠금 해제")

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/dto/res/SetlistLockResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/dto/res/SetlistLockResponse.kt
@@ -7,11 +7,25 @@ import java.util.UUID
 @Schema(description = "선곡 회의 잠금 응답")
 data class SetlistLockResponse(
     val lockedAt: LocalDateTime,
-    @Schema(description = "선곡 항목 - 합주곡 매핑")
+    @Schema(description = "선곡 항목 - 합주곡 매핑 (정상 잠금된 전체 곡)")
     val songs: List<SetlistLockSongMapping>,
+    @Schema(description = "곡별 itemId → practiceSongId 매핑 (편의 필드)")
+    val practiceSongMap: Map<UUID, UUID>,
+    @Schema(description = "재잠금 시 적용된 변경 내역")
+    val diff: SetlistLockDiff,
 )
 
 data class SetlistLockSongMapping(
     val setlistItemId: UUID,
     val practiceSongId: UUID?,
+)
+
+@Schema(description = "잠금 적용 변경 내역")
+data class SetlistLockDiff(
+    @Schema(description = "신규 생성된 합주곡 매핑")
+    val added: List<SetlistLockSongMapping>,
+    @Schema(description = "변경된 합주곡 매핑 (제목/아티스트/앨범/duration)")
+    val updated: List<SetlistLockSongMapping>,
+    @Schema(description = "이전 잠금에 있었으나 현재 항목에서 제거된 합주곡 매핑 (현 단계에서는 빈 배열 — 정책 미확정)")
+    val removed: List<SetlistLockSongMapping> = emptyList(),
 )

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/service/SetlistMeetingService.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/service/SetlistMeetingService.kt
@@ -12,8 +12,6 @@ import com.bandage.v1.domain.setlist.dto.req.SetlistMeetingUpdateRequest
 import com.bandage.v1.domain.setlist.dto.req.SetlistParticipantsUpdateRequest
 import com.bandage.v1.domain.setlist.dto.res.SetlistChatMessageResponse
 import com.bandage.v1.domain.setlist.dto.res.SetlistItemResponse
-import com.bandage.v1.domain.setlist.dto.res.SetlistLockResponse
-import com.bandage.v1.domain.setlist.dto.res.SetlistLockSongMapping
 import com.bandage.v1.domain.setlist.dto.res.SetlistMeetingDetailResponse
 import com.bandage.v1.domain.setlist.dto.res.SetlistMeetingResponse
 import com.bandage.v1.domain.setlist.model.PracticeWindow
@@ -400,23 +398,8 @@ class SetlistMeetingService(
         return SetlistChatMessageResponse.of(msg)
     }
 
-    // -------- lock / unlock --------
-    @Transactional
-    fun lockMeeting(
-        meetingId: UUID,
-        memberId: Long,
-    ): SetlistLockResponse {
-        val meeting = getMeetingOrThrow(meetingId)
-        validateManager(meeting, memberId)
-        if (meeting.isLocked) throw BusinessException(ErrorCode.SETLIST_MEETING_LOCKED)
-        meeting.lock()
-        // TODO: PracticeSong 벌크 생성 + Performance.setlist 자동 등록 (cross-domain)
-        val items = itemRepository.findAllByMeeting(meeting)
-        return SetlistLockResponse(
-            lockedAt = meeting.lockedAt!!,
-            songs = items.map { SetlistLockSongMapping(setlistItemId = it.id, practiceSongId = it.practiceSongId) },
-        )
-    }
+    // -------- unlock --------
+    // (lock 동작은 cross-domain 트랜잭션이 필요하여 com.bandage.v1.facade.SetlistLockFacade 로 이관됨)
 
     @Transactional
     fun unlockMeeting(

--- a/src/main/kotlin/com/bandage/v1/facade/SetlistLockFacade.kt
+++ b/src/main/kotlin/com/bandage/v1/facade/SetlistLockFacade.kt
@@ -1,0 +1,110 @@
+package com.bandage.v1.facade
+
+import com.bandage.v1.domain.practice.model.PracticeSong
+import com.bandage.v1.domain.practice.repository.PracticeSongRepository
+import com.bandage.v1.domain.setlist.dto.res.SetlistLockDiff
+import com.bandage.v1.domain.setlist.dto.res.SetlistLockResponse
+import com.bandage.v1.domain.setlist.dto.res.SetlistLockSongMapping
+import com.bandage.v1.domain.setlist.model.SetlistItem
+import com.bandage.v1.domain.setlist.repository.SetlistItemRepository
+import com.bandage.v1.domain.setlist.repository.SetlistMeetingRepository
+import com.bandage.v1.global.error.errorcode.ErrorCode
+import com.bandage.v1.global.error.exception.BusinessException
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+class SetlistLockFacade(
+    private val meetingRepository: SetlistMeetingRepository,
+    private val itemRepository: SetlistItemRepository,
+    private val practiceSongRepository: PracticeSongRepository,
+) {
+    @Transactional
+    fun lockMeeting(
+        meetingId: UUID,
+        memberId: Long,
+    ): SetlistLockResponse {
+        val meeting =
+            meetingRepository.findByIdOrNull(meetingId)
+                ?: throw BusinessException(ErrorCode.SETLIST_MEETING_NOT_FOUND)
+        if (meeting.managerId != memberId) throw BusinessException(ErrorCode.SETLIST_MEETING_NOT_MANAGER)
+        if (meeting.isLocked) throw BusinessException(ErrorCode.SETLIST_MEETING_LOCKED)
+
+        val items = itemRepository.findAllByMeeting(meeting)
+        val added = mutableListOf<SetlistLockSongMapping>()
+        val updated = mutableListOf<SetlistLockSongMapping>()
+
+        items.forEach { item ->
+            val existingId = item.practiceSongId
+            if (existingId == null) {
+                val created = practiceSongRepository.save(toPracticeSong(item))
+                item.assignPracticeSongId(created.id)
+                added += SetlistLockSongMapping(setlistItemId = item.id, practiceSongId = created.id)
+            } else {
+                val song = practiceSongRepository.findByIdOrNull(existingId)
+                if (song == null) {
+                    val created = practiceSongRepository.save(toPracticeSong(item))
+                    item.assignPracticeSongId(created.id)
+                    added += SetlistLockSongMapping(setlistItemId = item.id, practiceSongId = created.id)
+                } else if (isChanged(song, item)) {
+                    song.updateAll(
+                        title = item.title,
+                        artist = item.artist,
+                        album = item.album.orEmpty(),
+                        duration = parseDurationSeconds(item.duration),
+                        refLink = song.refLink,
+                    )
+                    updated += SetlistLockSongMapping(setlistItemId = item.id, practiceSongId = song.id)
+                }
+            }
+        }
+
+        meeting.lock()
+        val songs = items.map { SetlistLockSongMapping(setlistItemId = it.id, practiceSongId = it.practiceSongId) }
+        val practiceSongMap = items.mapNotNull { it.practiceSongId?.let { sid -> it.id to sid } }.toMap()
+
+        return SetlistLockResponse(
+            lockedAt = meeting.lockedAt!!,
+            songs = songs,
+            practiceSongMap = practiceSongMap,
+            diff = SetlistLockDiff(added = added, updated = updated),
+        )
+    }
+
+    private fun toPracticeSong(item: SetlistItem): PracticeSong =
+        PracticeSong.create(
+            title = item.title,
+            artist = item.artist,
+            album = item.album.orEmpty(),
+            duration = parseDurationSeconds(item.duration),
+        )
+
+    private fun isChanged(
+        song: PracticeSong,
+        item: SetlistItem,
+    ): Boolean =
+        song.title != item.title ||
+            song.artist != item.artist ||
+            song.album != item.album.orEmpty() ||
+            song.duration != parseDurationSeconds(item.duration)
+
+    /**
+     * SetlistItem.duration 은 String? (FE 가 "MM:SS", "M:SS", 또는 초 단위 정수 문자열을 보냄).
+     * PracticeSong.duration 은 초 단위 Int. 파싱 실패 / null 인 경우 0 반환 — 매니저가 사후 보정.
+     */
+    private fun parseDurationSeconds(raw: String?): Int {
+        if (raw.isNullOrBlank()) return 0
+        val trimmed = raw.trim()
+        if (":" in trimmed) {
+            val parts = trimmed.split(":")
+            if (parts.size == 2) {
+                val mm = parts[0].toIntOrNull() ?: return 0
+                val ss = parts[1].toIntOrNull() ?: return 0
+                return mm * 60 + ss
+            }
+        }
+        return trimmed.toIntOrNull() ?: 0
+    }
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #67

📌 **작업 내용 및 특이사항**

`API_REQUIRED_0502.md` §3-1 (FE-API-064) 대응. 기존 `SetlistMeetingService.lock` 의 cross-domain TODO 를 실구현. 회의 잠금 시 `PracticeSong` 을 일괄 생성/갱신하고, idempotent 한 diff 응답을 제공.

### 신규 — `SetlistLockFacade`
SetlistMeeting + SetlistItem + PracticeSong 단일 트랜잭션으로 처리:
- 신규 항목 → `PracticeSong` 생성 + `item.assignPracticeSongId`
- 기존 매핑 항목 → 메타 변경(제목/아티스트/앨범/duration) 시 `PracticeSong.updateAll`
- Idempotent: unlock → 항목 변경 → 재 lock 흐름에서 `added` / `updated` diff 산출

### 컨트롤러 / 서비스
- `SetlistMeetingController.lockMeeting` → `SetlistLockFacade` 위임
- `SetlistMeetingService.lockMeeting` 제거 (cross-domain 책임 이관, 주석으로 안내)

### 응답 DTO 확장 — `SetlistLockResponse`
- `diff: SetlistLockDiff { added, updated, removed }`
- `practiceSongMap: Map<itemId, practiceSongId>` 편의 필드
- `removed` 는 정책 미확정으로 항상 빈 배열 → 본 이슈 본문 참고

### 기타
- duration 파싱: `"MM:SS"` / 정수 문자열 / null 케이스 지원, 실패 시 0 (사후 보정)
- SetlistItem.album 이 null 이면 PracticeSong.album 은 빈 문자열로 매핑

### 결정 필요 (이슈 본문 참고)
- 잠금 후 곡 삭제 시 PracticeSong → hard delete vs detach (현재 `removed: []` 빈 배열)

📚 **참고사항**
- `API_REQUIRED_0502.md` §3 FE-API-064
- 베이스 브랜치 #65 머지 후 develop 기준으로 rebase (충돌 없음)
- Performance.setlist 자동 등록은 Schedule Confirm 단계로 미룸 (별도 이슈)