### PR TITLE
[BD-7] feat: Google OAuth 로그인/회원가입 API 구현

### DIFF
--- a/src/main/kotlin/com/bandage/v1/domain/auth/controller/GoogleOAuthController.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/auth/controller/GoogleOAuthController.kt
@@ -1,0 +1,43 @@
+package com.bandage.v1.domain.auth.controller
+
+import com.bandage.v1.domain.auth.dto.req.GoogleLoginRequest
+import com.bandage.v1.domain.auth.dto.res.OAuthLoginApiResponse
+import com.bandage.v1.domain.auth.oauth.google.GoogleOAuthClient
+import com.bandage.v1.facade.OAuthLoginFacade
+import com.bandage.v1.global.common.constants.PathPrefix.PREFIX
+import com.bandage.v1.global.common.response.ApiResponse
+import com.bandage.v1.global.util.CookieUtil
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpServletResponse
+import jakarta.validation.Valid
+import org.springframework.http.HttpHeaders
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "auth-oauth-google", description = "Google OAuth API")
+@RestController
+@RequestMapping("$PREFIX/auth/oauth/google")
+class GoogleOAuthController(
+    private val googleOAuthClient: GoogleOAuthClient,
+    private val oAuthLoginFacade: OAuthLoginFacade,
+) {
+    @PostMapping
+    @Operation(
+        summary = "Google OAuth 로그인 / 회원가입 API",
+        description =
+            "FE 에서 GIS 로 발급받은 ID token 을 검증하고, " +
+                "신규 회원이면 가입 후 JWT 를 발급한다. 기존 회원이면 로그인 처리한다.",
+    )
+    fun loginWithGoogle(
+        @Valid @RequestBody request: GoogleLoginRequest,
+        response: HttpServletResponse,
+    ): ApiResponse<OAuthLoginApiResponse> {
+        val userInfo = googleOAuthClient.fetchUserInfo(request.idToken)
+        val result = oAuthLoginFacade.loginOrJoin(userInfo)
+        response.setHeader(HttpHeaders.SET_COOKIE, CookieUtil.generateCookieFrom(result.refreshToken))
+        return ApiResponse.success(OAuthLoginApiResponse.of(result))
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/auth/dto/req/GoogleLoginRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/auth/dto/req/GoogleLoginRequest.kt
@@ -1,0 +1,11 @@
+package com.bandage.v1.domain.auth.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+
+@Schema(description = "Google OAuth 로그인 요청")
+data class GoogleLoginRequest(
+    @NotBlank
+    @Schema(description = "Google OAuth ID token (FE 에서 GIS 로 발급받은 JWT 형식 토큰)", example = "eyJhbGciOi...")
+    val idToken: String,
+)

--- a/src/main/kotlin/com/bandage/v1/domain/auth/oauth/google/GoogleOAuthClient.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/auth/oauth/google/GoogleOAuthClient.kt
@@ -1,0 +1,78 @@
+package com.bandage.v1.domain.auth.oauth.google
+
+import com.bandage.v1.domain.auth.model.enums.ProviderType
+import com.bandage.v1.domain.auth.oauth.OAuthUserInfo
+import com.bandage.v1.global.error.errorcode.ErrorCode
+import com.bandage.v1.global.error.exception.BusinessException
+import com.bandage.v1.global.properties.GoogleOAuthProperties
+import org.springframework.http.HttpStatusCode
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.RestClientException
+
+@Component
+class GoogleOAuthClient(
+    private val properties: GoogleOAuthProperties,
+    restClientBuilder: RestClient.Builder,
+) {
+    private val restClient: RestClient = restClientBuilder.build()
+
+    fun fetchUserInfo(idToken: String): OAuthUserInfo {
+        val tokenInfo = requestTokenInfo(idToken)
+        verifyAudience(tokenInfo.aud)
+        verifyIssuer(tokenInfo.iss)
+        verifyEmail(tokenInfo.emailVerified)
+
+        val sub =
+            tokenInfo.sub
+                ?: throw BusinessException(ErrorCode.OAUTH_TOKEN_INVALID)
+        val email =
+            tokenInfo.email
+                ?: throw BusinessException(ErrorCode.OAUTH_TOKEN_INVALID)
+        val name = tokenInfo.name ?: email.substringBefore("@")
+
+        return OAuthUserInfo(
+            provider = ProviderType.GOOGLE,
+            providerId = sub,
+            email = email,
+            name = name,
+            profileImg = tokenInfo.picture,
+        )
+    }
+
+    private fun requestTokenInfo(idToken: String): GoogleTokenInfoResponse =
+        try {
+            restClient
+                .get()
+                .uri("${properties.tokenInfoUri}?id_token={idToken}", idToken)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError) { _, _ ->
+                    throw BusinessException(ErrorCode.OAUTH_TOKEN_INVALID)
+                }.onStatus(HttpStatusCode::is5xxServerError) { _, _ ->
+                    throw BusinessException(ErrorCode.OAUTH_PROVIDER_ERROR)
+                }.body(GoogleTokenInfoResponse::class.java)
+                ?: throw BusinessException(ErrorCode.OAUTH_PROVIDER_ERROR)
+        } catch (e: BusinessException) {
+            throw e
+        } catch (e: RestClientException) {
+            throw BusinessException(ErrorCode.OAUTH_PROVIDER_ERROR)
+        }
+
+    private fun verifyAudience(aud: String?) {
+        if (aud != properties.clientId) {
+            throw BusinessException(ErrorCode.OAUTH_TOKEN_INVALID)
+        }
+    }
+
+    private fun verifyIssuer(iss: String?) {
+        if (iss != "https://accounts.google.com" && iss != "accounts.google.com") {
+            throw BusinessException(ErrorCode.OAUTH_TOKEN_INVALID)
+        }
+    }
+
+    private fun verifyEmail(emailVerified: String?) {
+        if (emailVerified?.lowercase() != "true") {
+            throw BusinessException(ErrorCode.OAUTH_TOKEN_INVALID)
+        }
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/auth/oauth/google/GoogleTokenInfoResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/auth/oauth/google/GoogleTokenInfoResponse.kt
@@ -1,0 +1,16 @@
+package com.bandage.v1.domain.auth.oauth.google
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class GoogleTokenInfoResponse(
+    val sub: String?,
+    val aud: String?,
+    val iss: String?,
+    val email: String?,
+    @JsonProperty("email_verified") val emailVerified: String?,
+    val name: String?,
+    val picture: String?,
+    val exp: String?,
+)

--- a/src/main/kotlin/com/bandage/v1/global/properties/GoogleOAuthProperties.kt
+++ b/src/main/kotlin/com/bandage/v1/global/properties/GoogleOAuthProperties.kt
@@ -1,0 +1,9 @@
+package com.bandage.v1.global.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "oauth.google")
+data class GoogleOAuthProperties(
+    val tokenInfoUri: String = "https://oauth2.googleapis.com/tokeninfo",
+    val clientId: String,
+)

--- a/src/main/kotlin/com/bandage/v1/global/properties/PropertiesConfig.kt
+++ b/src/main/kotlin/com/bandage/v1/global/properties/PropertiesConfig.kt
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Configuration
         JwtProperties::class,
         AwsProperties::class,
         KakaoOAuthProperties::class,
+        GoogleOAuthProperties::class,
     ],
 )
 class PropertiesConfig

