### PR TITLE
[BD-26] fix: Dockerfile runtime 베이스 이미지 alpine-jre → alpine 으로 교체

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,10 @@ RUN ./gradlew clean bootJar -x test --no-daemon \
 RUN java -Djarmode=tools -jar /workspace/app.jar extract --destination /workspace/extracted
 
 # ============================================================
-# Runtime stage — Amazon Corretto 21 JRE (초경량 런타임 환경)
+# Runtime stage — Amazon Corretto 21 (Alpine, JDK)
+# Java 11+ 부터 alpine-jre 단독 이미지가 deprecated 되어 alpine(JDK) 사용
 # ============================================================
-FROM amazoncorretto:21-alpine-jre AS runtime
+FROM amazoncorretto:21-alpine AS runtime
 
 RUN apk add --no-cache tzdata curl \
  && cp /usr/share/zoneinfo/Asia/Seoul /etc/localtime \


### PR DESCRIPTION
## 🛠️ Issue Number
### closes BD-26

📌 **작업 내용 및 특이사항**

직전 PR #84 머지 후 자동 트리거된 `Deploy to EC2 (Develop)` 워크플로우가 ECR 빌드 단계에서 실패. 원인은 Dockerfile 의 runtime 베이스 이미지 태그 부재.

```
ERROR: failed to build: failed to solve:
amazoncorretto:21-alpine-jre: docker.io/library/amazoncorretto:21-alpine-jre: not found
```

### 원인

Java 11 부터 Oracle 이 JRE 단독 배포를 deprecate 했고, Amazon Corretto 도 alpine 계열에서 JRE-only 이미지를 더 이상 발행하지 않음. `amazoncorretto:21-alpine-jre` 태그는 Docker Hub 에 존재하지 않는다.

### 수정

- `Dockerfile` L25: `amazoncorretto:21-alpine-jre` → `amazoncorretto:21-alpine` (빌더와 동일 태그)
- 주석에 alpine-jre deprecation 사유 명시

### 옵션 비교

| 방안 | 이미지 크기 | 변경 폭 | 채택 |
|---|---|---|---|
| `amazoncorretto:21-alpine` (JDK) | ~250MB | L1 | 채택 |
| `amazoncorretto:21-alpine-jdk` (명시 태그) | ~250MB | L1 | 의미상 동일, 짧은 태그 선호 |
| JLink custom JRE | ~80MB | 큼 | 추후 최적화 단계에서 검토 |

📚 **참고사항**

- 머지 후 `Deploy to EC2 (Develop)` 워크플로우가 다시 트리거되어 ECR 푸시 + EC2 배포 정상 완료 여부 확인 필요
- 본 PR 은 BD-26 의 후속 픽스 — 별도 이슈 발급 없이 동일 이슈 키 유지