### PR TITLE
fix: JWT secret 을 환경변수로 외부화

### DIFF
--- a/src/main/resources/application-security.yaml
+++ b/src/main/resources/application-security.yaml
@@ -1,7 +1,7 @@
 jwt:
   access-token-expr: 3600
   refresh-token-expr: 25200
-  secret: "OXCdljnxxIeLMbX/dnQIWyVSuVAdkGc6p6FYaChtCb6Zzg//p1tdUwekTL/CB7QPNf47GjGhhRvXYe2bs3UWTg=="
+  secret: ${JWT_TOKEN_SECRET}
 
 oauth:
   kakao:


### PR DESCRIPTION
## Issue Number
closes #

**작업 내용 및 특이사항**

- `application-security.yaml` 의 `jwt.secret` 평문 값을 `${JWT_TOKEN_SECRET}` 환경변수로 외부화
- 저장소(공개 가능 경로)에 평문 secret 이 커밋되어 있던 문제 제거
- 운영/dev 배포 측에서 `JWT_TOKEN_SECRET` 환경변수 주입 필요 (미주입 시 부팅 실패)
- 테스트 프로파일(`application-test.yaml`)은 평문 더미값 유지 — CI 안정성 위해 영향 범위 밖

**참고사항**

- 평문 secret 은 git history 에 이미 노출되어 있으므로, 가능하다면 **시크릿 로테이션**(JWT 키 재생성) 후 환경변수 주입 권장
- 본 PR 머지 후, 인프라 측 환경변수 등록(`JWT_TOKEN_SECRET`)이 선행되어야 정상 부팅