### PR TITLE
[BD-26] fix: git hook 자동설치 task 에 onlyIf 가드 추가 (Docker 빌드 깨짐 해결)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,11 +103,13 @@ spotless {
 }
 
 tasks.register<Copy>("updateGitHooks") {
+    onlyIf { file(".git").isDirectory }
     from("./scripts/pre-commit")
     into("./.git/hooks")
 }
 
 tasks.register<Exec>("makeGitHooksExecutable") {
+    onlyIf { file(".git/hooks/pre-commit").exists() }
     commandLine("chmod", "+x", "./.git/hooks/pre-commit")
     dependsOn("updateGitHooks")
 }


### PR DESCRIPTION
## 🛠️ Issue Number
### closes BD-26

📌 **작업 내용 및 특이사항**

직전 PR #85 (alpine 이미지 교체) 이후에도 `Deploy to EC2 (Develop)` 워크플로우가 실패. 원인은 Dockerfile 이 아닌 `build.gradle.kts` 의 git hook 자동 설치 task.

```
> Task :updateGitHooks NO-SOURCE
chmod: ./.git/hooks/pre-commit: No such file or directory
> Task :makeGitHooksExecutable FAILED
```

### 원인

| 단계 | 동작 |
|---|---|
| `.dockerignore` | `.git/`, `.github/` 등을 빌드 컨텍스트에서 제외 (정상) |
| Dockerfile builder | `gradle/`, `gradlew`, `*.gradle.kts`, `src/` 만 COPY (`scripts/` 미포함) |
| `updateGitHooks` (Copy) | `from("./scripts/pre-commit")` 가 컨텍스트에 없어 NO-SOURCE 스킵 |
| `makeGitHooksExecutable` (Exec) | `chmod ./.git/hooks/pre-commit` 시도 → 파일 부재로 실패 |
| `compileKotlin` | `dependsOn("makeGitHooksExecutable")` 로 연쇄 실패 → bootJar 무산 |

### 수정

`build.gradle.kts` 양 task 에 `onlyIf` 가드 추가 — git 체크아웃이 아닌 환경(Docker 등)에서 안전하게 스킵.

```kotlin
tasks.register<Copy>("updateGitHooks") {
    onlyIf { file(".git").isDirectory }
    ...
}

tasks.register<Exec>("makeGitHooksExecutable") {
    onlyIf { file(".git/hooks/pre-commit").exists() }
    ...
}
```

- 로컬 dev: `.git/hooks/` 존재 → 기존 동작 (pre-commit 자동 설치) 유지
- Docker builder: `.git/` 부재 → 두 task 모두 스킵 → bootJar 정상 진행

### 대안 (검토 후 기각)

- `dependsOn("makeGitHooksExecutable")` 제거 → 로컬 dev 첫 빌드 시 hook 자동 설치 누락 (regression)
- Dockerfile 에 `scripts/` 도 COPY → `.git/hooks/` 부재로 chmod 가 여전히 실패 (반쪽 해결)
- `chmod || true` 처리 → 실패를 숨기는 anti-pattern

📚 **참고사항**

- 머지 후 `Deploy to EC2 (Develop)` 워크플로우가 다시 트리거됨 — ECR 푸시 + EC2 배포 정상 완료까지 본 PR 시리즈의 마무리
- BD-26 deployment 픽스 시리즈: PR #84 (스코프 변경) → #85 (alpine 이미지) → #86 (본 PR, gradle hook 가드)