### PR TITLE
[BD-26] fix: 배포 파이프라인에 docker-compose.yml SCP 동기화 단계 추가

### DIFF
--- a/.github/workflows/develop_deploy.yml
+++ b/.github/workflows/develop_deploy.yml
@@ -47,7 +47,19 @@ jobs:
           docker push "$ECR_REGISTRY/$ECR_REPOSITORY:$SHA_TAG"
           docker push "$ECR_REGISTRY/$ECR_REPOSITORY:$LATEST_TAG"
 
-      # 5. EC2 SSH — 컨테이너 부팅에 필요한 모든 환경변수를 .env 로 일괄 주입 후 compose up
+      # 5. docker-compose.yml 을 EC2 의 ~/bandage/ 로 동기화 (repo 가 single source of truth)
+      #    SSH 단계에서 compose pull 이 동작하려면 작업 디렉토리에 compose 파일이 미리 존재해야 함
+      - name: Sync docker-compose.yml to EC2
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: rocky
+          key: ${{ secrets.EC2_SSH_KEY }}
+          source: docker-compose.yml
+          target: /home/rocky/bandage
+          overwrite: true
+
+      # 6. EC2 SSH — 컨테이너 부팅에 필요한 모든 환경변수를 .env 로 일괄 주입 후 compose up
       #    DB_HOST/REDIS_HOST 는 compose 의 service 명(고정값)이라 GH 시크릿 대상이 아니다.
       #    AWS_REGION 은 워크플로우 레벨의 env.AWS_REGION 을 그대로 재사용한다.
       - name: Deploy to EC2 & Inject ENV


### PR DESCRIPTION
## 🛠️ Issue Number
### closes BD-26

📌 **작업 내용 및 특이사항**

직전 PR #86 (gradle hook 가드) 머지 후 ECR 빌드/푸시까지 정상 통과했지만 `Deploy to EC2 & Inject ENV` 단계에서 `docker compose pull` 실행 직전 실패.

```
err: no configuration file provided: not found
2026/05/05 07:03:48 Process exited with status 1
```

### 원인

워크플로우가 EC2 의 `~/bandage/` 디렉토리에 `docker-compose.yml` 이 사전 배치돼 있다고 가정했지만 실제로는 부재. `.env` 는 SSH heredoc 으로 만들지만 compose 파일은 어디에서도 동기화되지 않는 구조였음.

### 수정

`appleboy/scp-action@v0.1.7` 한 step 을 ECR push 직후 / SSH compose pull 직전에 삽입.

```yaml
- name: Sync docker-compose.yml to EC2
  uses: appleboy/scp-action@v0.1.7
  with:
    host: ${{ secrets.EC2_HOST }}
    username: rocky
    key: ${{ secrets.EC2_SSH_KEY }}
    source: docker-compose.yml
    target: /home/rocky/bandage
    overwrite: true
```

- repo 가 single source of truth — compose 파일 수정분이 자동으로 EC2 에 반영, drift 방지
- `overwrite: true` 로 매 배포 시 최신본 강제 갱신
- `~/bandage/` 디렉토리는 EC2 에 이미 존재함 (직전 SSH 단계에서 `cd ~/bandage` 가 통과한 사실로 확인)

### 옵션 비교 (재정리)

| 방안 | 채택 | 이유 |
|---|---|---|
| **A. SCP 자동 동기화 (본 PR)** | 채택 | 표준 GHA → EC2 배포 패턴, drift 방지 |
| B. EC2 수동 사전 배치 | 기각 | compose 변경마다 수동 동기화, drift 위험 |
| C. EC2 측 git pull | 기각 | EC2 에 deploy key 별도 설정 필요, 비공개 repo 비용 |

📚 **참고사항**

- BD-26 deployment fix 시리즈 4번째: PR #84 (스코프 변경) → #85 (alpine) → #86 (gradle hook) → #87 (본 PR, compose SCP)
- 머지 후 다시 트리거되는 `Deploy to EC2 (Develop)` 워크플로우의 정상 종료 + `actuator/health` 응답까지 확인 후 본 시리즈 마무리