--- a/src/main/resources/application-security.yaml
+++ b/src/main/resources/application-security.yaml
@@ -6,3 +6,6 @@ jwt:
 oauth:
   kakao:
     user-info-uri: ${KAKAO_USER_INFO_URI:https://kapi.kakao.com/v2/user/me}
+  google:
+    token-info-uri: ${GOOGLE_TOKEN_INFO_URI:https://oauth2.googleapis.com/tokeninfo}
+    client-id: ${GOOGLE_OAUTH_CLIENT_ID:}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes BD-7

📌 **작업 내용 및 특이사항**

### 추가된 엔드포인트
- `POST /api/v1/auth/oauth/google` — Google OAuth 로그인 / 신규 회원가입 통합
  - request: `{ idToken: String }` (FE 가 GIS 로 발급받은 JWT 형식 ID token)
  - response body: `{ accessToken, isNewMember }`, response cookie: `refreshToken` (HttpOnly, 14d)

### ID Token 검증 방식
`oauth2.googleapis.com/tokeninfo?id_token={...}` 호출 후 다음 3중 검증:
1. `aud` 가 등록된 `oauth.google.client-id` 와 일치
2. `iss` 가 `https://accounts.google.com` 또는 `accounts.google.com`
3. `email_verified == "true"`

검증 실패 시 모두 `OAUTH_TOKEN_INVALID(401)`. 외부 호출 실패는 `OAUTH_PROVIDER_ERROR(502)`.

### BD-6 인프라 재사용
`OAuthLoginFacade`, `OAuthUserInfo`, `ProviderType.GOOGLE`, `OAuthLoginApiResponse` 등 BD-6 에서 도입한 공용 추상화를 그대로 사용. Google 전용 코드는 `GoogleOAuthClient`, `GoogleTokenInfoResponse`, `GoogleOAuthController`, `GoogleLoginRequest`, `GoogleOAuthProperties` 5개 파일.

### 환경변수
`application-security.yaml` 에 다음 추가:
- `GOOGLE_TOKEN_INFO_URI` (기본값 `https://oauth2.googleapis.com/tokeninfo`)
- `GOOGLE_OAUTH_CLIENT_ID` (필수, Google Cloud Console 에서 발급한 Web client OAuth 2.0 Client ID)

> `GOOGLE_OAUTH_CLIENT_ID` 미설정 시 부팅은 가능하나 모든 토큰의 audience 검증이 실패하여 `OAUTH_TOKEN_INVALID` 응답. 실서비스 전 반드시 발급/주입 필요.

📚 **참고사항**

- Authorization Code redirect 방식이 아닌, FE 토큰 교환 방식 (BD-6 와 동일 정책).
- 회원 매칭 정책 (이메일 기반 매칭 + provider 일치 검증) 도 BD-6 와 동일.
- 구글 client-secret 은 BE 단계에서 사용하지 않음 (FE 가 ID token 발급 담당, BE 는 검증만).