### PR TITLE
[BD-26] chore: 배포용 Dockerfile / docker-compose / develop CD 워크플로우 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+# VCS / IDE
+.git
+.github
+.gitignore
+.gitattributes
+.idea
+.vscode
+.kotlin
+.claude
+
+# Build artefacts (rebuilt inside image)
+.gradle
+build
+out
+
+# Local-only / sensitive
+.env
+.env.*
+set-env.sh
+*.log
+logs
+
+# OS / scratch
+.DS_Store
+
+# Docs not needed at runtime
+*.md
+.taskmaster
+
+# Tests not used in image build
+src/test

--- a/.github/workflows/develop_deploy.yml
+++ b/.github/workflows/develop_deploy.yml
@@ -47,29 +47,63 @@ jobs:
           docker push "$ECR_REGISTRY/$ECR_REPOSITORY:$SHA_TAG"
           docker push "$ECR_REGISTRY/$ECR_REPOSITORY:$LATEST_TAG"
 
-      # 5. [핵심] EC2 접속 및 환경변수 주입, 배포 실행
+      # 5. EC2 SSH — 컨테이너 부팅에 필요한 모든 환경변수를 .env 로 일괄 주입 후 compose up
+      #    DB_HOST/REDIS_HOST 는 compose 의 service 명(고정값)이라 GH 시크릿 대상이 아니다.
+      #    AWS_REGION 은 워크플로우 레벨의 env.AWS_REGION 을 그대로 재사용한다.
       - name: Deploy to EC2 & Inject ENV
         uses: appleboy/ssh-action@v1.0.3
         env:
