### PR TITLE
feat: 공연 응답에 참여 밴드 멤버 목록 포함 (FE-API-066)

### DIFF
--- a/src/main/kotlin/com/bandage/v1/domain/band/repository/BandMemberRepository.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/band/repository/BandMemberRepository.kt
@@ -23,6 +23,11 @@ interface BandMemberRepository :
         @Param("bandId") bandId: UUID,
     ): List<Long>
 
+    @Query("SELECT bm FROM BandMember bm JOIN FETCH bm.band WHERE bm.band.id IN :bandIds")
+    fun findAllByBandIdIn(
+        @Param("bandIds") bandIds: Collection<UUID>,
+    ): List<BandMember>
+
     fun existsBandMemberByBandAndMember(
         band: Band,
         member: Long,

--- a/src/main/kotlin/com/bandage/v1/domain/performance/dto/res/PerformanceBandSummary.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/dto/res/PerformanceBandSummary.kt
@@ -1,0 +1,27 @@
+package com.bandage.v1.domain.performance.dto.res
+
+import com.bandage.v1.domain.band.model.enums.BandRole
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.UUID
+
+@Schema(description = "공연 참여 밴드 + 소속 멤버 요약")
+data class PerformanceBandSummary(
+    @Schema(description = "밴드 고유 식별자", example = "550e8400-e29b-41d4-a716-446655440000")
+    val bandId: UUID,
+    @Schema(description = "밴드 이름", example = "TuNA")
+    val bandName: String,
+    @Schema(description = "밴드 소속 멤버 목록")
+    val members: List<PerformanceBandMemberSummary>,
+)
+
+@Schema(description = "공연 응답에 포함되는 밴드 멤버 요약")
+data class PerformanceBandMemberSummary(
+    @Schema(description = "회원 ID", example = "1")
+    val userId: Long,
+    @Schema(description = "이름", example = "홍길동")
+    val name: String,
+    @Schema(description = "프로필 이미지 URL", nullable = true)
+    val profileImg: String? = null,
+    @Schema(description = "밴드 내 역할", example = "LEADER")
+    val role: BandRole,
+)

--- a/src/main/kotlin/com/bandage/v1/domain/performance/dto/res/PerformanceDetailResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/dto/res/PerformanceDetailResponse.kt
@@ -1,6 +1,5 @@
 package com.bandage.v1.domain.performance.dto.res
 
-import com.bandage.v1.domain.band.model.Band
 import com.bandage.v1.domain.performance.model.Performance
 import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
@@ -20,21 +19,13 @@ data class PerformanceDetailResponse(
     val durationMinutes: Int,
     @Schema(description = "공연 장소", example = "Club FF")
     val venue: String?,
-    @Schema(description = "참여 밴드 요약 목록")
-    val bands: List<BandSummary>,
+    @Schema(description = "참여 밴드 + 소속 멤버 목록")
+    val bands: List<PerformanceBandSummary>,
     @Schema(description = "매니저 멤버 아이디 목록")
     val managerIds: List<Long>,
     @Schema(description = "연결된 합주 요약 목록")
     val practices: List<PracticeSummary>,
 ) {
-    @Schema(description = "공연 참여 밴드 요약")
-    data class BandSummary(
-        @Schema(description = "밴드 고유 식별자", example = "550e8400-e29b-41d4-a716-446655440000")
-        val bandId: UUID,
-        @Schema(description = "밴드 이름", example = "TuNA")
-        val bandName: String,
-    )
-
     @Schema(description = "공연 연결 합주 요약")
     data class PracticeSummary(
         @Schema(description = "합주 고유 식별자", example = "550e8400-e29b-41d4-a716-446655440000")
@@ -49,19 +40,15 @@ data class PerformanceDetailResponse(
     companion object {
         fun of(
             performance: Performance,
-            bands: List<Band>,
-        ): PerformanceDetailResponse {
-            val bandById = bands.associateBy { it.id }
-            return PerformanceDetailResponse(
+            bandSummariesByBandId: Map<UUID, PerformanceBandSummary>,
+        ): PerformanceDetailResponse =
+            PerformanceDetailResponse(
                 performanceId = performance.id,
                 title = performance.title,
                 startAt = performance.schedule.startAt,
                 durationMinutes = performance.schedule.durationMinutes,
                 venue = performance.schedule.venue,
-                bands =
-                    performance.bands.mapNotNull { pb ->
-                        bandById[pb.bandId]?.let { BandSummary(bandId = it.id, bandName = it.name) }
-                    },
+                bands = performance.bands.mapNotNull { pb -> bandSummariesByBandId[pb.bandId] },
                 managerIds = performance.managers.map { it.member },
                 practices =
                     performance.practices.map { pp ->
@@ -72,6 +59,5 @@ data class PerformanceDetailResponse(
                         )
                     },
             )
-        }
     }
 }

--- a/src/main/kotlin/com/bandage/v1/domain/performance/dto/res/PerformanceListResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/dto/res/PerformanceListResponse.kt
@@ -19,15 +19,21 @@ data class PerformanceListResponse(
     val durationMinutes: Int,
     @Schema(description = "공연 장소", example = "Club FF")
     val venue: String?,
+    @Schema(description = "참여 밴드 + 소속 멤버 목록")
+    val bands: List<PerformanceBandSummary>,
 ) {
     companion object {
-        fun of(performance: Performance): PerformanceListResponse =
+        fun of(
+            performance: Performance,
+            bandSummariesByBandId: Map<UUID, PerformanceBandSummary>,
+        ): PerformanceListResponse =
             PerformanceListResponse(
                 performanceId = performance.id,
                 title = performance.title,
                 startAt = performance.schedule.startAt,
                 durationMinutes = performance.schedule.durationMinutes,
                 venue = performance.schedule.venue,
+                bands = performance.bands.mapNotNull { pb -> bandSummariesByBandId[pb.bandId] },
             )
     }
 }

--- a/src/main/kotlin/com/bandage/v1/domain/performance/service/PerformanceService.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/service/PerformanceService.kt
@@ -2,13 +2,16 @@ package com.bandage.v1.domain.performance.service
 
 import com.bandage.v1.domain.band.repository.BandMemberRepository
 import com.bandage.v1.domain.band.repository.BandRepository
+import com.bandage.v1.domain.member.repository.MemberRepository
 import com.bandage.v1.domain.performance.dto.req.PerformanceBandAddRequest
 import com.bandage.v1.domain.performance.dto.req.PerformanceCreateRequest
 import com.bandage.v1.domain.performance.dto.req.PerformancePagingQuery
 import com.bandage.v1.domain.performance.dto.req.PerformancePracticeAddRequest
 import com.bandage.v1.domain.performance.dto.req.PerformanceSearchQuery
 import com.bandage.v1.domain.performance.dto.req.PerformanceUpdateRequest
+import com.bandage.v1.domain.performance.dto.res.PerformanceBandMemberSummary
 import com.bandage.v1.domain.performance.dto.res.PerformanceBandResponse
+import com.bandage.v1.domain.performance.dto.res.PerformanceBandSummary
 import com.bandage.v1.domain.performance.dto.res.PerformanceDetailResponse
 import com.bandage.v1.domain.performance.dto.res.PerformanceListResponse
 import com.bandage.v1.domain.performance.dto.res.PerformancePracticeResponse
@@ -41,6 +44,7 @@ class PerformanceService(
     private val practiceRepository: PracticeRepository,
     private val bandMemberRepository: BandMemberRepository,
     private val bandRepository: BandRepository,
+    private val memberRepository: MemberRepository,
 ) {
     @Transactional
     fun createPerformance(
@@ -65,8 +69,9 @@ class PerformanceService(
 
     fun getPerformances(query: PerformancePagingQuery): CursorResponse<PerformanceListResponse, UUID> {
         val result = performanceRepository.findAllByPaging(query.lastId, query.pageSize)
+        val bandSummaries = buildBandSummaries(result.content.flatMap { p -> p.bands.map { it.bandId } })
         return CursorResponse(
-            content = result.content.map { PerformanceListResponse.of(it) },
+            content = result.content.map { PerformanceListResponse.of(it, bandSummaries) },
             nextCursor = result.nextCursor,
             hasNext = result.hasNext,
         )
@@ -77,8 +82,9 @@ class PerformanceService(
         query: PerformancePagingQuery,
     ): CursorResponse<PerformanceListResponse, UUID> {
         val result = performanceRepository.findAllByBandIdAndPaging(bandId, query.lastId, query.pageSize)
+        val bandSummaries = buildBandSummaries(result.content.flatMap { p -> p.bands.map { it.bandId } })
         return CursorResponse(
-            content = result.content.map { PerformanceListResponse.of(it) },
+            content = result.content.map { PerformanceListResponse.of(it, bandSummaries) },
             nextCursor = result.nextCursor,
             hasNext = result.hasNext,
         )
@@ -93,8 +99,9 @@ class PerformanceService(
             return CursorResponse(content = emptyList(), nextCursor = null, hasNext = false)
         }
         val result = performanceRepository.findAllByBandIdsAndPaging(bandIds, query.lastId, query.pageSize)
+        val bandSummaries = buildBandSummaries(result.content.flatMap { p -> p.bands.map { it.bandId } })
         return CursorResponse(
-            content = result.content.map { PerformanceListResponse.of(it) },
+            content = result.content.map { PerformanceListResponse.of(it, bandSummaries) },
             nextCursor = result.nextCursor,
             hasNext = result.hasNext,
         )
@@ -102,8 +109,9 @@ class PerformanceService(
 
     fun searchPerformancesByCursor(query: PerformanceSearchQuery): CursorResponse<PerformanceListResponse, UUID> {
         val result = performanceRepository.searchByTitleAndPaging(query.keyword, query.lastId, query.pageSize)
+        val bandSummaries = buildBandSummaries(result.content.flatMap { p -> p.bands.map { it.bandId } })
         return CursorResponse(
-            content = result.content.map { PerformanceListResponse.of(it) },
+            content = result.content.map { PerformanceListResponse.of(it, bandSummaries) },
             nextCursor = result.nextCursor,
             hasNext = result.hasNext,
         )
@@ -111,8 +119,35 @@ class PerformanceService(
 
     fun getPerformanceDetail(performanceId: UUID): PerformanceDetailResponse {
         val performance = getPerformance(performanceId)
-        val bands = bandRepository.findAllById(performance.bands.map { it.bandId })
-        return PerformanceDetailResponse.of(performance, bands)
+        val bandSummaries = buildBandSummaries(performance.bands.map { it.bandId })
+        return PerformanceDetailResponse.of(performance, bandSummaries)
+    }
+
+    private fun buildBandSummaries(bandIds: Collection<UUID>): Map<UUID, PerformanceBandSummary> {
+        if (bandIds.isEmpty()) return emptyMap()
+        val distinctBandIds = bandIds.toSet()
+        val bands = bandRepository.findAllById(distinctBandIds)
+        val bandMembers = bandMemberRepository.findAllByBandIdIn(distinctBandIds)
+        val members = memberRepository.findAllById(bandMembers.map { it.member }.toSet()).associateBy { it.id }
+        val membersByBandId = bandMembers.groupBy { it.band.id }
+        return bands.associate { band ->
+            band.id to
+                PerformanceBandSummary(
+                    bandId = band.id,
+                    bandName = band.name,
+                    members =
+                        membersByBandId[band.id].orEmpty().mapNotNull { bm ->
+                            members[bm.member]?.let {
+                                PerformanceBandMemberSummary(
+                                    userId = it.id,
+                                    name = it.name,
+                                    profileImg = null,
+                                    role = bm.role,
+                                )
+                            }
+                        },
+                )
+        }
     }
 
     @Transactional


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #70

📌 **작업 내용 및 특이사항**

`API_REQUIRED_0502.md` §4 (FE-API-066) 대응. FE 의 MeetingCreateModal 마법사가 공연 선택 시 그 공연의 모든 밴드 멤버를 자동 참여자 후보로 표시할 수 있도록 응답을 보강.

### 신규 DTO
- `PerformanceBandSummary { bandId, bandName, members: List<PerformanceBandMemberSummary> }`
- `PerformanceBandMemberSummary { userId, name, profileImg, role }`

### 응답 변경
- `PerformanceDetailResponse.bands` 를 `List<PerformanceBandSummary>` 로 교체 (기존 `BandSummary` 내부 클래스 제거)
- `PerformanceListResponse` 에 `bands: List<PerformanceBandSummary>` 필드 추가
  - 적용 엔드포인트: `GET /performances`, `/performances/me`, `/performances/search`, 밴드별 목록

### Repository / Service
- `BandMemberRepository.findAllByBandIdIn` 추가 (`JOIN FETCH bm.band` 로 N+1 방지)
- `PerformanceService.buildBandSummaries` 헬퍼: bandIds 일괄 조회 → BandMember + Member 그룹핑

### 결정 (이슈 본문 참고)
- 옵션 A (인라인 응답) 채택. 옵션 B (별도 `GET /performances/{id}/members`) 는 미구현

📚 **참고사항**
- `API_REQUIRED_0502.md` §4 FE-API-066
- profileImg 는 현재 Member 엔티티에 컬럼이 없으므로 `null` 고정 (다른 응답들과 동일한 방식)