### PR TITLE
[BD-14] feat: Kakao OAuth Authorization Code Grant 흐름으로 BE 이관

### DIFF
--- a/src/main/kotlin/com/bandage/v1/domain/auth/controller/KakaoOAuthController.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/auth/controller/KakaoOAuthController.kt
@@ -28,14 +28,19 @@ class KakaoOAuthController(
     @Operation(
         summary = "Kakao OAuth 로그인 / 회원가입 API",
         description =
-            "FE 에서 Kakao SDK 로 발급받은 access token 을 검증하고, " +
-                "신규 회원이면 가입 후 JWT 를 발급한다. 기존 회원이면 로그인 처리한다.",
+            "FE 가 전달한 authorization code 를 카카오 token endpoint 와 교환해 access token 을 받고, " +
+                "user info 검증 후 JWT 를 발급한다. 신규 회원이면 가입 처리, 기존 회원이면 로그인 처리.",
     )
     fun loginWithKakao(
         @Valid @RequestBody request: KakaoLoginRequest,
         response: HttpServletResponse,
     ): ApiResponse<OAuthLoginApiResponse> {
-        val userInfo = kakaoOAuthClient.fetchUserInfo(request.accessToken)
+        val accessToken =
+            kakaoOAuthClient.exchangeCodeForAccessToken(
+                code = request.code,
+                redirectUri = request.redirectUri,
+            )
+        val userInfo = kakaoOAuthClient.fetchUserInfo(accessToken)
         val result = oAuthLoginFacade.loginOrJoin(userInfo)
         response.setHeader(HttpHeaders.SET_COOKIE, CookieUtil.generateCookieFrom(result.refreshToken))
         return ApiResponse.success(OAuthLoginApiResponse.of(result))

--- a/src/main/kotlin/com/bandage/v1/domain/auth/dto/req/KakaoLoginRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/auth/dto/req/KakaoLoginRequest.kt
@@ -6,6 +6,11 @@ import jakarta.validation.constraints.NotBlank
 @Schema(description = "Kakao OAuth 로그인 요청")
 data class KakaoLoginRequest(
     @NotBlank
-    @Schema(description = "Kakao OAuth access token (FE에서 카카오 SDK로 발급받은 토큰)", example = "AAAA...")
-    val accessToken: String,
+    @Schema(description = "Kakao authorize 단계에서 받은 authorization code", example = "abc123...")
+    val code: String,
+    @NotBlank
+    @Schema(description = "FE 가 authorize 시 사용한 redirect URI. 카카오가 token 교환 시 동일성 검증")
+    val redirectUri: String,
+    @Schema(description = "(선택) FE CSRF state. BE 측 추가 검증이 필요한 경우만 사용")
+    val state: String? = null,
 )

--- a/src/main/kotlin/com/bandage/v1/domain/auth/oauth/kakao/KakaoOAuthClient.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/auth/oauth/kakao/KakaoOAuthClient.kt
@@ -9,6 +9,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatusCode
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
+import org.springframework.util.LinkedMultiValueMap
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.RestClientException
 
@@ -17,6 +18,45 @@ class KakaoOAuthClient(
     private val properties: KakaoOAuthProperties,
 ) {
     private val restClient: RestClient = RestClient.create()
+
+    fun exchangeCodeForAccessToken(
+        code: String,
+        redirectUri: String,
+    ): String {
+        val body =
+            LinkedMultiValueMap<String, String>().apply {
+                add("grant_type", "authorization_code")
+                add("client_id", properties.clientId)
+                add("redirect_uri", redirectUri)
+                add("code", code)
+                if (!properties.clientSecret.isNullOrBlank()) {
+                    add("client_secret", properties.clientSecret)
+                }
+            }
+
+        val response =
+            try {
+                restClient
+                    .post()
+                    .uri(properties.tokenUri)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(body)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::is4xxClientError) { _, _ ->
+                        throw BusinessException(ErrorCode.OAUTH_TOKEN_INVALID)
+                    }.onStatus(HttpStatusCode::is5xxServerError) { _, _ ->
+                        throw BusinessException(ErrorCode.OAUTH_PROVIDER_ERROR)
+                    }.body(KakaoTokenResponse::class.java)
+                    ?: throw BusinessException(ErrorCode.OAUTH_PROVIDER_ERROR)
+            } catch (e: BusinessException) {
+                throw e
+            } catch (e: RestClientException) {
+                throw BusinessException(ErrorCode.OAUTH_PROVIDER_ERROR)
+            }
+
+        return response.accessToken
+            ?: throw BusinessException(ErrorCode.OAUTH_TOKEN_INVALID)
+    }
 
     fun fetchUserInfo(accessToken: String): OAuthUserInfo {
         val response =

--- a/src/main/kotlin/com/bandage/v1/domain/auth/oauth/kakao/KakaoTokenResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/auth/oauth/kakao/KakaoTokenResponse.kt
@@ -1,0 +1,13 @@
+package com.bandage.v1.domain.auth.oauth.kakao
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class KakaoTokenResponse(
+    @field:JsonProperty("access_token") val accessToken: String?,
+    @field:JsonProperty("token_type") val tokenType: String?,
+    @field:JsonProperty("refresh_token") val refreshToken: String?,
+    @field:JsonProperty("expires_in") val expiresIn: Long?,
+    @field:JsonProperty("scope") val scope: String?,
+)

--- a/src/main/kotlin/com/bandage/v1/global/properties/KakaoOAuthProperties.kt
+++ b/src/main/kotlin/com/bandage/v1/global/properties/KakaoOAuthProperties.kt
@@ -5,4 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties(prefix = "oauth.kakao")
 data class KakaoOAuthProperties(
     val userInfoUri: String = "https://kapi.kakao.com/v2/user/me",
+    val tokenUri: String = "https://kauth.kakao.com/oauth/token",
+    val clientId: String,
+    val clientSecret: String? = null,
 )

--- a/src/main/resources/application-security.yaml
+++ b/src/main/resources/application-security.yaml
@@ -6,6 +6,9 @@ jwt:
 oauth:
   kakao:
     user-info-uri: ${KAKAO_USER_INFO_URI:https://kapi.kakao.com/v2/user/me}
+    token-uri: ${KAKAO_TOKEN_URI:https://kauth.kakao.com/oauth/token}
+    client-id: ${KAKAO_OAUTH_CLIENT_ID}
+    client-secret: ${KAKAO_OAUTH_CLIENT_SECRET:}
   google:
     token-info-uri: ${GOOGLE_TOKEN_INFO_URI:https://oauth2.googleapis.com/tokeninfo}
     client-id: ${GOOGLE_OAUTH_CLIENT_ID:}

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -37,6 +37,9 @@ oauth:
     client-id: test-client-id
   kakao:
     user-info-uri: https://kapi.kakao.com/v2/user/me
+    token-uri: https://kauth.kakao.com/oauth/token
+    client-id: test-kakao-client-id
+    client-secret: test-kakao-client-secret
 
 aws:
   credentials:


### PR DESCRIPTION
## Issue Number
closes # (BD-14, Jira)

**작업 내용 및 특이사항**

FE 가 카카오 token endpoint 를 직접 호출해 access_token 을 교환하던 흐름을 BE 로 이관한다. FE 는 authorization code 만 전달하고, BE 가 token 교환 + user info 검증 + JWT 발급을 일괄 처리.

### API 시그니처 변경 — `POST /api/v1/auth/oauth/kakao`

변경 전: `{ accessToken }` → 변경 후: `{ code, redirectUri, state? }`

### 변경 파일

- `KakaoLoginRequest` — `accessToken` → `code` / `redirectUri` / `state?`
- `KakaoOAuthClient.exchangeCodeForAccessToken` 신규 (form-urlencoded POST → kauth.kakao.com/oauth/token, 4xx → `OAUTH_TOKEN_INVALID`, 5xx → `OAUTH_PROVIDER_ERROR`)
- `KakaoTokenResponse` 신규 DTO
- `KakaoOAuthProperties` — `tokenUri`, `clientId`(필수), `clientSecret`(선택) 추가
- `KakaoOAuthController.loginWithKakao` — code → access_token 교환 선행, 이후 `fetchUserInfo` → `loginOrJoin` 흐름 유지
- `application-security.yaml` — `oauth.kakao.token-uri / client-id / client-secret` 환경변수 매핑
- `application-test.yaml` — 더미값으로 테스트 컨텍스트 바인딩 회귀 방지

### 운영 영향 (배포 측)

- `KAKAO_OAUTH_CLIENT_ID` 환경변수 신규 필수 — 카카오 콘솔 REST API 키 주입
- `KAKAO_OAUTH_CLIENT_SECRET` 환경변수 선택 — 카카오 콘솔 [보안 → Client Secret] 활성화 시에만
- BE 가 새 시그니처 반영되기 전에 FE 만 먼저 배포되면 카카오 로그인이 깨진다 — **반드시 BE 먼저 배포**

**참고사항**

- Google OAuth 는 ID token 흐름 유지 (변경 없음)
- 에러 코드는 기존 `OAUTH_TOKEN_INVALID` / `OAUTH_PROVIDER_ERROR` / `OAUTH_PROVIDER_MISMATCH` / `INVALID_INPUT_VALUE` 그대로 재사용
- 명세: `API_REQUIRED_OAUTH_KAKAO_0504.md`
- BE 가 받은 카카오 refresh_token 자체 보관·폐기 정책은 별도 후속 이슈