### PR TITLE
hotfix: docker compose --remove-orphans 제거 + CORS 운영 도메인 추가

### DIFF
--- a/.github/workflows/develop_deploy.yml
+++ b/.github/workflows/develop_deploy.yml
@@ -120,5 +120,5 @@ jobs:
               | docker login --username AWS --password-stdin "${ECR_REGISTRY}"
 
             docker compose pull
-            docker compose up -d --remove-orphans
+            docker compose up -d
             docker image prune -f

--- a/src/main/kotlin/com/bandage/v1/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/bandage/v1/global/security/SecurityConfig.kt
@@ -59,6 +59,7 @@ class SecurityConfig(
                     listOf(
                         "http://localhost:*",
                         "http://127.0.0.1:*",
+                        "https://bandage.team",
                     )
                 allowedMethods =
                     listOf(


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #

📌 **작업 내용 및 특이사항**

운영 환경에서 발생한 두 건의 hotfix 를 한 PR 로 묶음.

### 1. `develop_deploy.yml`: `docker compose --remove-orphans` 제거
- **현상**: BE CD 가 돌 때마다 동일 EC2 의 FE 도커 컨테이너가 함께 내려가는 문제 (FE 팀 신고).
- **원인**: `docker compose up -d --remove-orphans` 는 현재 compose 파일에 정의되지 않았지만 동일 compose project 라벨(기본값 = compose 파일 디렉토리명)을 공유하는 컨테이너를 자동 제거한다. FE 컨테이너가 동일 project name 을 공유하면서 매 BE 배포마다 orphan 으로 간주되어 강제 종료됨.
- **조치**: `--remove-orphans` 플래그 제거.
- **트레이드오프**: BE compose 파일에서 서비스를 빼는 경우(예: `bandage-music-metadata` 주석처럼) 잔여 컨테이너가 자동 청소되지 않음 → 운영자가 `docker rm` 으로 수동 정리 필요. FE 보호가 우선이라 감수.

### 2. `SecurityConfig.kt`: CORS allowedOriginPatterns 에 `https://bandage.team` 추가
- **현상**: 운영 FE(`https://bandage.team`) 가 BE API 호출 시 CORS 차단.
- **원인**: 기존 화이트리스트가 `http://localhost:*`, `http://127.0.0.1:*` 만 포함.
- **조치**: `https://bandage.team` 추가. 나머지 옵션(allowedMethods / allowedHeaders / exposedHeaders / allowCredentials / maxAge) 변경 없음.

📚 **참고사항**

- 두 변경 모두 부수효과 없는 단순 수정 (워크플로우 한 줄, CORS 리스트 한 항목).
- Jira 키 미지정 — 추후 매핑 필요 시 알려주세요.