### PR TITLE
[BD-7] hotfix: 테스트 컨텍스트 OAuth/AWS Properties 바인딩 NPE 수정

### DIFF
--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -31,6 +31,24 @@ jwt:
   refresh-token-expr: 25200
   secret: "OXCdljnxxIeLMbX/dnQIWyVSuVAdkGc6p6FYaChtCb6Zzg//p1tdUwekTL/CB7QPNf47GjGhhRvXYe2bs3UWTg=="
 
+oauth:
+  google:
+    token-info-uri: https://oauth2.googleapis.com/tokeninfo
+    client-id: test-client-id
+  kakao:
+    user-info-uri: https://kapi.kakao.com/v2/user/me
+
+aws:
+  credentials:
+    access-key: test-access-key
+    secret-key: test-secret-key
+  region:
+    static: ap-northeast-2
+  s3:
+    bucket: test-bucket
+  cloudfront:
+    domain: test.cloudfront.net
+
 logging:
   level:
     org.hibernate.SQL: DEBUG


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #

📌 **작업 내용 및 특이사항**

- `application-test.yaml` 에 `oauth.google`, `oauth.kakao`, `aws` 더미 설정 블록 추가
- 원인: test 프로파일이 `security` / `s3` 프로파일 그룹을 포함하지 않아 `application-security.yaml`, `application-s3.yaml` 의 설정이 컨텍스트에 로드되지 않음. 그 결과 `GoogleOAuthProperties.clientId`, `AwsProperties.*` 등 default 가 없는 non-null 필드 바인딩이 실패하면서 `V1ApplicationTests > contextLoads()` 가 NPE 로 실패
- 수정 방식: 기존 jwt 설정이 `application-test.yaml` 에 직접 정의된 패턴과 동일하게, oauth/aws 도 테스트 전용 더미 값을 같은 파일에 직접 추가. (security/s3 그룹 자체를 import 하면 다른 운영 설정과의 충돌 가능성이 있어 회피)
- 로컬 검증: `./gradlew test` 통과 확인

📚 **참고사항**

- 직전 커밋 e748f71 (`[BD-7] fix: OAuth 클라이언트가 RestClient.Builder 주입을 요구해 부팅 실패`) 머지 후 CI 의 `contextLoads()` 가 실패하는 회귀가 발견되어 이어서 처리하는 hotfix
- `application-security.yaml:11` 의 `${GOOGLE_OAUTH_CLIENT_ID:}` (빈 문자열 default) 는 운영/local 에는 영향 없음. test profile 만 이 yaml 자체를 로드하지 않는 것이 본질 원인

[BD-7]: https://sunwoo1137.atlassian.net/browse/BD-7?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