-          # GitHub Secrets에 저장된 민감한 값들을 SSH Action 내부로 안전하게 전달
-          AWS_CDN_DOMAIN: ${{ secrets.AWS_CDN_DOMAIN }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          # ----- Spring profile -----
+          PROFILE_ACTIVE: dev
+          # ----- DB (PostgreSQL container) -----
+          DB_NAME: ${{ secrets.DB_NAME }}
+          DB_USERNAME: ${{ secrets.DB_USERNAME }}
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-          JWT_SECRET: ${{ secrets.JWT_SECRET }}
-          # 필요한 변수가 있다면 여기에 계속 추가하세요.
+          # ----- JWT -----
+          JWT_TOKEN_SECRET: ${{ secrets.JWT_TOKEN_SECRET }}
+          # ----- AWS (S3 + CloudFront, 앱 측) -----
+          APP_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          APP_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_CDN_DOMAIN: ${{ secrets.AWS_CDN_DOMAIN }}
+          # ----- OAuth -----
+          GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
+          KAKAO_OAUTH_CLIENT_ID: ${{ secrets.KAKAO_OAUTH_CLIENT_ID }}
+          KAKAO_OAUTH_CLIENT_SECRET: ${{ secrets.KAKAO_OAUTH_CLIENT_SECRET }}
         with:
           host: ${{ secrets.EC2_HOST }}
           username: rocky
           key: ${{ secrets.EC2_SSH_KEY }}
-          # env 항목에 정의한 변수 이름들을 쉼표(,)로 연결하여 명시합니다.
-          envs: AWS_CDN_DOMAIN,DB_PASSWORD,JWT_SECRET
+          envs: ECR_REGISTRY,AWS_REGION,PROFILE_ACTIVE,DB_NAME,DB_USERNAME,DB_PASSWORD,JWT_TOKEN_SECRET,APP_AWS_ACCESS_KEY_ID,APP_AWS_SECRET_ACCESS_KEY,AWS_S3_BUCKET,AWS_CDN_DOMAIN,GOOGLE_OAUTH_CLIENT_ID,KAKAO_OAUTH_CLIENT_ID,KAKAO_OAUTH_CLIENT_SECRET
           script: |
+            set -euo pipefail
             cd ~/bandage
-            
-            echo "AWS_CDN_DOMAIN=$AWS_CDN_DOMAIN" > .env
-            echo "POSTGRES_PASSWORD=$DB_PASSWORD" >> .env
-            echo "JWT_TOKEN_SECRET=$JWT_SECRET" >> .env
-            
-            aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin ${{ steps.login-ecr.outputs.registry }}
-            
+
+            umask 077
+            cat > .env <<EOF
+            PROFILE_ACTIVE=${PROFILE_ACTIVE}
+            DB_HOST=postgres
+            DB_PORT=5432
+            DB_NAME=${DB_NAME}
+            DB_USERNAME=${DB_USERNAME}
+            DB_PASSWORD=${DB_PASSWORD}
+            REDIS_HOST=redis
+            REDIS_PORT=6379
+            JWT_TOKEN_SECRET=${JWT_TOKEN_SECRET}
+            AWS_ACCESS_KEY_ID=${APP_AWS_ACCESS_KEY_ID}
+            AWS_SECRET_ACCESS_KEY=${APP_AWS_SECRET_ACCESS_KEY}
+            AWS_REGION=${AWS_REGION}
+            AWS_S3_BUCKET=${AWS_S3_BUCKET}
+            AWS_CDN_DOMAIN=${AWS_CDN_DOMAIN}
+            GOOGLE_OAUTH_CLIENT_ID=${GOOGLE_OAUTH_CLIENT_ID}
+            KAKAO_OAUTH_CLIENT_ID=${KAKAO_OAUTH_CLIENT_ID}
+            KAKAO_OAUTH_CLIENT_SECRET=${KAKAO_OAUTH_CLIENT_SECRET}
+            EOF
+
+            aws ecr get-login-password --region "${AWS_REGION}" \
+              | docker login --username AWS --password-stdin "${ECR_REGISTRY}"
+
             docker compose pull
             docker compose up -d --remove-orphans
+            docker image prune -f

--- a/.github/workflows/develop_deploy.yml
+++ b/.github/workflows/develop_deploy.yml
@@ -17,12 +17,12 @@ jobs:
       - name: Checkout Source Code
         uses: actions/checkout@v4
 
-      # ECR 접근 권한 획득
+      # ECR 전용 IAM 자격으로 러너에 AWS 자격 주입 (S3 키와 분리)
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_ECR_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_ECR_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
       # 3. ECR 로그인
@@ -56,15 +56,17 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           # ----- Spring profile -----
           PROFILE_ACTIVE: dev
+          # ----- App server port -----
+          BAND_MANAGER_PORT: "8080"
           # ----- DB (PostgreSQL container) -----
           DB_NAME: ${{ secrets.DB_NAME }}
           DB_USERNAME: ${{ secrets.DB_USERNAME }}
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
           # ----- JWT -----
           JWT_TOKEN_SECRET: ${{ secrets.JWT_TOKEN_SECRET }}
-          # ----- AWS (S3 + CloudFront, 앱 측) -----
-          APP_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          APP_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          # ----- AWS (S3 + CloudFront, 앱 런타임 — S3 전용 IAM) -----
+          AWS_S3_ACCESS_KEY_ID: ${{ secrets.AWS_S3_ACCESS_KEY_ID }}
+          AWS_S3_SECRET_ACCESS_KEY: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           AWS_CDN_DOMAIN: ${{ secrets.AWS_CDN_DOMAIN }}
           # ----- OAuth -----
@@ -75,7 +77,7 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: rocky
           key: ${{ secrets.EC2_SSH_KEY }}
-          envs: ECR_REGISTRY,AWS_REGION,PROFILE_ACTIVE,DB_NAME,DB_USERNAME,DB_PASSWORD,JWT_TOKEN_SECRET,APP_AWS_ACCESS_KEY_ID,APP_AWS_SECRET_ACCESS_KEY,AWS_S3_BUCKET,AWS_CDN_DOMAIN,GOOGLE_OAUTH_CLIENT_ID,KAKAO_OAUTH_CLIENT_ID,KAKAO_OAUTH_CLIENT_SECRET
+          envs: ECR_REGISTRY,AWS_REGION,PROFILE_ACTIVE,BAND_MANAGER_PORT,DB_NAME,DB_USERNAME,DB_PASSWORD,JWT_TOKEN_SECRET,AWS_S3_ACCESS_KEY_ID,AWS_S3_SECRET_ACCESS_KEY,AWS_S3_BUCKET,AWS_CDN_DOMAIN,GOOGLE_OAUTH_CLIENT_ID,KAKAO_OAUTH_CLIENT_ID,KAKAO_OAUTH_CLIENT_SECRET
           script: |
             set -euo pipefail
             cd ~/bandage
@@ -83,6 +85,7 @@ jobs:
             umask 077
             cat > .env <<EOF
             PROFILE_ACTIVE=${PROFILE_ACTIVE}
+            BAND_MANAGER_PORT=${BAND_MANAGER_PORT}
             DB_HOST=postgres
             DB_PORT=5432
             DB_NAME=${DB_NAME}
@@ -91,8 +94,8 @@ jobs:
             REDIS_HOST=redis
             REDIS_PORT=6379
             JWT_TOKEN_SECRET=${JWT_TOKEN_SECRET}
-            AWS_ACCESS_KEY_ID=${APP_AWS_ACCESS_KEY_ID}
-            AWS_SECRET_ACCESS_KEY=${APP_AWS_SECRET_ACCESS_KEY}
+            AWS_S3_ACCESS_KEY_ID=${AWS_S3_ACCESS_KEY_ID}
+            AWS_S3_SECRET_ACCESS_KEY=${AWS_S3_SECRET_ACCESS_KEY}
             AWS_REGION=${AWS_REGION}
             AWS_S3_BUCKET=${AWS_S3_BUCKET}
             AWS_CDN_DOMAIN=${AWS_CDN_DOMAIN}

--- a/.github/workflows/develop_deploy.yml
+++ b/.github/workflows/develop_deploy.yml
@@ -1,0 +1,75 @@
+name: Deploy to EC2 (Develop)
+
+on:
+  push:
+    branches:
+      - develop
+
+env:
+  AWS_REGION: ap-northeast-2
+  ECR_REPOSITORY: bandage-band-manager
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Source Code
+        uses: actions/checkout@v4
+
+      # ECR 접근 권한 획득
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      # 3. ECR 로그인
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      # 4. Docker 이미지 빌드 및 ECR 푸시 — 태그 이원화 (dev-<sha> + dev-latest)
+      #    - dev-<short_sha> : immutable, 롤백/추적용
+      #    - dev-latest      : mutable, docker compose pull 참조 포인트
+      - name: Build and Push Docker image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+          SHA_TAG="dev-${SHORT_SHA}"
+          LATEST_TAG="dev-latest"
+          docker build \
+            -t "$ECR_REGISTRY/$ECR_REPOSITORY:$SHA_TAG" \
+            -t "$ECR_REGISTRY/$ECR_REPOSITORY:$LATEST_TAG" \
+            .
+          docker push "$ECR_REGISTRY/$ECR_REPOSITORY:$SHA_TAG"
+          docker push "$ECR_REGISTRY/$ECR_REPOSITORY:$LATEST_TAG"
+
+      # 5. [핵심] EC2 접속 및 환경변수 주입, 배포 실행
+      - name: Deploy to EC2 & Inject ENV
+        uses: appleboy/ssh-action@v1.0.3
+        env:
+          # GitHub Secrets에 저장된 민감한 값들을 SSH Action 내부로 안전하게 전달
+          AWS_CDN_DOMAIN: ${{ secrets.AWS_CDN_DOMAIN }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          # 필요한 변수가 있다면 여기에 계속 추가하세요.
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: rocky
+          key: ${{ secrets.EC2_SSH_KEY }}
+          # env 항목에 정의한 변수 이름들을 쉼표(,)로 연결하여 명시합니다.
+          envs: AWS_CDN_DOMAIN,DB_PASSWORD,JWT_SECRET
+          script: |
+            cd ~/bandage
+            
+            echo "AWS_CDN_DOMAIN=$AWS_CDN_DOMAIN" > .env
+            echo "POSTGRES_PASSWORD=$DB_PASSWORD" >> .env
+            echo "JWT_TOKEN_SECRET=$JWT_SECRET" >> .env
+            
+            aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin ${{ steps.login-ecr.outputs.registry }}
+            
+            docker compose pull
+            docker compose up -d --remove-orphans

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+# syntax=docker/dockerfile:1.7
+
+# ============================================================
+# Build stage — Amazon Corretto 21 (Alpine)
+# ============================================================
+FROM amazoncorretto:21-alpine AS builder
+
+WORKDIR /workspace
+
+COPY gradle ./gradle
+COPY gradlew settings.gradle.kts build.gradle.kts ./
+RUN chmod +x ./gradlew \
+ && ./gradlew dependencies --no-daemon
+
+COPY src ./src
+RUN ./gradlew clean bootJar -x test --no-daemon \
+ && cp build/libs/*-SNAPSHOT.jar /workspace/app.jar
+
+# /workspace/extracted/app.jar 파일 & /workspace/extracted/lib/ 폴더 생성
+RUN java -Djarmode=tools -jar /workspace/app.jar extract --destination /workspace/extracted
+
+# ============================================================
+# Runtime stage — Amazon Corretto 21 JRE (초경량 런타임 환경)
+# ============================================================
+FROM amazoncorretto:21-alpine-jre AS runtime
+
+RUN apk add --no-cache tzdata curl \
+ && cp /usr/share/zoneinfo/Asia/Seoul /etc/localtime \
+ && echo "Asia/Seoul" > /etc/timezone
+
+RUN addgroup -S appgroup \
+ && adduser -S appuser -G appgroup -h /app -s /sbin/nologin
+
+WORKDIR /app
+
+# 외부 라이브러리 먼저 복사 (도커 캐시 타겟)
+COPY --from=builder --chown=appuser:appgroup /workspace/extracted/lib/ ./lib/
+# 소스 코드 jar 파일 복사
+COPY --from=builder --chown=appuser:appgroup /workspace/extracted/app.jar ./app.jar
+
+USER appuser
+
+ENV PROFILE_ACTIVE=dev \
+    SERVER_PORT=8080 \
+    TZ=Asia/Seoul \
+    JAVA_OPTS="-XX:MaxRAMPercentage=75.0 -XX:+UseG1GC -Djava.security.egd=file:/dev/./urandom"
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+  CMD curl -fsS "http://localhost:${SERVER_PORT}/actuator/health" || exit 1
+
+# java -jar 실행
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -Dspring.profiles.active=$PROFILE_ACTIVE -jar app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,14 +41,14 @@ COPY --from=builder --chown=appuser:appgroup /workspace/extracted/app.jar ./app.
 USER appuser
 
 ENV PROFILE_ACTIVE=dev \
-    SERVER_PORT=8080 \
+    BAND_MANAGER_PORT=8080 \
     TZ=Asia/Seoul \
     JAVA_OPTS="-XX:MaxRAMPercentage=75.0 -XX:+UseG1GC -Djava.security.egd=file:/dev/./urandom"
 
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
-  CMD curl -fsS "http://localhost:${SERVER_PORT}/actuator/health" || exit 1
+  CMD curl -fsS "http://localhost:${BAND_MANAGER_PORT}/actuator/health" || exit 1
 
 # java -jar 실행
 ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -Dspring.profiles.active=$PROFILE_ACTIVE -jar app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,50 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:15
+    container_name: bandage-postgres
+    environment:
+      POSTGRES_USER: devuser
+      POSTGRES_PASSWORD: devpassword
+      POSTGRES_DB: bandage_db
+      TZ: Asia/Seoul
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./db:/var/lib/postgresql/data
+    restart: always
+
+  redis:
+    image: redis:7-alpine
+    container_name: bandage-redis
+    ports:
+      - "6379:6379"
+    command: redis-server --appendonly yes
+    volumes:
+      - ./redis:/data
+    restart: always
+
+  api-server-a:
+    image: 595028889928.dkr.ecr.ap-northeast-2.amazonaws.com/bandage-band-manager:dev-latest
+    container_name: bandage-band-manager
+    expose:
+      - "8080"
+    env_file:
+      - .env
+    depends_on:
+      - postgres
+      - redis
+    restart: always
+
+#  api-server-b:
+#    image: 595028889928.dkr.ecr.ap-northeast-2.amazonaws.com/bandage-music-metadata:latest
+#    container_name: bandage-api-b
+#    ports:
+#      - "8081:8081"
+#    env_file:
+#      - .env
+#    depends_on:
+#      - postgres
+#      - redis
+#    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,13 @@ services:
   postgres:
     image: postgres:15
     container_name: bandage-postgres
+    # POSTGRES_* 는 .env 의 DB_* 와 단일 출처를 공유한다.
+    # 주의: 이미 ./db 에 데이터가 있다면 postgres 는 최초 init 시점의 자격증명을 유지하므로
+    # DB_USERNAME/DB_PASSWORD/DB_NAME 변경 시 기존 볼륨을 비우거나 수동 마이그레이션 필요.
     environment:
-      POSTGRES_USER: devuser
-      POSTGRES_PASSWORD: devpassword
-      POSTGRES_DB: bandage_db
+      POSTGRES_USER: ${DB_USERNAME}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${DB_NAME}
       TZ: Asia/Seoul
     ports:
       - "5432:5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,6 @@ services:
   postgres:
     image: postgres:15
     container_name: bandage-postgres
-    # POSTGRES_* 는 .env 의 DB_* 와 단일 출처를 공유한다.
-    # 주의: 이미 ./db 에 데이터가 있다면 postgres 는 최초 init 시점의 자격증명을 유지하므로
-    # DB_USERNAME/DB_PASSWORD/DB_NAME 변경 시 기존 볼륨을 비우거나 수동 마이그레이션 필요.
     environment:
       POSTGRES_USER: ${DB_USERNAME}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
@@ -28,11 +25,11 @@ services:
       - ./redis:/data
     restart: always
 
-  api-server-a:
+  bandage-band-manager:
     image: 595028889928.dkr.ecr.ap-northeast-2.amazonaws.com/bandage-band-manager:dev-latest
     container_name: bandage-band-manager
     expose:
-      - "8080"
+      - "${BAND_MANAGER_PORT}"
     env_file:
       - .env
     depends_on:
@@ -40,9 +37,9 @@ services:
       - redis
     restart: always
 
-#  api-server-b:
+#  bandage-music-metadata:
 #    image: 595028889928.dkr.ecr.ap-northeast-2.amazonaws.com/bandage-music-metadata:latest
-#    container_name: bandage-api-b
+#    container_name: bandage-music-metadata
 #    ports:
 #      - "8081:8081"
 #    env_file:

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,2 +1,2 @@
 server:
-  port: 8080
+  port: ${BAND_MANAGER_PORT}

--- a/src/main/resources/application-s3.yaml
+++ b/src/main/resources/application-s3.yaml
@@ -1,7 +1,7 @@
 aws:
   credentials:
-    access-key: ${AWS_ACCESS_KEY_ID}
-    secret-key: ${AWS_SECRET_ACCESS_KEY}
+    access-key: ${AWS_S3_ACCESS_KEY_ID}
+    secret-key: ${AWS_S3_SECRET_ACCESS_KEY}
   region:
     static: ${AWS_REGION:ap-northeast-2}
   s3:


### PR DESCRIPTION
## 🛠️ Issue Number
### closes BD-26

📌 **작업 내용 및 특이사항**

### 1. 배포 산출물 신규 추가 (선행 커밋)

- **Dockerfile** — `amazoncorretto:21-alpine` 멀티스테이지 빌드, layered jar 추출(`/lib` + `app.jar` 분리), 비루트(`appuser`) 실행, `/actuator/health` HEALTHCHECK, KST 타임존
- **docker-compose.yml** — `postgres:15` + `redis:7-alpine` + `bandage-band-manager` 구성. 서비스명 정합화 (`api-server-a` → `bandage-band-manager`)
- **develop_deploy.yml** — `develop` push 시 ECR 빌드/푸시 후 EC2 SSH 로 docker compose 배포. 이미지 태그 이원화 — `dev-<short_sha>`(immutable, 롤백용) + `dev-latest`(mutable, compose pull 참조)
- **.dockerignore** — `.git`/`.idea`/`build`/`.env`/문서/`.taskmaster` 등 빌드 컨텍스트 제외

### 2. 환경변수 / 자격증명 정합성 정리

- 워크플로우 SSH 단계에서 `.env` 를 heredoc 으로 일괄 작성 — 컨테이너 부팅에 필요한 모든 환경변수 단일 출처화
- `DB_HOST=postgres`, `REDIS_HOST=redis` 고정값으로 컨테이너 간 통신 성립 (compose service 명)
- 잘못된 `secrets.JWT_SECRET` 참조를 `secrets.JWT_TOKEN_SECRET` 로 정정
- `set -euo pipefail` / `umask 077` / `docker image prune -f` 추가

### 3. dev 프로필 포트 환경변수화 (`BAND_MANAGER_PORT`)

기존 하드코딩 8080 을 환경변수 기반으로 전환 — 환경별 포트 변경 시 yaml 수정 불필요.

| 파일 | 변경 |
|---|---|
| `application-dev.yaml` | `port: 8080` → `port: ${BAND_MANAGER_PORT}` |
| `Dockerfile` | `ENV SERVER_PORT=8080` → `ENV BAND_MANAGER_PORT=8080` (HEALTHCHECK 동기화) |
| `docker-compose.yml` | `expose: "8080"` → `expose: "${BAND_MANAGER_PORT}"` |
| `develop_deploy.yml` | env / envs / `.env` heredoc 에 `BAND_MANAGER_PORT=8080` 주입 |

`Dockerfile EXPOSE 8080` 은 메타데이터(런타임 영향 없음)라 의도적 하드코딩 유지. `application-local.yaml` 은 `./gradlew bootRun` 편의상 그대로 유지.

### 4. AWS IAM 권한 분리 (S3 / ECR)

GitHub Actions 러너의 ECR 푸시 권한과 앱 런타임의 S3/CloudFront 권한이 동일 IAM 키를 공유하던 구조를 분리.

| 용도 | 사용처 | 신규 시크릿 |
|---|---|---|
| ECR 빌드/푸시 | 워크플로우 러너 (`Configure AWS Credentials`) | `AWS_ECR_ACCESS_KEY_ID`, `AWS_ECR_SECRET_ACCESS_KEY` |
| S3 presigned URL / CloudFront | 앱 런타임 (`application-s3.yaml`) | `AWS_S3_ACCESS_KEY_ID`, `AWS_S3_SECRET_ACCESS_KEY` |

- `application-s3.yaml` 의 `${AWS_ACCESS_KEY_ID/SECRET_ACCESS_KEY}` 를 `${AWS_S3_*}` 로 변경
- 워크플로우의 `APP_AWS_*` 중간 매핑 제거 (시크릿명과 컨테이너 환경변수명 일원화)

### 5. GH Secrets 정리

- **신규 등록 (6)** — `EC2_HOST`, `EC2_SSH_KEY`, `AWS_S3_ACCESS_KEY_ID`, `AWS_S3_SECRET_ACCESS_KEY`, `AWS_ECR_ACCESS_KEY_ID`, `AWS_ECR_SECRET_ACCESS_KEY`
- **삭제 (13)** — 통합 IAM 키 `AWS_ACCESS_KEY_ID/SECRET_ACCESS_KEY`, JWT 통합 전 잔재 `ACCESS_TOKEN_SECRET/REFRESH_TOKEN_SECRET`, 워크플로우에서 hardcode 처리되는 `DB_HOST/DB_PORT/REDIS_HOST/REDIS_PORT/PROFILE_ACTIVE/AWS_REGION`, 앱 default 사용 `GOOGLE_TOKEN_INFO_URI/KAKAO_TOKEN_URI/KAKAO_USER_INFO_URI`

📚 **참고사항**

- develop 머지 후 첫 푸시 시 `Deploy to EC2 (Develop)` 워크플로우가 트리거되어 ECR 빌드 + EC2 배포까지 자동 진행
- EC2 호스트는 EIP `3.37.243.226` (rocky 사용자, `bandage-dev.pem`)
- `docker-compose.yml` 의 postgres 볼륨(`./db`)에 기존 데이터가 있으면 `DB_USERNAME/DB_PASSWORD` 변경 시 최초 init 자격증명이 유지되므로 수동 마이그레이션 필요 (BD-26 fix 커밋에서 주석으로 명시)