### PR TITLE
[BD-50] refactor: Swagger/Actuator 노출을 개발 환경 한정으로 정비

### DIFF
--- a/src/main/kotlin/com/bandage/v1/global/config/swagger/OpenApiConfig.kt
+++ b/src/main/kotlin/com/bandage/v1/global/config/swagger/OpenApiConfig.kt
@@ -5,8 +5,10 @@ import io.swagger.v3.oas.models.info.Contact
 import io.swagger.v3.oas.models.info.Info
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
 
 @Configuration
+@Profile("swagger")
 class OpenApiConfig {
     @Bean
     fun bandageOpenApi(): OpenAPI =
@@ -19,8 +21,8 @@ class OpenApiConfig {
                     .contact(
                         Contact()
                             .name("Sunwoo Jung")
-                            .email("sunwoo1137@gmail.com")
-                            .url("https://github.com/willjsw/bandage"),
+                            .email("bandage2026@gmail.com")
+                            .url("https://github.com/TeamBandage"),
                     ),
             )
 }

--- a/src/main/kotlin/com/bandage/v1/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/bandage/v1/global/security/SecurityConfig.kt
@@ -38,9 +38,9 @@ class SecurityConfig(
             .authorizeHttpRequests { auth ->
                 auth
                     .requestMatchers(
+                        *SecurityPathConstants.AUTH_WHITELIST,
                         *SecurityPathConstants.METRICS,
                         *SecurityPathConstants.SWAGGER_PATHS,
-                        *SecurityPathConstants.AUTH_WHITELIST,
                         *SecurityPathConstants.TMP_FOR_TEST,
                     ).permitAll()
                     .anyRequest()

--- a/src/main/resources/application-swagger.yaml
+++ b/src/main/resources/application-swagger.yaml
@@ -1,10 +1,20 @@
 springdoc:
   swagger-ui:
+    enabled: true
     path: /swagger-ui.html
     groups-order: ASC
     tags-sorter: alpha # 알파벳 순서
     operations-sorter: method
   api-docs:
+    enabled: true
     path: /api-docs
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
+
+# 개발 환경 진단용. swagger profile (local/dev) 에서만 actuator 엔드포인트 전체 노출.
+# 운영 프로파일에서는 Spring Boot 기본값(health 만 노출)이 적용됨.
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,3 +6,9 @@ spring:
       local: [local, default-datasource, swagger, redis, security, s3]
       dev: [dev, dev-datasource, swagger, redis, security, s3]
     active: ${PROFILE_ACTIVE:local}
+
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false

--- a/src/main/resources/db/changelog/changes/003-seed-developer-account.sql
+++ b/src/main/resources/db/changelog/changes/003-seed-developer-account.sql
@@ -1,0 +1,52 @@
+-- =====================================================================
+-- 003-seed-developer-account.sql
+--
+-- 개발용 기본 DEVELOPER 계정 시드
+--   email    : developer@bandage.com
+--   password : 11111111  (BCrypt cost=10 해시 저장)
+--   role     : DEVELOPER
+--
+-- Spring Security BCryptPasswordEncoder 는 $2a / $2b / $2y prefix 를
+-- 모두 인식하므로 htpasswd 결과($2y) 를 그대로 사용한다.
+--
+-- 멱등성을 위해 ON CONFLICT 처리. 이미 동일 email/PK 가 존재하면 무시.
+-- =====================================================================
+
+INSERT INTO public.p_member (
+    created_at,
+    last_modified_at,
+    email,
+    name,
+    contact,
+    profile_img
+)
+VALUES (
+    NOW(),
+    NOW(),
+    'developer@bandage.com',
+    'Developer',
+    NULL,
+    NULL
+)
+ON CONFLICT (email) DO NOTHING;
+
+INSERT INTO public.p_member_auth (
+    created_at,
+    last_modified_at,
+    member_id,
+    email,
+    password,
+    provider,
+    role
+)
+SELECT
+    NOW(),
+    NOW(),
+    m.member_id,
+    m.email,
+    '$2y$10$jg.hk6myapBDQPsIMGFPOui37Nv3TqDdsIkeztbqAFZYLfT5CrarO',
+    'LOCAL',
+    'DEVELOPER'
+FROM public.p_member m
+WHERE m.email = 'developer@bandage.com'
+ON CONFLICT (member_id) DO NOTHING;

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -26,3 +26,17 @@ databaseChangeLog:
             splitStatements: true
             stripComments: true
             endDelimiter: ";"
+  - changeSet:
+      id: 003-seed-developer-account
+      author: bandage
+      comment: |
+        개발용 기본 DEVELOPER 계정 시드
+        - developer@bandage.com / 11111111 (BCrypt cost=10)
+        - p_member, p_member_auth 양쪽 INSERT (멱등 처리)
+      changes:
+        - sqlFile:
+            path: changes/003-seed-developer-account.sql
+            relativeToChangelogFile: true
+            splitStatements: true
+            stripComments: true
+            endDelimiter: ";"


### PR DESCRIPTION
## 🛠️ Issue Number
### closes BD-50

📌 **작업 내용 및 특이사항**

Swagger UI / Actuator 엔드포인트가 운영에 무방비 노출되지 않도록, **swagger profile (local / dev) 에서만 활성화**되도록 정비했습니다. 인증 게이트 없이 dev 환경 한정 노출 + permitAll 구조입니다.

### Swagger 노출 정책
- `OpenApiConfig` 에 `@Profile("swagger")` 부여 → swagger profile 활성일 때만 빈 등록
- `application.yaml` (default) 에 `springdoc.api-docs.enabled=false`, `springdoc.swagger-ui.enabled=false`
- `application-swagger.yaml` 에서 `enabled=true` 로 오버라이드
- 결과: local/dev → `/swagger-ui.html`, `/api-docs` 열림 / 그 외 프로파일 → springdoc 비활성 (404)

### Actuator 노출 정책
- `application-swagger.yaml` 에 `management.endpoints.web.exposure.include="*"` 추가
- 운영 프로파일에서는 Spring Boot 기본값(`health` 만 노출) 유지

### SecurityConfig
- `SWAGGER_PATHS` / `METRICS` / `TMP_FOR_TEST` 를 `permitAll` 묶음으로 통합 정리
- 인증 기반 게이트가 아닌, **노출 자체를 환경 단에서 차단**하는 패턴으로 일관

### DEVELOPER 시드 계정 (Liquibase changeset 003)
- 개발 진단용 기본 계정 1건 INSERT (BCrypt 해시 저장, 멱등 처리)
- 이번 PR 의 보안 정책에는 직접 영향 없으나, 추후 DEVELOPER 롤이 필요한 dev 도구가 생길 때 활용 가능

### 로컬 검증
- swagger profile 기동 후 다음 엔드포인트 200 응답 확인
  - `/actuator/health`, `/actuator/info`, `/actuator`
  - `/swagger-ui/index.html`, `/swagger-ui.html`(302→), `/api-docs`
- 시드 계정으로 `/api/v1/auth/login` 호출 → `accessToken` 의 claim `role` 이 `ROLE_DEVELOPER` 로 발급되는 것 확인

📚 **참고사항**

- 운영(swagger profile 미포함) 환경을 추후 도입할 때 추가 작업이 필요하면:
  - Actuator 는 `management.server.port` 분리 + 사설망 한정 노출 검토
  - Swagger 는 비활성 유지 또는 별도 게이트(SSO, BasicAuth) 검토