### PR TITLE
[BD-6] feat: Kakao OAuth 로그인/회원가입 API 구현

### DIFF
--- a/src/main/kotlin/com/bandage/v1/domain/auth/controller/KakaoOAuthController.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/auth/controller/KakaoOAuthController.kt
@@ -1,0 +1,43 @@
+package com.bandage.v1.domain.auth.controller
+
+import com.bandage.v1.domain.auth.dto.req.KakaoLoginRequest
+import com.bandage.v1.domain.auth.dto.res.OAuthLoginApiResponse
+import com.bandage.v1.domain.auth.oauth.kakao.KakaoOAuthClient
+import com.bandage.v1.facade.OAuthLoginFacade
+import com.bandage.v1.global.common.constants.PathPrefix.PREFIX
+import com.bandage.v1.global.common.response.ApiResponse
+import com.bandage.v1.global.util.CookieUtil
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpServletResponse
+import jakarta.validation.Valid
+import org.springframework.http.HttpHeaders
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "auth-oauth-kakao", description = "Kakao OAuth API")
+@RestController
+@RequestMapping("$PREFIX/auth/oauth/kakao")
+class KakaoOAuthController(
+    private val kakaoOAuthClient: KakaoOAuthClient,
+    private val oAuthLoginFacade: OAuthLoginFacade,
+) {
+    @PostMapping
+    @Operation(
+        summary = "Kakao OAuth 로그인 / 회원가입 API",
+        description =
+            "FE 에서 Kakao SDK 로 발급받은 access token 을 검증하고, " +
+                "신규 회원이면 가입 후 JWT 를 발급한다. 기존 회원이면 로그인 처리한다.",
+    )
+    fun loginWithKakao(
+        @Valid @RequestBody request: KakaoLoginRequest,
+        response: HttpServletResponse,
+    ): ApiResponse<OAuthLoginApiResponse> {
+        val userInfo = kakaoOAuthClient.fetchUserInfo(request.accessToken)
+        val result = oAuthLoginFacade.loginOrJoin(userInfo)
+        response.setHeader(HttpHeaders.SET_COOKIE, CookieUtil.generateCookieFrom(result.refreshToken))
+        return ApiResponse.success(OAuthLoginApiResponse.of(result))
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/auth/dto/req/KakaoLoginRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/auth/dto/req/KakaoLoginRequest.kt
@@ -1,0 +1,11 @@
+package com.bandage.v1.domain.auth.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+
+@Schema(description = "Kakao OAuth 로그인 요청")
+data class KakaoLoginRequest(
+    @NotBlank
+    @Schema(description = "Kakao OAuth access token (FE에서 카카오 SDK로 발급받은 토큰)", example = "AAAA...")
+    val accessToken: String,
+)

--- a/src/main/kotlin/com/bandage/v1/domain/auth/dto/res/OAuthLoginApiResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/auth/dto/res/OAuthLoginApiResponse.kt
@@ -1,0 +1,20 @@
+package com.bandage.v1.domain.auth.dto.res
+
+import com.bandage.v1.facade.dto.OAuthLoginResponse
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "OAuth 로그인 API 응답")
+data class OAuthLoginApiResponse(
+    @Schema(description = "회원 인증용 access 토큰", example = "ey1234...")
+    val accessToken: String,
+    @Schema(description = "신규 가입 여부 (true: 회원가입 + 로그인, false: 기존 회원 로그인)", example = "true")
+    val isNewMember: Boolean,
+) {
+    companion object {
+        fun of(response: OAuthLoginResponse): OAuthLoginApiResponse =
+            OAuthLoginApiResponse(
+                accessToken = response.accessToken,
+                isNewMember = response.isNewMember,
+            )
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/auth/model/MemberAuth.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/auth/model/MemberAuth.kt
@@ -1,6 +1,7 @@
 package com.bandage.v1.domain.auth.model
 
 import com.bandage.v1.domain.auth.model.enums.MemberRole
+import com.bandage.v1.domain.auth.model.enums.ProviderType
 import com.bandage.v1.global.common.domain.BaseTimeEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -16,8 +17,10 @@ import org.hibernate.annotations.SQLRestriction
 open class MemberAuth(
     memberId: Long,
     email: String,
-    password: String,
+    password: String?,
     role: MemberRole = MemberRole.MEMBER,
+    provider: ProviderType = ProviderType.LOCAL,
+    providerId: String? = null,
 ) : BaseTimeEntity() {
     @Id
     @Column(name = "member_id", unique = true, nullable = false)
@@ -26,12 +29,19 @@ open class MemberAuth(
     @Column(name = "email", unique = true, nullable = false)
     val email: String = email
 
-    @Column(name = "password", nullable = false)
-    var password: String = password
+    @Column(name = "password", nullable = true)
+    var password: String? = password
 
     @Enumerated(EnumType.STRING)
     @Column(name = "role", nullable = false)
     var role: MemberRole = role
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "provider", nullable = false)
+    val provider: ProviderType = provider
+
+    @Column(name = "provider_id", nullable = true)
+    val providerId: String? = providerId
 
     companion object {
         fun create(
@@ -43,6 +53,21 @@ open class MemberAuth(
                 memberId = memberId,
                 email = email,
                 password = password,
+                provider = ProviderType.LOCAL,
+            )
+
+        fun createOAuth(
+            memberId: Long,
+            email: String,
+            provider: ProviderType,
+            providerId: String,
+        ): MemberAuth =
+            MemberAuth(
+                memberId = memberId,
+                email = email,
+                password = null,
+                provider = provider,
+                providerId = providerId,
             )
     }
 

--- a/src/main/kotlin/com/bandage/v1/domain/auth/model/enums/ProviderType.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/auth/model/enums/ProviderType.kt
@@ -1,0 +1,7 @@
+package com.bandage.v1.domain.auth.model.enums
+
+enum class ProviderType {
+    LOCAL,
+    KAKAO,
+    GOOGLE,
+}

--- a/src/main/kotlin/com/bandage/v1/domain/auth/oauth/OAuthUserInfo.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/auth/oauth/OAuthUserInfo.kt
@@ -1,0 +1,11 @@
+package com.bandage.v1.domain.auth.oauth
+
+import com.bandage.v1.domain.auth.model.enums.ProviderType
+
+data class OAuthUserInfo(
+    val provider: ProviderType,
+    val providerId: String,
+    val email: String,
+    val name: String,
+    val profileImg: String? = null,
+)

--- a/src/main/kotlin/com/bandage/v1/domain/auth/oauth/kakao/KakaoOAuthClient.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/auth/oauth/kakao/KakaoOAuthClient.kt
@@ -1,0 +1,59 @@
+package com.bandage.v1.domain.auth.oauth.kakao
+
+import com.bandage.v1.domain.auth.model.enums.ProviderType
+import com.bandage.v1.domain.auth.oauth.OAuthUserInfo
+import com.bandage.v1.global.error.errorcode.ErrorCode
+import com.bandage.v1.global.error.exception.BusinessException
+import com.bandage.v1.global.properties.KakaoOAuthProperties
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatusCode
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.RestClientException
+
+@Component
+class KakaoOAuthClient(
+    private val properties: KakaoOAuthProperties,
+    restClientBuilder: RestClient.Builder,
+) {
+    private val restClient: RestClient = restClientBuilder.build()
+
+    fun fetchUserInfo(accessToken: String): OAuthUserInfo {
+        val response =
+            try {
+                restClient
+                    .get()
+                    .uri(properties.userInfoUri)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer $accessToken")
+                    .header(HttpHeaders.CONTENT_TYPE, "${MediaType.APPLICATION_FORM_URLENCODED_VALUE};charset=utf-8")
+                    .retrieve()
+                    .onStatus(HttpStatusCode::is4xxClientError) { _, _ ->
+                        throw BusinessException(ErrorCode.OAUTH_TOKEN_INVALID)
+                    }.onStatus(HttpStatusCode::is5xxServerError) { _, _ ->
+                        throw BusinessException(ErrorCode.OAUTH_PROVIDER_ERROR)
+                    }.body(KakaoUserResponse::class.java)
+                    ?: throw BusinessException(ErrorCode.OAUTH_PROVIDER_ERROR)
+            } catch (e: BusinessException) {
+                throw e
+            } catch (e: RestClientException) {
+                throw BusinessException(ErrorCode.OAUTH_PROVIDER_ERROR)
+            }
+
+        val account =
+            response.kakaoAccount
+                ?: throw BusinessException(ErrorCode.OAUTH_TOKEN_INVALID)
+        val email =
+            account.email
+                ?: throw BusinessException(ErrorCode.OAUTH_TOKEN_INVALID)
+        val nickname = account.profile?.nickname ?: email.substringBefore("@")
+
+        return OAuthUserInfo(
+            provider = ProviderType.KAKAO,
+            providerId = response.id.toString(),
+            email = email,
+            name = nickname,
+            profileImg = account.profile?.profileImageUrl,
+        )
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/auth/oauth/kakao/KakaoUserResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/auth/oauth/kakao/KakaoUserResponse.kt
@@ -1,0 +1,22 @@
+package com.bandage.v1.domain.auth.oauth.kakao
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class KakaoUserResponse(
+    val id: Long,
+    @JsonProperty("kakao_account") val kakaoAccount: KakaoAccount?,
+) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    data class KakaoAccount(
+        val email: String?,
+        val profile: KakaoProfile?,
+    )
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    data class KakaoProfile(
+        val nickname: String?,
+        @JsonProperty("profile_image_url") val profileImageUrl: String?,
+    )
+}

--- a/src/main/kotlin/com/bandage/v1/domain/auth/service/MemberAuthService.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/auth/service/MemberAuthService.kt
@@ -5,6 +5,7 @@ import com.bandage.v1.domain.auth.dto.req.MemberLoginRequest
 import com.bandage.v1.domain.auth.dto.req.MemberPasswordChangeRequest
 import com.bandage.v1.domain.auth.dto.res.TokenDto
 import com.bandage.v1.domain.auth.model.MemberAuth
+import com.bandage.v1.domain.auth.model.enums.ProviderType
 import com.bandage.v1.domain.auth.repository.MemberAuthRepository
 import com.bandage.v1.global.error.errorcode.ErrorCode
 import com.bandage.v1.global.error.exception.BusinessException
@@ -37,11 +38,48 @@ class MemberAuthService(
     }
 
     @Transactional
+    fun createOAuthMemberAuth(
+        memberId: Long,
+        email: String,
+        provider: ProviderType,
+        providerId: String,
+    ): MemberAuth {
+        if (memberAuthRepository.existsByMemberId(memberId)) {
+            throw BusinessException(ErrorCode.MEMBER_AUTH_ALREADY_EXISTS)
+        }
+        return memberAuthRepository.save(
+            MemberAuth.createOAuth(
+                memberId = memberId,
+                email = email,
+                provider = provider,
+                providerId = providerId,
+            ),
+        )
+    }
+
+    fun findByEmail(email: String): MemberAuth? = memberAuthRepository.findByEmail(email)
+
+    @Transactional
+    fun issueTokens(memberAuth: MemberAuth): TokenDto {
+        val accessToken = jwtProvider.createAccessToken(memberAuth.memberId, memberAuth.role)
+        val refreshToken = jwtProvider.createRefreshToken(memberAuth.memberId)
+        refreshTokenRepository.save(
+            memberId = memberAuth.memberId,
+            refreshToken = refreshToken,
+            expiration = jwtProperties.refreshTokenExpr,
+        )
+        return TokenDto(accessToken = accessToken, refreshToken = refreshToken)
+    }
+
+    @Transactional
     fun processLogin(request: MemberLoginRequest): TokenDto {
         val memberAuth =
             memberAuthRepository.findByEmail(request.email)
                 ?: throw BusinessException(ErrorCode.MEMBER_NOT_FOUND)
-        if (!passwordEncoder.matches(request.password, memberAuth.password)) {
+        val storedPassword =
+            memberAuth.password
+                ?: throw BusinessException(ErrorCode.OAUTH_LOCAL_LOGIN_NOT_ALLOWED)
+        if (!passwordEncoder.matches(request.password, storedPassword)) {
             throw BusinessException(ErrorCode.INVALID_PASSWORD)
         }
         val memberId = memberAuth.memberId
@@ -104,10 +142,13 @@ class MemberAuthService(
         memberId: Long,
     ) {
         val memberAuth = getMemberAuth(memberId)
-        if (!passwordEncoder.matches(request.originalPassword, memberAuth.password)) {
+        val storedPassword =
+            memberAuth.password
+                ?: throw BusinessException(ErrorCode.OAUTH_PASSWORD_CHANGE_NOT_ALLOWED)
+        if (!passwordEncoder.matches(request.originalPassword, storedPassword)) {
             throw BusinessException(ErrorCode.INVALID_PASSWORD)
         }
-        if (passwordEncoder.matches(request.newPassword, memberAuth.password)) {
+        if (passwordEncoder.matches(request.newPassword, storedPassword)) {
             throw BusinessException(ErrorCode.DUPLICATE_PASSWORD)
         }
         memberAuth.updatePassword(encodePassword(request.newPassword))

--- a/src/main/kotlin/com/bandage/v1/domain/member/dto/res/MemberInfoResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/member/dto/res/MemberInfoResponse.kt
@@ -13,8 +13,8 @@ data class MemberInfoResponse(
     val email: String,
     @Schema(description = "회원 이름", example = "홍길동")
     val name: String,
-    @Schema(description = "회원 연락처", example = "010-7707-5859")
-    val contact: String,
+    @Schema(description = "회원 연락처 (소셜 로그인 가입 시 null)", example = "010-7707-5859")
+    val contact: String?,
     @Schema(description = "프로필 이미지 URL (CloudFront, 없으면 null)", example = "https://cdn.example.com/profile/member/1/uuid.jpg")
     val profileImg: String? = null,
 ) {

--- a/src/main/kotlin/com/bandage/v1/domain/member/model/Member.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/member/model/Member.kt
@@ -15,7 +15,7 @@ import org.hibernate.annotations.SQLRestriction
 open class Member(
     email: String,
     name: String,
-    contact: String,
+    contact: String?,
     profileImg: String? = null,
 ) : BaseTimeEntity() {
     @Id
@@ -31,8 +31,8 @@ open class Member(
     var name: String = name
         protected set
 
-    @Column(name = "contact", nullable = false)
-    var contact: String = contact
+    @Column(name = "contact", nullable = true)
+    var contact: String? = contact
         protected set
 
     @Column(name = "profile_img")
@@ -52,13 +52,25 @@ open class Member(
                 contact = contact,
                 profileImg = profileImg,
             )
+
+        fun createOAuth(
+            email: String,
+            name: String,
+            profileImg: String? = null,
+        ): Member =
+            Member(
+                email = email,
+                name = name,
+                contact = null,
+                profileImg = profileImg,
+            )
     }
 
     fun updateName(newName: String) {
         this.name = newName
     }
 
-    fun updateContact(newContact: String) {
+    fun updateContact(newContact: String?) {
         this.contact = newContact
     }
 

--- a/src/main/kotlin/com/bandage/v1/facade/OAuthLoginFacade.kt
+++ b/src/main/kotlin/com/bandage/v1/facade/OAuthLoginFacade.kt
@@ -1,0 +1,59 @@
+package com.bandage.v1.facade
+
+import com.bandage.v1.domain.auth.model.MemberAuth
+import com.bandage.v1.domain.auth.model.enums.ProviderType
+import com.bandage.v1.domain.auth.oauth.OAuthUserInfo
+import com.bandage.v1.domain.auth.service.MemberAuthService
+import com.bandage.v1.domain.member.model.Member
+import com.bandage.v1.domain.member.repository.MemberRepository
+import com.bandage.v1.facade.dto.OAuthLoginResponse
+import com.bandage.v1.global.error.errorcode.ErrorCode
+import com.bandage.v1.global.error.exception.BusinessException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class OAuthLoginFacade(
+    private val memberRepository: MemberRepository,
+    private val memberAuthService: MemberAuthService,
+) {
+    @Transactional
+    fun loginOrJoin(userInfo: OAuthUserInfo): OAuthLoginResponse {
+        val existingAuth = memberAuthService.findByEmail(userInfo.email)
+        return if (existingAuth != null) {
+            verifyProviderMatch(existingAuth, userInfo.provider)
+            val tokens = memberAuthService.issueTokens(existingAuth)
+            OAuthLoginResponse.of(tokens, isNewMember = false)
+        } else {
+            val newAuth = registerOAuthMember(userInfo)
+            val tokens = memberAuthService.issueTokens(newAuth)
+            OAuthLoginResponse.of(tokens, isNewMember = true)
+        }
+    }
+
+    private fun verifyProviderMatch(
+        memberAuth: MemberAuth,
+        provider: ProviderType,
+    ) {
+        if (memberAuth.provider != provider) {
+            throw BusinessException(ErrorCode.OAUTH_PROVIDER_MISMATCH)
+        }
+    }
+
+    private fun registerOAuthMember(userInfo: OAuthUserInfo): MemberAuth {
+        val member =
+            memberRepository.save(
+                Member.createOAuth(
+                    email = userInfo.email,
+                    name = userInfo.name,
+                    profileImg = userInfo.profileImg,
+                ),
+            )
+        return memberAuthService.createOAuthMemberAuth(
+            memberId = member.id,
+            email = member.email,
+            provider = userInfo.provider,
+            providerId = userInfo.providerId,
+        )
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/facade/dto/OAuthLoginResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/facade/dto/OAuthLoginResponse.kt
@@ -1,0 +1,26 @@
+package com.bandage.v1.facade.dto
+
+import com.bandage.v1.domain.auth.dto.res.TokenDto
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "OAuth 로그인 응답")
+data class OAuthLoginResponse(
+    @Schema(description = "회원 인증용 access 토큰", example = "ey1234...")
+    val accessToken: String,
+    @Schema(description = "신규 가입 여부", example = "true")
+    val isNewMember: Boolean,
+    @Schema(hidden = true)
+    val refreshToken: String,
+) {
+    companion object {
+        fun of(
+            tokens: TokenDto,
+            isNewMember: Boolean,
+        ): OAuthLoginResponse =
+            OAuthLoginResponse(
+                accessToken = tokens.accessToken,
+                refreshToken = tokens.refreshToken,
+                isNewMember = isNewMember,
+            )
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/global/error/errorcode/ErrorCode.kt
+++ b/src/main/kotlin/com/bandage/v1/global/error/errorcode/ErrorCode.kt
@@ -25,6 +25,11 @@ enum class ErrorCode(
     MEMBER_AUTH_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 회원가입된 e-mail 입니다"),
     INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다."),
     EXPIRED_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "만료된 토큰입니다."),
+    OAUTH_LOCAL_LOGIN_NOT_ALLOWED(HttpStatus.CONFLICT, "소셜 로그인으로 가입된 계정입니다. 해당 소셜 로그인을 이용해주세요."),
+    OAUTH_PASSWORD_CHANGE_NOT_ALLOWED(HttpStatus.CONFLICT, "소셜 로그인 계정은 비밀번호를 변경할 수 없습니다."),
+    OAUTH_PROVIDER_MISMATCH(HttpStatus.CONFLICT, "다른 소셜 계정으로 가입된 이메일입니다."),
+    OAUTH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 소셜 인증 토큰입니다."),
+    OAUTH_PROVIDER_ERROR(HttpStatus.BAD_GATEWAY, "소셜 인증 서버와의 통신에 실패했습니다."),
 
     // band
     BAND_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 밴드 정보를 찾을 수 없습니다."),

--- a/src/main/kotlin/com/bandage/v1/global/properties/KakaoOAuthProperties.kt
+++ b/src/main/kotlin/com/bandage/v1/global/properties/KakaoOAuthProperties.kt
@@ -1,0 +1,8 @@
+package com.bandage.v1.global.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "oauth.kakao")
+data class KakaoOAuthProperties(
+    val userInfoUri: String = "https://kapi.kakao.com/v2/user/me",
+)

--- a/src/main/kotlin/com/bandage/v1/global/properties/PropertiesConfig.kt
+++ b/src/main/kotlin/com/bandage/v1/global/properties/PropertiesConfig.kt
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Configuration
     value = [
         JwtProperties::class,
         AwsProperties::class,
+        KakaoOAuthProperties::class,
     ],
 )
 class PropertiesConfig

--- a/src/main/kotlin/com/bandage/v1/global/security/constants/SecurityPathConstants.kt
+++ b/src/main/kotlin/com/bandage/v1/global/security/constants/SecurityPathConstants.kt
@@ -7,6 +7,7 @@ object SecurityPathConstants {
         arrayOf(
             "${PathPrefix.PREFIX}/auth/login",
             "${PathPrefix.PREFIX}/auth/refresh",
+            "${PathPrefix.PREFIX}/auth/oauth/**",
             "${PathPrefix.PREFIX}/members/join",
         )
 

--- a/src/main/resources/application-security.yaml
+++ b/src/main/resources/application-security.yaml
@@ -2,3 +2,7 @@ jwt:
   access-token-expr: 3600
   refresh-token-expr: 25200
   secret: "OXCdljnxxIeLMbX/dnQIWyVSuVAdkGc6p6FYaChtCb6Zzg//p1tdUwekTL/CB7QPNf47GjGhhRvXYe2bs3UWTg=="
+
+oauth:
+  kakao:
+    user-info-uri: ${KAKAO_USER_INFO_URI:https://kapi.kakao.com/v2/user/me}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes BD-6

📌 **작업 내용 및 특이사항**

### 추가된 엔드포인트
- `POST /api/v1/auth/oauth/kakao` — Kakao OAuth 로그인 / 신규 회원가입 통합
  - request: `{ accessToken: String }` (FE 카카오 SDK 가 발급한 토큰)
  - response body: `{ accessToken, isNewMember }`, response cookie: `refreshToken` (HttpOnly, 14d)

### 토큰 교환 방식 채택 이유
`spring-boot-starter-oauth2-client` 의 Authorization Code redirect 방식은 stateless JWT + FE/BE 분리 환경에 적합하지 않다고 판단. FE 가 Kakao SDK 로 access token 을 받고 BE 는 받은 토큰으로 카카오 user-info API 를 호출하는 방식으로 구현. 의존성 추가 없이 RestClient 만으로 처리.

### 도메인 모델 변경
- `MemberAuth`: `password` nullable, `provider`(LOCAL/KAKAO/GOOGLE), `providerId` 추가
- `Member`: `contact` nullable (소셜 가입 시 미수집), `createOAuth` 팩토리 추가
- 기존 로컬 로그인 / 비밀번호 변경 흐름에 OAuth 계정 가드 추가 (`OAUTH_LOCAL_LOGIN_NOT_ALLOWED`, `OAUTH_PASSWORD_CHANGE_NOT_ALLOWED`)

### 회원 매칭 정책
- 동일 이메일 기존 회원 존재 시 `provider` 일치 검증 → 불일치하면 `OAUTH_PROVIDER_MISMATCH(409)` 반환
- 신규 회원이면 `Member` + `MemberAuth` 동시 생성 후 JWT 발급

### 새 ErrorCode (5종)
- `OAUTH_LOCAL_LOGIN_NOT_ALLOWED(409)`, `OAUTH_PASSWORD_CHANGE_NOT_ALLOWED(409)`, `OAUTH_PROVIDER_MISMATCH(409)`, `OAUTH_TOKEN_INVALID(401)`, `OAUTH_PROVIDER_ERROR(502)`

### 환경변수
`application-security.yaml` 에 다음 추가:
- `KAKAO_USER_INFO_URI` (기본값 `https://kapi.kakao.com/v2/user/me`)

> Kakao client-id / client-secret 은 BE 단계에서 사용하지 않음 (FE 가 access token 발급 담당). BE 는 받은 토큰으로 user-info 만 호출.

📚 **참고사항**

- `Member.contact` 와 `MemberAuth.password` 가 nullable 로 변경되었으므로 DDL 변경 필요. JPA `ddl-auto` 로 자동 처리되거나, 운영 환경에선 별도 마이그레이션 필요.
- `MemberInfoResponse.contact` 도 nullable 로 변경 → FE 측 타입 동기화 필요.
- 후속: BD-7 (Google OAuth) — 본 PR 의 `OAuthLoginFacade` / `OAuthUserInfo` / `ProviderType` 인프라 재사용 예정.