### PR TITLE
[BD-33] PRD-2 M2: ScheduleBoard Performance 이전 및 Confirm 재작성 (T5~T9)

### DIFF
--- a/src/main/kotlin/com/bandage/v1/domain/schedule/controller/ScheduleBlockController.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/schedule/controller/ScheduleBlockController.kt
@@ -19,43 +19,43 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
-@Tag(name = "schedule-blocks", description = "시간표 블록 API")
+@Tag(name = "schedule-blocks", description = "시간표 블록 API (공연 단위)")
 @RestController
-@RequestMapping("$PREFIX/setlist-meetings/{meetingId}/schedule-boards/{boardId}/blocks")
+@RequestMapping("$PREFIX/performances/{performanceId}/schedule-boards/{boardId}/blocks")
 class ScheduleBlockController(
     private val scheduleBlockService: ScheduleBlockService,
 ) {
     @PutMapping("/{blockId}")
-    @Operation(summary = "시간표 블록 등록/수정", description = "매니저 권한, blockId 가 없으면 새로 생성, 있으면 갱신.")
+    @Operation(summary = "시간표 블록 등록/수정", description = "공연 매니저 권한, blockId 가 없으면 새로 생성, 있으면 갱신.")
     fun upsertBlock(
-        @PathVariable meetingId: UUID,
+        @PathVariable performanceId: UUID,
         @PathVariable boardId: UUID,
         @PathVariable blockId: UUID,
         @CurrentMemberId memberId: Long,
         @Valid @RequestBody request: ScheduleBlockUpsertRequest,
     ): ApiResponse<ScheduleBlockResponse> =
-        ApiResponse.success(scheduleBlockService.upsertBlock(meetingId, boardId, blockId, memberId, request))
+        ApiResponse.success(scheduleBlockService.upsertBlock(performanceId, boardId, blockId, memberId, request))
 
     @DeleteMapping("/{blockId}")
-    @Operation(summary = "시간표 블록 삭제", description = "매니저 권한, confirmed=true 인 시안의 블록은 삭제 불가.")
+    @Operation(summary = "시간표 블록 삭제", description = "공연 매니저 권한, confirmed=true 인 시안의 블록은 삭제 불가.")
     fun deleteBlock(
-        @PathVariable meetingId: UUID,
+        @PathVariable performanceId: UUID,
         @PathVariable boardId: UUID,
         @PathVariable blockId: UUID,
         @CurrentMemberId memberId: Long,
     ): ApiResponse<Unit> {
-        scheduleBlockService.deleteBlock(meetingId, boardId, blockId, memberId)
+        scheduleBlockService.deleteBlock(performanceId, boardId, blockId, memberId)
         return ApiResponse.success()
     }
 
     @PatchMapping("/{blockId}/pin")
-    @Operation(summary = "시간표 블록 핀 토글", description = "매니저 권한, 요청 body 의 pinned 값으로 설정.")
+    @Operation(summary = "시간표 블록 핀 토글", description = "공연 매니저 권한, 요청 body 의 pinned 값으로 설정.")
     fun setPin(
-        @PathVariable meetingId: UUID,
+        @PathVariable performanceId: UUID,
         @PathVariable boardId: UUID,
         @PathVariable blockId: UUID,
         @CurrentMemberId memberId: Long,
         @Valid @RequestBody request: ScheduleBlockPinRequest,
     ): ApiResponse<ScheduleBlockResponse> =
-        ApiResponse.success(scheduleBlockService.setPin(meetingId, boardId, blockId, memberId, request.pinned))
+        ApiResponse.success(scheduleBlockService.setPin(performanceId, boardId, blockId, memberId, request.pinned))
 }

--- a/src/main/kotlin/com/bandage/v1/domain/schedule/controller/ScheduleBoardController.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/schedule/controller/ScheduleBoardController.kt
@@ -23,78 +23,67 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
-@Tag(name = "schedule-boards", description = "시간표 시안 API")
+@Tag(name = "schedule-boards", description = "시간표 시안 API (공연 단위)")
 @RestController
-@RequestMapping("$PREFIX/setlist-meetings/{meetingId}/schedule-boards")
+@RequestMapping("$PREFIX/performances/{performanceId}/schedule-boards")
 class ScheduleBoardController(
     private val scheduleBoardService: ScheduleBoardService,
     private val scheduleConfirmFacade: ScheduleConfirmFacade,
 ) {
     @GetMapping
-    @Operation(summary = "시간표 시안 목록", description = "회의 참여자만 호출 가능.")
+    @Operation(summary = "시간표 시안 목록", description = "공연 참여자만 호출 가능.")
     fun getBoards(
-        @PathVariable meetingId: UUID,
+        @PathVariable performanceId: UUID,
         @CurrentMemberId memberId: Long,
-    ): ApiResponse<List<ScheduleBoardResponse>> = ApiResponse.success(scheduleBoardService.getBoards(meetingId, memberId))
+    ): ApiResponse<List<ScheduleBoardResponse>> = ApiResponse.success(scheduleBoardService.getBoards(performanceId, memberId))
 
     @PostMapping
-    @Operation(summary = "시간표 시안 생성", description = "매니저 권한, 회의당 최대 5개.")
+    @Operation(summary = "시간표 시안 생성", description = "공연 매니저 권한, 공연당 최대 5개.")
     fun createBoard(
-        @PathVariable meetingId: UUID,
+        @PathVariable performanceId: UUID,
         @CurrentMemberId memberId: Long,
         @Valid @RequestBody request: ScheduleBoardCreateRequest,
-    ): ApiResponse<ScheduleBoardResponse> = ApiResponse.success(scheduleBoardService.createBoard(meetingId, memberId, request))
+    ): ApiResponse<ScheduleBoardResponse> = ApiResponse.success(scheduleBoardService.createBoard(performanceId, memberId, request))
 
     @PatchMapping("/{boardId}")
-    @Operation(summary = "시간표 시안 수정", description = "매니저 권한, confirmed=true 인 시안은 수정 불가(409).")
+    @Operation(summary = "시간표 시안 수정", description = "공연 매니저 권한, confirmed=true 인 시안은 수정 불가(409).")
     fun updateBoard(
-        @PathVariable meetingId: UUID,
+        @PathVariable performanceId: UUID,
         @PathVariable boardId: UUID,
         @CurrentMemberId memberId: Long,
         @Valid @RequestBody request: ScheduleBoardUpdateRequest,
-    ): ApiResponse<ScheduleBoardResponse> = ApiResponse.success(scheduleBoardService.updateBoard(meetingId, boardId, memberId, request))
-
-//    @PostMapping("/auto-suggest")
-//    @Operation(summary = "시간표 시안 자동 생성", description = "합주 일정 블럭 자동 배치")
-//    fun autoSuggestBoard(
-//        @PathVariable meetingID: UUID,
-//        @CurrentMemberId memberId: Long,
-//        @RequestParam suggestionQty: Int,
-//    ): ApiResponse<ScheduleBoardResponse> =
-//        ApiResponse.success(scheduleBoardArrangeFacade.setupInitialScheduleBoard(meetingID, memberId, suggestionQty))
+    ): ApiResponse<ScheduleBoardResponse> = ApiResponse.success(scheduleBoardService.updateBoard(performanceId, boardId, memberId, request))
 
     @DeleteMapping("/{boardId}")
-    @Operation(summary = "시간표 시안 삭제", description = "매니저 권한, confirmed=true 인 시안은 삭제 불가(409).")
+    @Operation(summary = "시간표 시안 삭제", description = "공연 매니저 권한, confirmed=true 인 시안은 삭제 불가(409).")
     fun deleteBoard(
-        @PathVariable meetingId: UUID,
+        @PathVariable performanceId: UUID,
         @PathVariable boardId: UUID,
         @CurrentMemberId memberId: Long,
     ): ApiResponse<Unit> {
-        scheduleBoardService.deleteBoard(meetingId, boardId, memberId)
+        scheduleBoardService.deleteBoard(performanceId, boardId, memberId)
         return ApiResponse.success()
     }
 
     @PostMapping("/{boardId}/confirm")
     @Operation(
         summary = "시간표 시안 확정",
-        description =
-            "매니저 권한. setlist meeting 이 lock 상태여야 하며, 같은 회의에 confirmed 시안이 이미 있으면 409. " +
-                "확정 시 모든 ScheduleBlock 을 Jam 으로 일괄 생성.",
+        description = "공연 매니저 권한. 같은 공연에 confirmed 시안이 이미 있으면 409. 확정 시 모든 ScheduleBlock 을 Jam 으로 일괄 생성.",
     )
     fun confirmBoard(
-        @PathVariable meetingId: UUID,
+        @PathVariable performanceId: UUID,
         @PathVariable boardId: UUID,
         @CurrentMemberId memberId: Long,
-    ): ApiResponse<ScheduleConfirmResponse> = ApiResponse.success(scheduleConfirmFacade.confirmBoard(meetingId, boardId, memberId))
+    ): ApiResponse<ScheduleConfirmResponse> = ApiResponse.success(scheduleConfirmFacade.confirmBoard(performanceId, boardId, memberId))
 
     @PostMapping("/{boardId}/unconfirm")
     @Operation(
         summary = "시간표 시안 확정 해제",
-        description = "매니저 권한. 이미 생성된 Jam 은 유지되고 board.confirmed 만 false 로 토글.",
+        description = "공연 매니저 권한. 생성된 Jam 은 정리(soft-delete)되고 board.confirmed 가 false 로 토글.",
     )
     fun unconfirmBoard(
-        @PathVariable meetingId: UUID,
+        @PathVariable performanceId: UUID,
         @PathVariable boardId: UUID,
         @CurrentMemberId memberId: Long,
-    ): ApiResponse<ScheduleUnconfirmResponse> = ApiResponse.success(scheduleConfirmFacade.unconfirmBoard(meetingId, boardId, memberId))
+    ): ApiResponse<ScheduleUnconfirmResponse> = ApiResponse.success(scheduleConfirmFacade.unconfirmBoard(performanceId, boardId, memberId))
 }

--- a/src/main/kotlin/com/bandage/v1/domain/schedule/dto/req/ScheduleBlockUpsertRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/schedule/dto/req/ScheduleBlockUpsertRequest.kt
@@ -1,14 +1,16 @@
 package com.bandage.v1.domain.schedule.dto.req
 
+import com.bandage.v1.domain.schedule.model.RecurrenceFreq
 import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import java.time.LocalDate
 import java.util.UUID
 
 data class ScheduleBlockUpsertRequest(
-    @field:NotNull(message = "songId 는 필수입니다.")
-    val songId: UUID,
+    @field:NotEmpty(message = "trackIds 는 최소 1개 이상이어야 합니다.")
+    val trackIds: List<UUID>,
     @field:NotNull(message = "date 는 필수입니다.")
     val date: LocalDate,
     @field:NotNull
@@ -19,7 +21,16 @@ data class ScheduleBlockUpsertRequest(
     val durationSlots: Int,
     val pinned: Boolean? = null,
     val paletteIndex: Int? = null,
-    val songTitleOverride: String? = null,
+    val titleOverride: String? = null,
     @field:Size(max = 200, message = "note 는 최대 200자까지 입력할 수 있습니다.")
     val note: String? = null,
-)
+    val recurrence: RecurrenceRequest? = null,
+) {
+    data class RecurrenceRequest(
+        val freq: RecurrenceFreq = RecurrenceFreq.NONE,
+        @field:Min(value = 1, message = "interval 은 1 이상이어야 합니다.")
+        val interval: Int = 1,
+        val until: LocalDate? = null,
+        val count: Int? = null,
+    )
+}

--- a/src/main/kotlin/com/bandage/v1/domain/schedule/dto/req/ScheduleBoardCreateRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/schedule/dto/req/ScheduleBoardCreateRequest.kt
@@ -3,6 +3,7 @@ package com.bandage.v1.domain.schedule.dto.req
 import com.bandage.v1.domain.schedule.dto.ScheduleBoardConstraintsDto
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
+import java.time.LocalDate
 
 data class ScheduleBoardCreateRequest(
     @field:NotBlank(message = "name 은 필수입니다.")
@@ -10,4 +11,7 @@ data class ScheduleBoardCreateRequest(
     val name: String,
     val paletteSeed: Int? = null,
     val constraints: ScheduleBoardConstraintsDto? = null,
+    // 보드 레벨 연습 가능 날짜 범위(선택). 미지정 시 Performance 기준.
+    val windowFrom: LocalDate? = null,
+    val windowTo: LocalDate? = null,
 )

--- a/src/main/kotlin/com/bandage/v1/domain/schedule/dto/req/ScheduleBoardUpdateRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/schedule/dto/req/ScheduleBoardUpdateRequest.kt
@@ -2,10 +2,13 @@ package com.bandage.v1.domain.schedule.dto.req
 
 import com.bandage.v1.domain.schedule.dto.ScheduleBoardConstraintsDto
 import jakarta.validation.constraints.Size
+import java.time.LocalDate
 
 data class ScheduleBoardUpdateRequest(
     @field:Size(max = 50, message = "name 은 최대 50자까지 입력할 수 있습니다.")
     val name: String? = null,
     val paletteSeed: Int? = null,
     val constraints: ScheduleBoardConstraintsDto? = null,
+    val windowFrom: LocalDate? = null,
+    val windowTo: LocalDate? = null,
 )

--- a/src/main/kotlin/com/bandage/v1/domain/schedule/dto/res/ScheduleBlockResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/schedule/dto/res/ScheduleBlockResponse.kt
@@ -1,32 +1,54 @@
 package com.bandage.v1.domain.schedule.dto.res
 
+import com.bandage.v1.domain.schedule.model.PlacementOrigin
+import com.bandage.v1.domain.schedule.model.RecurrenceFreq
 import com.bandage.v1.domain.schedule.model.ScheduleBlock
 import java.time.LocalDate
 import java.util.UUID
 
 data class ScheduleBlockResponse(
     val blockId: UUID,
-    val songId: UUID,
+    val trackIds: List<UUID>,
     val date: LocalDate,
     val startSlot: Int,
     val durationSlots: Int,
     val pinned: Boolean,
     val paletteIndex: Int?,
-    val songTitleOverride: String?,
+    val titleOverride: String?,
     val note: String?,
+    val recurrence: RecurrenceDto,
+    val placementOrigin: PlacementOrigin,
 ) {
+    data class RecurrenceDto(
+        val freq: RecurrenceFreq,
+        val interval: Int,
+        val until: LocalDate?,
+        val count: Int?,
+    )
+
     companion object {
-        fun from(block: ScheduleBlock): ScheduleBlockResponse =
+        fun from(
+            block: ScheduleBlock,
+            trackIds: List<UUID>,
+        ): ScheduleBlockResponse =
             ScheduleBlockResponse(
                 blockId = block.id,
-                songId = block.songId,
+                trackIds = trackIds,
                 date = block.date,
                 startSlot = block.startSlot,
                 durationSlots = block.durationSlots,
                 pinned = block.pinned,
                 paletteIndex = block.paletteIndex,
-                songTitleOverride = block.songTitleOverride,
+                titleOverride = block.titleOverride,
                 note = block.note,
+                recurrence =
+                    RecurrenceDto(
+                        freq = block.recurrenceRule.freq,
+                        interval = block.recurrenceRule.interval,
+                        until = block.recurrenceRule.until,
+                        count = block.recurrenceRule.count,
+                    ),
+                placementOrigin = block.placementOrigin,
             )
     }
 }

--- a/src/main/kotlin/com/bandage/v1/domain/schedule/dto/res/ScheduleBoardResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/schedule/dto/res/ScheduleBoardResponse.kt
@@ -3,16 +3,19 @@ package com.bandage.v1.domain.schedule.dto.res
 import com.bandage.v1.domain.schedule.dto.ScheduleBoardConstraintsDto
 import com.bandage.v1.domain.schedule.model.ScheduleBlock
 import com.bandage.v1.domain.schedule.model.ScheduleBoard
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
 
 data class ScheduleBoardResponse(
     val boardId: UUID,
-    val meetingId: UUID,
+    val performanceId: UUID,
     val name: String,
     val paletteSeed: Int?,
     val confirmed: Boolean,
     val constraints: ScheduleBoardConstraintsDto,
+    val windowFrom: LocalDate?,
+    val windowTo: LocalDate?,
     val blocks: List<ScheduleBlockResponse>,
     val version: Long,
     val createdAt: LocalDateTime,
@@ -21,15 +24,18 @@ data class ScheduleBoardResponse(
         fun of(
             board: ScheduleBoard,
             blocks: List<ScheduleBlock>,
+            trackIdsByBlock: Map<UUID, List<UUID>> = emptyMap(),
         ): ScheduleBoardResponse =
             ScheduleBoardResponse(
                 boardId = board.id,
-                meetingId = board.meetingId,
+                performanceId = board.performanceId,
                 name = board.name,
                 paletteSeed = board.paletteSeed,
                 confirmed = board.confirmed,
                 constraints = ScheduleBoardConstraintsDto.from(board.constraints),
-                blocks = blocks.map { ScheduleBlockResponse.from(it) },
+                windowFrom = board.windowFrom,
+                windowTo = board.windowTo,
+                blocks = blocks.map { ScheduleBlockResponse.from(it, trackIdsByBlock[it.id].orEmpty()) },
                 version = board.version,
                 createdAt = board.createdAt,
             )

--- a/src/main/kotlin/com/bandage/v1/domain/schedule/model/PlacementOrigin.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/schedule/model/PlacementOrigin.kt
@@ -1,0 +1,13 @@
+package com.bandage.v1.domain.schedule.model
+
+/**
+ * ScheduleBlock 이 어떻게 배치되었는지 출처.
+ * - MANUAL: 사용자가 직접 배치
+ * - AUTO: AutoPlacer 자동 배치
+ * - ANCHORED: 자동 배치 후 사용자가 고정(anchor)한 블록
+ */
+enum class PlacementOrigin {
+    MANUAL,
+    AUTO,
+    ANCHORED,
+}

--- a/src/main/kotlin/com/bandage/v1/domain/schedule/model/RecurrenceFreq.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/schedule/model/RecurrenceFreq.kt
@@ -1,0 +1,12 @@
+package com.bandage.v1.domain.schedule.model
+
+/**
+ * ScheduleBlock 의 반복 주기.
+ * NONE 이면 단발성 블록, 그 외는 반복 전개(expandRecurrence) 대상이다.
+ */
+enum class RecurrenceFreq {
+    NONE,
+    DAILY,
+    WEEKLY,
+    BIWEEKLY,
+}

--- a/src/main/kotlin/com/bandage/v1/domain/schedule/model/RecurrenceRule.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/schedule/model/RecurrenceRule.kt
@@ -1,0 +1,48 @@
+package com.bandage.v1.domain.schedule.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import java.time.LocalDate
+
+/**
+ * ScheduleBlock 의 반복 배치 규칙.
+ *
+ * freq == NONE 이면 단발성이며 나머지 필드는 무시된다.
+ * 반복 블록은 ScheduleConfirmFacade.expandRecurrence 에서 [anchorDate, until] 구간을 전개해
+ * 실제 Jam 인스턴스들로 펼친다.
+ */
+@Embeddable
+open class RecurrenceRule(
+    freq: RecurrenceFreq = RecurrenceFreq.NONE,
+    interval: Int = 1,
+    until: LocalDate? = null,
+    count: Int? = null,
+) {
+    @Enumerated(EnumType.STRING)
+    @Column(name = "recurrence_freq", nullable = false)
+    var freq: RecurrenceFreq = freq
+        protected set
+
+    // freq 의 배수 간격(예: WEEKLY + interval=2 → 격주). 최소 1.
+    @Column(name = "recurrence_interval", nullable = false)
+    var interval: Int = interval
+        protected set
+
+    // 반복 종료일(포함). null 이면 count 로 제한하거나 보드 window 로 제한.
+    @Column(name = "recurrence_until", nullable = true)
+    var until: LocalDate? = until
+        protected set
+
+    // 최대 반복 횟수. null 이면 until/window 로 제한.
+    @Column(name = "recurrence_count", nullable = true)
+    var count: Int? = count
+        protected set
+
+    val isRecurring: Boolean get() = freq != RecurrenceFreq.NONE
+
+    companion object {
+        fun none(): RecurrenceRule = RecurrenceRule(freq = RecurrenceFreq.NONE)
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/schedule/model/ScheduleBlock.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/schedule/model/ScheduleBlock.kt
@@ -3,7 +3,10 @@ package com.bandage.v1.domain.schedule.model
 import com.bandage.v1.global.common.domain.BaseEntity
 import com.github.f4b6a3.uuid.UuidCreator
 import jakarta.persistence.Column
+import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
@@ -15,19 +18,27 @@ import org.hibernate.annotations.SQLRestriction
 import java.time.LocalDate
 import java.util.UUID
 
+/**
+ * 시간표 블록(하나의 연습 시간 구간).
+ *
+ * PRD-2 변경점:
+ * - 단일 songId 제거 → SetlistTrack 과 N:M([ScheduleBlockTrack])
+ * - 반복 배치 규칙(recurrenceRule) 및 배치 출처(placementOrigin) 메타데이터 추가
+ */
 @Entity
 @Table(name = "p_schedule_block")
 @SQLRestriction("deleted_at IS NULL")
 open class ScheduleBlock(
     id: UUID,
     board: ScheduleBoard,
-    songId: UUID,
     date: LocalDate,
     startSlot: Int,
     durationSlots: Int,
     paletteIndex: Int?,
-    songTitleOverride: String?,
+    titleOverride: String?,
     note: String?,
+    recurrenceRule: RecurrenceRule,
+    placementOrigin: PlacementOrigin,
 ) : BaseEntity() {
     @Id
     @Column(name = "schedule_block_id")
@@ -37,9 +48,6 @@ open class ScheduleBlock(
     @JoinColumn(name = "schedule_board_id", nullable = false)
     @OnDelete(action = OnDeleteAction.CASCADE)
     val board: ScheduleBoard = board
-
-    @Column(name = "song_id", nullable = false)
-    val songId: UUID = songId
 
     @Column(name = "block_date", nullable = false)
     var date: LocalDate = date
@@ -61,12 +69,21 @@ open class ScheduleBlock(
     var paletteIndex: Int? = paletteIndex
         protected set
 
-    @Column(name = "song_title_override", nullable = true)
-    var songTitleOverride: String? = songTitleOverride
+    @Column(name = "title_override", nullable = true)
+    var titleOverride: String? = titleOverride
         protected set
 
     @Column(name = "note", nullable = true, length = 200)
     var note: String? = note
+        protected set
+
+    @Embedded
+    var recurrenceRule: RecurrenceRule = recurrenceRule
+        protected set
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "placement_origin", nullable = false)
+    var placementOrigin: PlacementOrigin = placementOrigin
         protected set
 
     companion object {
@@ -74,15 +91,35 @@ open class ScheduleBlock(
 
         fun create(
             board: ScheduleBoard,
-            songId: UUID,
             date: LocalDate,
             startSlot: Int,
             durationSlots: Int,
             paletteIndex: Int? = null,
-            songTitleOverride: String? = null,
+            titleOverride: String? = null,
             note: String? = null,
+            recurrenceRule: RecurrenceRule = RecurrenceRule.none(),
+            placementOrigin: PlacementOrigin = PlacementOrigin.MANUAL,
             id: UUID = UuidCreator.getTimeOrderedEpoch(),
         ): ScheduleBlock {
+            validateSlot(startSlot, durationSlots)
+            return ScheduleBlock(
+                id = id,
+                board = board,
+                date = date,
+                startSlot = startSlot,
+                durationSlots = durationSlots,
+                paletteIndex = paletteIndex,
+                titleOverride = titleOverride,
+                note = note,
+                recurrenceRule = recurrenceRule,
+                placementOrigin = placementOrigin,
+            )
+        }
+
+        private fun validateSlot(
+            startSlot: Int,
+            durationSlots: Int,
+        ) {
             require(startSlot in 0 until SLOTS_PER_DAY) {
                 "startSlot must be in 0..${SLOTS_PER_DAY - 1}, was $startSlot"
             }
@@ -92,17 +129,6 @@ open class ScheduleBlock(
             require(startSlot + durationSlots <= SLOTS_PER_DAY) {
                 "startSlot + durationSlots must be <= $SLOTS_PER_DAY (got ${startSlot + durationSlots})"
             }
-            return ScheduleBlock(
-                id = id,
-                board = board,
-                songId = songId,
-                date = date,
-                startSlot = startSlot,
-                durationSlots = durationSlots,
-                paletteIndex = paletteIndex,
-                songTitleOverride = songTitleOverride,
-                note = note,
-            )
         }
     }
 
@@ -111,15 +137,7 @@ open class ScheduleBlock(
         startSlot: Int,
         durationSlots: Int,
     ) {
-        require(startSlot in 0 until SLOTS_PER_DAY) {
-            "startSlot must be in 0..${SLOTS_PER_DAY - 1}, was $startSlot"
-        }
-        require(durationSlots >= 1) {
-            "durationSlots must be >= 1, was $durationSlots"
-        }
-        require(startSlot + durationSlots <= SLOTS_PER_DAY) {
-            "startSlot + durationSlots must be <= $SLOTS_PER_DAY (got ${startSlot + durationSlots})"
-        }
+        validateSlot(startSlot, durationSlots)
         this.date = date
         this.startSlot = startSlot
         this.durationSlots = durationSlots
@@ -137,11 +155,19 @@ open class ScheduleBlock(
         this.paletteIndex = index
     }
 
-    fun updateSongTitleOverride(title: String?) {
-        this.songTitleOverride = title
+    fun updateTitleOverride(title: String?) {
+        this.titleOverride = title
     }
 
     fun updateNote(note: String?) {
         this.note = note
+    }
+
+    fun updateRecurrenceRule(rule: RecurrenceRule) {
+        this.recurrenceRule = rule
+    }
+
+    fun updatePlacementOrigin(origin: PlacementOrigin) {
+        this.placementOrigin = origin
     }
 }

--- a/src/main/kotlin/com/bandage/v1/domain/schedule/model/ScheduleBlockJam.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/schedule/model/ScheduleBlockJam.kt
@@ -1,0 +1,56 @@
+package com.bandage.v1.domain.schedule.model
+
+import com.github.f4b6a3.uuid.UuidCreator
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import java.util.UUID
+
+/**
+ * ScheduleBlock(+반복 전개 인스턴스) → 확정 생성된 Jam 추적 매핑.
+ *
+ * confirmBoard 시 어떤 블록이 어떤 Jam 들을 만들었는지 기록하여, unconfirm/재확정 시 추적·정리에 사용한다.
+ * occurrenceDate 는 반복 전개된 개별 발생일(단발성이면 블록 date 와 동일).
+ * 파생 추적 테이블이므로 감사/소프트삭제 필드를 두지 않는다.
+ */
+@Entity
+@Table(
+    name = "p_schedule_block_jam",
+    indexes = [
+        Index(name = "idx_schedule_block_jam_block", columnList = "schedule_block_id"),
+        Index(name = "idx_schedule_block_jam_board", columnList = "schedule_board_id"),
+    ],
+)
+open class ScheduleBlockJam(
+    scheduleBlockId: UUID,
+    scheduleBoardId: UUID,
+    jamId: UUID,
+) {
+    @Id
+    @Column(name = "schedule_block_jam_id")
+    val id: UUID = UuidCreator.getTimeOrderedEpoch()
+
+    @Column(name = "schedule_block_id", nullable = false)
+    val scheduleBlockId: UUID = scheduleBlockId
+
+    @Column(name = "schedule_board_id", nullable = false)
+    val scheduleBoardId: UUID = scheduleBoardId
+
+    @Column(name = "jam_id", nullable = false)
+    val jamId: UUID = jamId
+
+    companion object {
+        fun create(
+            scheduleBlockId: UUID,
+            scheduleBoardId: UUID,
+            jamId: UUID,
+        ): ScheduleBlockJam =
+            ScheduleBlockJam(
+                scheduleBlockId = scheduleBlockId,
+                scheduleBoardId = scheduleBoardId,
+                jamId = jamId,
+            )
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/schedule/model/ScheduleBlockTrack.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/schedule/model/ScheduleBlockTrack.kt
@@ -1,0 +1,75 @@
+package com.bandage.v1.domain.schedule.model
+
+import com.bandage.v1.global.common.domain.BaseEntity
+import com.github.f4b6a3.uuid.UuidCreator
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.OnDelete
+import org.hibernate.annotations.OnDeleteAction
+import org.hibernate.annotations.SQLRestriction
+import java.util.UUID
+
+/**
+ * ScheduleBlock 과 SetlistTrack 의 N:M 매핑.
+ *
+ * 기존 단일 songId 를 대체한다. 한 블록(시간 구간)에 여러 트랙을 묶어 함께 연습할 수 있다.
+ * ordinal 로 블록 내 트랙 순서를 유지한다.
+ */
+@Entity
+@Table(
+    name = "p_schedule_block_track",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_schedule_block_track",
+            columnNames = ["schedule_block_id", "setlist_track_id"],
+        ),
+    ],
+)
+@SQLRestriction("deleted_at IS NULL")
+open class ScheduleBlockTrack(
+    id: UUID,
+    block: ScheduleBlock,
+    setlistTrackId: UUID,
+    ordinal: Int,
+) : BaseEntity() {
+    @Id
+    @Column(name = "schedule_block_track_id")
+    val id: UUID = id
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "schedule_block_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    val block: ScheduleBlock = block
+
+    @Column(name = "setlist_track_id", nullable = false)
+    val setlistTrackId: UUID = setlistTrackId
+
+    @Column(name = "ordinal", nullable = false)
+    var ordinal: Int = ordinal
+        protected set
+
+    fun updateOrdinal(ordinal: Int) {
+        this.ordinal = ordinal
+    }
+
+    companion object {
+        fun create(
+            block: ScheduleBlock,
+            setlistTrackId: UUID,
+            ordinal: Int,
+            id: UUID = UuidCreator.getTimeOrderedEpoch(),
+        ): ScheduleBlockTrack =
+            ScheduleBlockTrack(
+                id = id,
+                block = block,
+                setlistTrackId = setlistTrackId,
+                ordinal = ordinal,
+            )
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/schedule/model/ScheduleBoard.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/schedule/model/ScheduleBoard.kt
@@ -1,5 +1,6 @@
 package com.bandage.v1.domain.schedule.model
 
+import com.bandage.v1.domain.selection.model.PracticeWindow
 import com.bandage.v1.global.common.domain.BaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Embedded
@@ -9,16 +10,27 @@ import jakarta.persistence.Table
 import jakarta.persistence.Version
 import org.hibernate.annotations.SQLRestriction
 import org.hibernate.annotations.UuidGenerator
+import java.time.LocalDate
 import java.util.UUID
 
+/**
+ * 시간표 시안. PRD-2 에서 스코프가 TrackSelection(meeting) → Performance 로 이전되었다.
+ *
+ * - performanceId: 보드가 속한 공연(필수)
+ * - meetingId: 구(舊) 선곡회의 스코프. 마이그레이션/dual-write 기간 동안만 유지되는 nullable 필드(추후 drop)
+ * - windowFrom/windowTo: 보드 레벨 연습 가능 날짜 범위. 미지정 시 Performance 기준으로 계산
+ */
 @Entity
 @Table(name = "p_schedule_board")
 @SQLRestriction("deleted_at IS NULL")
 open class ScheduleBoard(
-    meetingId: UUID,
+    performanceId: UUID,
+    meetingId: UUID?,
     name: String,
     paletteSeed: Int?,
     constraints: ScheduleBoardConstraints,
+    windowFrom: LocalDate?,
+    windowTo: LocalDate?,
 ) : BaseEntity() {
     @Id
     @Column(name = "schedule_board_id")
@@ -26,8 +38,11 @@ open class ScheduleBoard(
     lateinit var id: UUID
         protected set
 
-    @Column(name = "meeting_id", nullable = false)
-    val meetingId: UUID = meetingId
+    @Column(name = "performance_id", nullable = false)
+    val performanceId: UUID = performanceId
+
+    @Column(name = "meeting_id", nullable = true)
+    val meetingId: UUID? = meetingId
 
     @Column(name = "name", nullable = false, length = 50)
     var name: String = name
@@ -44,6 +59,14 @@ open class ScheduleBoard(
     @Embedded
     val constraints: ScheduleBoardConstraints = constraints
 
+    @Column(name = "window_from", nullable = true)
+    var windowFrom: LocalDate? = windowFrom
+        protected set
+
+    @Column(name = "window_to", nullable = true)
+    var windowTo: LocalDate? = windowTo
+        protected set
+
     @Version
     @Column(name = "version", nullable = false)
     var version: Long = 0
@@ -51,17 +74,38 @@ open class ScheduleBoard(
 
     companion object {
         fun create(
-            meetingId: UUID,
+            performanceId: UUID,
             name: String,
             paletteSeed: Int? = null,
             constraints: ScheduleBoardConstraints = ScheduleBoardConstraints(),
+            windowFrom: LocalDate? = null,
+            windowTo: LocalDate? = null,
+            meetingId: UUID? = null,
         ): ScheduleBoard =
             ScheduleBoard(
+                performanceId = performanceId,
                 meetingId = meetingId,
                 name = name,
                 paletteSeed = paletteSeed,
                 constraints = constraints,
+                windowFrom = windowFrom,
+                windowTo = windowTo,
             )
+    }
+
+    /** 보드 레벨 연습 가능 날짜 범위. windowFrom/To 가 모두 설정된 경우에만 반환. */
+    fun practiceWindowOrNull(): PracticeWindow? {
+        val from = windowFrom
+        val to = windowTo
+        return if (from != null && to != null) PracticeWindow(from, to) else null
+    }
+
+    fun updateWindow(
+        from: LocalDate?,
+        to: LocalDate?,
+    ) {
+        this.windowFrom = from
+        this.windowTo = to
     }
 
     fun rename(newName: String) {

--- a/src/main/kotlin/com/bandage/v1/domain/schedule/repository/ScheduleBlockJamRepository.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/schedule/repository/ScheduleBlockJamRepository.kt
@@ -1,0 +1,15 @@
+package com.bandage.v1.domain.schedule.repository
+
+import com.bandage.v1.domain.schedule.model.ScheduleBlockJam
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface ScheduleBlockJamRepository : JpaRepository<ScheduleBlockJam, UUID> {
+    fun findAllByScheduleBoardId(scheduleBoardId: UUID): List<ScheduleBlockJam>
+
+    fun findAllByScheduleBlockId(scheduleBlockId: UUID): List<ScheduleBlockJam>
+
+    fun deleteAllByScheduleBoardId(scheduleBoardId: UUID)
+}

--- a/src/main/kotlin/com/bandage/v1/domain/schedule/repository/ScheduleBlockTrackRepository.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/schedule/repository/ScheduleBlockTrackRepository.kt
@@ -1,0 +1,15 @@
+package com.bandage.v1.domain.schedule.repository
+
+import com.bandage.v1.domain.schedule.model.ScheduleBlockTrack
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface ScheduleBlockTrackRepository : JpaRepository<ScheduleBlockTrack, UUID> {
+    fun findAllByBlockIdOrderByOrdinalAsc(blockId: UUID): List<ScheduleBlockTrack>
+
+    fun findAllByBlockIdIn(blockIds: Collection<UUID>): List<ScheduleBlockTrack>
+
+    fun deleteAllByBlockId(blockId: UUID)
+}

--- a/src/main/kotlin/com/bandage/v1/domain/schedule/repository/ScheduleBoardRepository.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/schedule/repository/ScheduleBoardRepository.kt
@@ -7,7 +7,10 @@ import java.util.UUID
 
 @Repository
 interface ScheduleBoardRepository : JpaRepository<ScheduleBoard, UUID> {
-    fun findAllByMeetingId(meetingId: UUID): List<ScheduleBoard>
+    fun findAllByPerformanceId(performanceId: UUID): List<ScheduleBoard>
 
-    fun findFirstByMeetingIdAndConfirmedTrue(meetingId: UUID): ScheduleBoard?
+    fun findFirstByPerformanceIdAndConfirmedTrue(performanceId: UUID): ScheduleBoard?
+
+    // 마이그레이션 기간 한정(구 meeting 스코프). 추후 제거 예정.
+    fun findAllByMeetingId(meetingId: UUID): List<ScheduleBoard>
 }

--- a/src/main/kotlin/com/bandage/v1/domain/schedule/service/ScheduleAuthService.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/schedule/service/ScheduleAuthService.kt
@@ -1,7 +1,12 @@
 package com.bandage.v1.domain.schedule.service
 
+import com.bandage.v1.domain.band.repository.BandMemberRepository
+import com.bandage.v1.domain.performance.model.Performance
+import com.bandage.v1.domain.performance.repository.PerformanceManagerRepository
+import com.bandage.v1.domain.performance.repository.PerformanceRepository
 import com.bandage.v1.domain.selection.repository.TrackSelectionMemberRepository
 import com.bandage.v1.domain.selection.repository.TrackSelectionRepository
+import com.bandage.v1.domain.setlist.repository.SetlistBandRepository
 import com.bandage.v1.global.error.errorcode.ErrorCode
 import com.bandage.v1.global.error.exception.BusinessException
 import org.springframework.data.repository.findByIdOrNull
@@ -14,7 +19,62 @@ import java.util.UUID
 class ScheduleAuthService(
     private val trackSelectionRepository: TrackSelectionRepository,
     private val trackSelectionMemberRepository: TrackSelectionMemberRepository,
+    private val performanceRepository: PerformanceRepository,
+    private val performanceManagerRepository: PerformanceManagerRepository,
+    private val setlistBandRepository: SetlistBandRepository,
+    private val bandMemberRepository: BandMemberRepository,
 ) {
+    // ===== Performance 스코프 (PRD-2) =====
+
+    fun getPerformanceOrThrow(performanceId: UUID): Performance =
+        performanceRepository.findByIdOrNull(performanceId)
+            ?: throw BusinessException(ErrorCode.PERFORMANCE_NOT_FOUND)
+
+    fun isPerformanceManager(
+        performanceId: UUID,
+        memberId: Long,
+    ): Boolean {
+        val performance = getPerformanceOrThrow(performanceId)
+        return performanceManagerRepository.existsByPerformanceAndMember(performance, memberId)
+    }
+
+    /**
+     * 공연 참여자 여부. 공연 매니저이거나, 공연의 셋리스트가 속한 밴드의 멤버이면 참여자로 본다.
+     */
+    fun isPerformanceParticipant(
+        performanceId: UUID,
+        memberId: Long,
+    ): Boolean {
+        val performance = getPerformanceOrThrow(performanceId)
+        if (performanceManagerRepository.existsByPerformanceAndMember(performance, memberId)) return true
+
+        val setlistIds = performance.setlists.map { it.setlistId }
+        if (setlistIds.isEmpty()) return false
+        val bandIds = setlistBandRepository.findAllBySetlistIdIn(setlistIds).map { it.bandId }.distinct()
+        if (bandIds.isEmpty()) return false
+        return bandMemberRepository.findAllByBandIdIn(bandIds).any { it.member == memberId }
+    }
+
+    fun validatePerformanceManager(
+        performanceId: UUID,
+        memberId: Long,
+    ) {
+        if (!isPerformanceManager(performanceId, memberId)) {
+            throw BusinessException(ErrorCode.NOT_A_PERFORMANCE_MANAGER)
+        }
+    }
+
+    fun validatePerformanceParticipant(
+        performanceId: UUID,
+        memberId: Long,
+    ) {
+        if (!isPerformanceParticipant(performanceId, memberId)) {
+            throw BusinessException(ErrorCode.SCHEDULE_PERFORMANCE_FORBIDDEN)
+        }
+    }
+
+    // ===== 구(舊) Meeting 스코프 (MemberSchedule 폐기 전까지 유지) =====
+
     fun isParticipant(
         meetingId: UUID,
         memberId: Long,

--- a/src/main/kotlin/com/bandage/v1/domain/schedule/service/ScheduleBlockService.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/schedule/service/ScheduleBlockService.kt
@@ -1,13 +1,17 @@
 package com.bandage.v1.domain.schedule.service
 
+import com.bandage.v1.domain.performance.repository.PerformanceRepository
 import com.bandage.v1.domain.schedule.dto.req.ScheduleBlockUpsertRequest
 import com.bandage.v1.domain.schedule.dto.res.ScheduleBlockResponse
+import com.bandage.v1.domain.schedule.model.RecurrenceRule
 import com.bandage.v1.domain.schedule.model.ScheduleBlock
+import com.bandage.v1.domain.schedule.model.ScheduleBlockTrack
 import com.bandage.v1.domain.schedule.model.ScheduleBoard
 import com.bandage.v1.domain.schedule.repository.ScheduleBlockRepository
+import com.bandage.v1.domain.schedule.repository.ScheduleBlockTrackRepository
 import com.bandage.v1.domain.schedule.repository.ScheduleBoardRepository
 import com.bandage.v1.domain.selection.model.PracticeWindow
-import com.bandage.v1.domain.selection.repository.TrackSelectionRepository
+import com.bandage.v1.domain.setlist.repository.SetlistTrackRepository
 import com.bandage.v1.global.error.errorcode.ErrorCode
 import com.bandage.v1.global.error.exception.BusinessException
 import org.springframework.data.repository.findByIdOrNull
@@ -21,24 +25,27 @@ import java.util.UUID
 class ScheduleBlockService(
     private val scheduleBoardRepository: ScheduleBoardRepository,
     private val scheduleBlockRepository: ScheduleBlockRepository,
-    private val trackSelectionRepository: TrackSelectionRepository,
+    private val scheduleBlockTrackRepository: ScheduleBlockTrackRepository,
+    private val performanceRepository: PerformanceRepository,
+    private val setlistTrackRepository: SetlistTrackRepository,
     private val scheduleAuthService: ScheduleAuthService,
 ) {
     @Transactional
     fun upsertBlock(
-        meetingId: UUID,
+        performanceId: UUID,
         boardId: UUID,
         blockId: UUID,
         memberId: Long,
         request: ScheduleBlockUpsertRequest,
     ): ScheduleBlockResponse {
-        scheduleAuthService.validateManager(meetingId, memberId)
-        val board = getBoardOrThrow(meetingId, boardId)
+        scheduleAuthService.validatePerformanceManager(performanceId, memberId)
+        val board = getBoardOrThrow(performanceId, boardId)
         ensureBoardEditable(board)
         validateSlot(request.startSlot, request.durationSlots)
-        val window = getPracticeWindow(meetingId)
-        validateDateInWindow(request.date, window)
+        board.practiceWindowOrNull()?.let { validateDateInWindow(request.date, it) }
+        validateTracksInPerformance(performanceId, request.trackIds)
 
+        val recurrence = toRecurrenceRule(request)
         val existing = scheduleBlockRepository.findByIdOrNull(blockId)
         val block =
             if (existing != null) {
@@ -47,8 +54,9 @@ class ScheduleBlockService(
                 }
                 existing.reposition(request.date, request.startSlot, request.durationSlots)
                 existing.updatePaletteIndex(request.paletteIndex)
-                existing.updateSongTitleOverride(request.songTitleOverride)
+                existing.updateTitleOverride(request.titleOverride)
                 existing.updateNote(request.note)
+                existing.updateRecurrenceRule(recurrence)
                 request.pinned?.let { if (it) existing.pin() else existing.unpin() }
                 existing
             } else {
@@ -56,59 +64,110 @@ class ScheduleBlockService(
                     .create(
                         id = blockId,
                         board = board,
-                        songId = request.songId,
                         date = request.date,
                         startSlot = request.startSlot,
                         durationSlots = request.durationSlots,
                         paletteIndex = request.paletteIndex,
-                        songTitleOverride = request.songTitleOverride,
+                        titleOverride = request.titleOverride,
                         note = request.note,
+                        recurrenceRule = recurrence,
                     ).apply {
                         request.pinned?.let { if (it) pin() }
                     }
             }
         val saved = scheduleBlockRepository.save(block)
-        return ScheduleBlockResponse.from(saved)
+        val trackIds = replaceBlockTracks(saved, request.trackIds)
+        return ScheduleBlockResponse.from(saved, trackIds)
     }
 
     @Transactional
     fun deleteBlock(
-        meetingId: UUID,
+        performanceId: UUID,
         boardId: UUID,
         blockId: UUID,
         memberId: Long,
     ) {
-        scheduleAuthService.validateManager(meetingId, memberId)
-        val board = getBoardOrThrow(meetingId, boardId)
+        scheduleAuthService.validatePerformanceManager(performanceId, memberId)
+        val board = getBoardOrThrow(performanceId, boardId)
         ensureBoardEditable(board)
         val block = getBlockOrThrow(boardId, blockId)
+        scheduleBlockTrackRepository.deleteAllByBlockId(block.id)
         scheduleBlockRepository.delete(block)
     }
 
     @Transactional
     fun setPin(
-        meetingId: UUID,
+        performanceId: UUID,
         boardId: UUID,
         blockId: UUID,
         memberId: Long,
         pinned: Boolean,
     ): ScheduleBlockResponse {
-        scheduleAuthService.validateManager(meetingId, memberId)
-        val board = getBoardOrThrow(meetingId, boardId)
+        scheduleAuthService.validatePerformanceManager(performanceId, memberId)
+        val board = getBoardOrThrow(performanceId, boardId)
         ensureBoardEditable(board)
         val block = getBlockOrThrow(boardId, blockId)
         if (pinned) block.pin() else block.unpin()
-        return ScheduleBlockResponse.from(block)
+        val trackIds =
+            scheduleBlockTrackRepository
+                .findAllByBlockIdOrderByOrdinalAsc(block.id)
+                .map { it.setlistTrackId }
+        return ScheduleBlockResponse.from(block, trackIds)
+    }
+
+    /** 블록의 트랙 매핑을 전체 교체하고, 적용된 trackId 목록을 순서대로 반환한다. */
+    private fun replaceBlockTracks(
+        block: ScheduleBlock,
+        trackIds: List<UUID>,
+    ): List<UUID> {
+        scheduleBlockTrackRepository.deleteAllByBlockId(block.id)
+        val distinct = trackIds.distinct()
+        distinct.forEachIndexed { index, trackId ->
+            scheduleBlockTrackRepository.save(
+                ScheduleBlockTrack.create(block = block, setlistTrackId = trackId, ordinal = index),
+            )
+        }
+        return distinct
+    }
+
+    private fun validateTracksInPerformance(
+        performanceId: UUID,
+        trackIds: List<UUID>,
+    ) {
+        if (trackIds.isEmpty()) throw BusinessException(ErrorCode.SCHEDULE_BLOCK_TRACK_REQUIRED)
+        val candidateTrackIds = candidateTrackIds(performanceId)
+        if (!candidateTrackIds.containsAll(trackIds.toSet())) {
+            throw BusinessException(ErrorCode.SCHEDULE_BLOCK_TRACK_NOT_IN_PERFORMANCE)
+        }
+    }
+
+    private fun candidateTrackIds(performanceId: UUID): Set<UUID> {
+        val performance =
+            performanceRepository.findByIdOrNull(performanceId)
+                ?: throw BusinessException(ErrorCode.PERFORMANCE_NOT_FOUND)
+        val setlistIds = performance.setlists.map { it.setlistId }
+        if (setlistIds.isEmpty()) return emptySet()
+        return setlistTrackRepository.findAllBySetlistIdIn(setlistIds).map { it.id }.toSet()
+    }
+
+    private fun toRecurrenceRule(request: ScheduleBlockUpsertRequest): RecurrenceRule {
+        val r = request.recurrence ?: return RecurrenceRule.none()
+        return RecurrenceRule(
+            freq = r.freq,
+            interval = r.interval,
+            until = r.until,
+            count = r.count,
+        )
     }
 
     private fun getBoardOrThrow(
-        meetingId: UUID,
+        performanceId: UUID,
         boardId: UUID,
     ): ScheduleBoard {
         val board =
             scheduleBoardRepository.findByIdOrNull(boardId)
                 ?: throw BusinessException(ErrorCode.SCHEDULE_BOARD_NOT_FOUND)
-        if (board.meetingId != meetingId) {
+        if (board.performanceId != performanceId) {
             throw BusinessException(ErrorCode.SCHEDULE_BOARD_NOT_FOUND)
         }
         return board
@@ -143,13 +202,6 @@ class ScheduleBlockService(
         ) {
             throw BusinessException(ErrorCode.SCHEDULE_SLOT_INVALID)
         }
-    }
-
-    private fun getPracticeWindow(meetingId: UUID): PracticeWindow {
-        val meeting =
-            trackSelectionRepository.findByIdOrNull(meetingId)
-                ?: throw BusinessException(ErrorCode.SETLIST_MEETING_NOT_FOUND)
-        return meeting.practiceWindow
     }
 
     private fun validateDateInWindow(

--- a/src/main/kotlin/com/bandage/v1/domain/schedule/service/ScheduleBoardService.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/schedule/service/ScheduleBoardService.kt
@@ -6,6 +6,7 @@ import com.bandage.v1.domain.schedule.dto.res.ScheduleBoardResponse
 import com.bandage.v1.domain.schedule.model.ScheduleBoard
 import com.bandage.v1.domain.schedule.model.ScheduleBoardConstraints
 import com.bandage.v1.domain.schedule.repository.ScheduleBlockRepository
+import com.bandage.v1.domain.schedule.repository.ScheduleBlockTrackRepository
 import com.bandage.v1.domain.schedule.repository.ScheduleBoardRepository
 import com.bandage.v1.global.error.errorcode.ErrorCode
 import com.bandage.v1.global.error.exception.BusinessException
@@ -20,41 +21,45 @@ import java.util.UUID
 class ScheduleBoardService(
     private val scheduleBoardRepository: ScheduleBoardRepository,
     private val scheduleBlockRepository: ScheduleBlockRepository,
+    private val scheduleBlockTrackRepository: ScheduleBlockTrackRepository,
     private val scheduleAuthService: ScheduleAuthService,
 ) {
     fun getBoards(
-        meetingId: UUID,
+        performanceId: UUID,
         memberId: Long,
     ): List<ScheduleBoardResponse> {
-        scheduleAuthService.validateParticipant(meetingId, memberId)
-        val boards = scheduleBoardRepository.findAllByMeetingId(meetingId)
+        scheduleAuthService.validatePerformanceParticipant(performanceId, memberId)
+        val boards = scheduleBoardRepository.findAllByPerformanceId(performanceId)
         if (boards.isEmpty()) return emptyList()
-        val boardIds = boards.map { it.id }
-        val blocksByBoard =
-            boardIds
-                .associateWith { scheduleBlockRepository.findAllByBoardId(it) }
-        return boards.map { ScheduleBoardResponse.of(it, blocksByBoard[it.id].orEmpty()) }
+        val blocksByBoard = boards.associate { it.id to scheduleBlockRepository.findAllByBoardId(it.id) }
+        val allBlockIds = blocksByBoard.values.flatten().map { it.id }
+        val trackIdsByBlock = trackIdsByBlock(allBlockIds)
+        return boards.map { board ->
+            ScheduleBoardResponse.of(board, blocksByBoard[board.id].orEmpty(), trackIdsByBlock)
+        }
     }
 
     @Transactional
     fun createBoard(
-        meetingId: UUID,
+        performanceId: UUID,
         memberId: Long,
         request: ScheduleBoardCreateRequest,
     ): ScheduleBoardResponse {
-        scheduleAuthService.validateManager(meetingId, memberId)
-        val existingCount = scheduleBoardRepository.findAllByMeetingId(meetingId).size
-        if (existingCount >= MAX_BOARDS_PER_MEETING) {
+        scheduleAuthService.validatePerformanceManager(performanceId, memberId)
+        val existingCount = scheduleBoardRepository.findAllByPerformanceId(performanceId).size
+        if (existingCount >= MAX_BOARDS_PER_PERFORMANCE) {
             throw BusinessException(ErrorCode.SCHEDULE_BOARD_LIMIT_EXCEEDED)
         }
         val constraints = request.constraints?.toEntity() ?: ScheduleBoardConstraints()
         val board =
             scheduleBoardRepository.save(
                 ScheduleBoard.create(
-                    meetingId = meetingId,
+                    performanceId = performanceId,
                     name = request.name,
                     paletteSeed = request.paletteSeed,
                     constraints = constraints,
+                    windowFrom = request.windowFrom,
+                    windowTo = request.windowTo,
                 ),
             )
         return ScheduleBoardResponse.of(board, emptyList())
@@ -62,18 +67,21 @@ class ScheduleBoardService(
 
     @Transactional
     fun updateBoard(
-        meetingId: UUID,
+        performanceId: UUID,
         boardId: UUID,
         memberId: Long,
         request: ScheduleBoardUpdateRequest,
     ): ScheduleBoardResponse {
-        scheduleAuthService.validateManager(meetingId, memberId)
-        val board = getBoardOrThrow(meetingId, boardId)
+        scheduleAuthService.validatePerformanceManager(performanceId, memberId)
+        val board = getBoardOrThrow(performanceId, boardId)
         if (board.confirmed) {
             throw BusinessException(ErrorCode.SCHEDULE_BOARD_ALREADY_CONFIRMED)
         }
         request.name?.let { board.rename(it) }
         if (request.paletteSeed != null) board.updatePaletteSeed(request.paletteSeed)
+        if (request.windowFrom != null || request.windowTo != null) {
+            board.updateWindow(request.windowFrom ?: board.windowFrom, request.windowTo ?: board.windowTo)
+        }
         request.constraints?.let { dto ->
             board.constraints.update(
                 workingHoursStart = dto.workingHoursStart,
@@ -89,37 +97,46 @@ class ScheduleBoardService(
                 throw BusinessException(ErrorCode.SCHEDULE_BOARD_VERSION_CONFLICT)
             }
         val blocks = scheduleBlockRepository.findAllByBoardId(saved.id)
-        return ScheduleBoardResponse.of(saved, blocks)
+        val trackIdsByBlock = trackIdsByBlock(blocks.map { it.id })
+        return ScheduleBoardResponse.of(saved, blocks, trackIdsByBlock)
     }
 
     @Transactional
     fun deleteBoard(
-        meetingId: UUID,
+        performanceId: UUID,
         boardId: UUID,
         memberId: Long,
     ) {
-        scheduleAuthService.validateManager(meetingId, memberId)
-        val board = getBoardOrThrow(meetingId, boardId)
+        scheduleAuthService.validatePerformanceManager(performanceId, memberId)
+        val board = getBoardOrThrow(performanceId, boardId)
         if (board.confirmed) {
             throw BusinessException(ErrorCode.SCHEDULE_BOARD_ALREADY_CONFIRMED)
         }
         scheduleBoardRepository.delete(board)
     }
 
+    private fun trackIdsByBlock(blockIds: List<UUID>): Map<UUID, List<UUID>> {
+        if (blockIds.isEmpty()) return emptyMap()
+        return scheduleBlockTrackRepository
+            .findAllByBlockIdIn(blockIds)
+            .sortedBy { it.ordinal }
+            .groupBy({ it.block.id }, { it.setlistTrackId })
+    }
+
     private fun getBoardOrThrow(
-        meetingId: UUID,
+        performanceId: UUID,
         boardId: UUID,
     ): ScheduleBoard {
         val board =
             scheduleBoardRepository.findByIdOrNull(boardId)
                 ?: throw BusinessException(ErrorCode.SCHEDULE_BOARD_NOT_FOUND)
-        if (board.meetingId != meetingId) {
+        if (board.performanceId != performanceId) {
             throw BusinessException(ErrorCode.SCHEDULE_BOARD_NOT_FOUND)
         }
         return board
     }
 
     companion object {
-        const val MAX_BOARDS_PER_MEETING = 5
+        const val MAX_BOARDS_PER_PERFORMANCE = 5
     }
 }

--- a/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistTrackRepository.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/setlist/repository/SetlistTrackRepository.kt
@@ -11,4 +11,6 @@ interface SetlistTrackRepository :
     JpaRepository<SetlistTrack, UUID>,
     SetlistTrackRepositoryCustom {
     fun findAllBySetlist(setlist: Setlist): List<SetlistTrack>
+
+    fun findAllBySetlistIdIn(setlistIds: Collection<UUID>): List<SetlistTrack>
 }

--- a/src/main/kotlin/com/bandage/v1/facade/ScheduleConfirmFacade.kt
+++ b/src/main/kotlin/com/bandage/v1/facade/ScheduleConfirmFacade.kt
@@ -2,72 +2,119 @@ package com.bandage.v1.facade
 
 import com.bandage.v1.domain.jam.model.Jam
 import com.bandage.v1.domain.jam.repository.JamRepository
+import com.bandage.v1.domain.jam.service.JamReservationSyncService
+import com.bandage.v1.domain.jam.service.SetlistTrackToJamConverter
 import com.bandage.v1.domain.schedule.dto.res.ScheduleConfirmResponse
 import com.bandage.v1.domain.schedule.dto.res.ScheduleUnconfirmResponse
+import com.bandage.v1.domain.schedule.model.RecurrenceFreq
 import com.bandage.v1.domain.schedule.model.ScheduleBlock
+import com.bandage.v1.domain.schedule.model.ScheduleBlockJam
 import com.bandage.v1.domain.schedule.model.ScheduleBoard
+import com.bandage.v1.domain.schedule.repository.ScheduleBlockJamRepository
 import com.bandage.v1.domain.schedule.repository.ScheduleBlockRepository
+import com.bandage.v1.domain.schedule.repository.ScheduleBlockTrackRepository
 import com.bandage.v1.domain.schedule.repository.ScheduleBoardRepository
 import com.bandage.v1.domain.schedule.service.ScheduleAuthService
-import com.bandage.v1.domain.selection.model.TrackSelection
-import com.bandage.v1.domain.selection.model.TrackSelectionItem
-import com.bandage.v1.domain.selection.repository.TrackSelectionItemConfirmationRepository
-import com.bandage.v1.domain.selection.repository.TrackSelectionItemRepository
-import com.bandage.v1.domain.selection.repository.TrackSelectionRepository
-import com.bandage.v1.global.common.domain.SessionDef
-import com.bandage.v1.global.common.domain.TrackInfo
+import com.bandage.v1.domain.setlist.model.SetlistTrack
+import com.bandage.v1.domain.setlist.repository.SetlistTrackParticipantRepository
+import com.bandage.v1.domain.setlist.repository.SetlistTrackRepository
 import com.bandage.v1.global.error.errorcode.ErrorCode
 import com.bandage.v1.global.error.exception.BusinessException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
 
+/**
+ * 시간표 시안(ScheduleBoard) 확정/해제 Facade. PRD-2 에서 Performance 스코프로 재작성됨.
+ *
+ * 확정 시 각 ScheduleBlock 을 (반복 전개된) 발생일 × 트랙 단위로 [SetlistTrackToJamConverter] 를 통해
+ * Jam 으로 생성하고, 어떤 블록이 어떤 Jam 을 만들었는지 [ScheduleBlockJam] 으로 추적한다.
+ * Jam 은 단일 트랙(TrackInfo)을 가지므로 한 블록의 여러 트랙은 같은 시간대에 트랙별 Jam 으로 분리 생성된다.
+ */
 @Service
 class ScheduleConfirmFacade(
     private val scheduleBoardRepository: ScheduleBoardRepository,
     private val scheduleBlockRepository: ScheduleBlockRepository,
-    private val trackSelectionRepository: TrackSelectionRepository,
-    private val trackSelectionItemRepository: TrackSelectionItemRepository,
-    private val confirmationRepository: TrackSelectionItemConfirmationRepository,
+    private val scheduleBlockTrackRepository: ScheduleBlockTrackRepository,
+    private val scheduleBlockJamRepository: ScheduleBlockJamRepository,
+    private val setlistTrackRepository: SetlistTrackRepository,
+    private val setlistTrackParticipantRepository: SetlistTrackParticipantRepository,
+    private val setlistTrackToJamConverter: SetlistTrackToJamConverter,
     private val jamRepository: JamRepository,
+    private val jamReservationSyncService: JamReservationSyncService,
     private val scheduleAuthService: ScheduleAuthService,
 ) {
     @Transactional
     fun confirmBoard(
-        meetingId: UUID,
+        performanceId: UUID,
         boardId: UUID,
         memberId: Long,
     ): ScheduleConfirmResponse {
-        val board = getBoardOrThrow(meetingId, boardId)
-        val meeting = getMeetingOrThrow(meetingId)
-        scheduleAuthService.validateManager(meetingId, memberId)
-        if (!meeting.isLocked) throw BusinessException(ErrorCode.SETLIST_NOT_LOCKED)
+        scheduleAuthService.validatePerformanceManager(performanceId, memberId)
+        val board = getBoardOrThrow(performanceId, boardId)
 
-        val sameMeetingBoards = scheduleBoardRepository.findAllByMeetingId(meetingId)
-        if (sameMeetingBoards.any { it.id != board.id && it.confirmed }) {
+        val samePerformanceBoards = scheduleBoardRepository.findAllByPerformanceId(performanceId)
+        if (samePerformanceBoards.any { it.id != board.id && it.confirmed }) {
             throw BusinessException(ErrorCode.SCHEDULE_BOARD_ALREADY_CONFIRMED)
         }
 
         val blocks = scheduleBlockRepository.findAllByBoardId(boardId)
-        val items = trackSelectionItemRepository.findAllBySelection(meeting).associateBy { it.id }
 
-        val createdJams =
-            blocks.map { block ->
-                val item = items[block.songId] ?: throw BusinessException(ErrorCode.SETLIST_MEETING_ITEM_NOT_FOUND)
-                val jam = buildJam(block, item)
-                confirmationRepository.findAllByItem(item).forEach { conf ->
-                    jam.addParticipant(conf.sessionId, conf.memberId)
+        // 블록별 트랙 매핑 및 SetlistTrack/참여자 일괄 로드
+        val blockTracks =
+            scheduleBlockTrackRepository
+                .findAllByBlockIdIn(blocks.map { it.id })
+                .groupBy({ it.block.id }, { it.setlistTrackId to it.ordinal })
+        val allTrackIds =
+            blockTracks.values
+                .flatten()
+                .map { it.first }
+                .distinct()
+        val tracksById = setlistTrackRepository.findAllById(allTrackIds).associateBy { it.id }
+        val participantsByTrack =
+            setlistTrackParticipantRepository
+                .findAllByTrackIn(tracksById.values.toList())
+                .groupBy { it.track.id }
+
+        val createdJams = mutableListOf<Jam>()
+        blocks.forEach { block ->
+            val orderedTrackIds =
+                blockTracks[block.id].orEmpty().sortedBy { it.second }.map { it.first }
+            val occurrences = expandRecurrence(block, board.windowTo)
+            occurrences.forEach { occurrenceDate ->
+                val startAt = startAtOf(occurrenceDate, block.startSlot)
+                val durationMinutes = block.durationSlots * MINUTES_PER_SLOT
+                orderedTrackIds.forEach { trackId ->
+                    val track: SetlistTrack =
+                        tracksById[trackId]
+                            ?: throw BusinessException(ErrorCode.SETLIST_TRACK_NOT_FOUND)
+                    val jam =
+                        setlistTrackToJamConverter.toJam(
+                            track = track,
+                            participants = participantsByTrack[trackId].orEmpty(),
+                            startAt = startAt,
+                            durationMinutes = durationMinutes,
+                            venue = null,
+                            titleOverride = block.titleOverride,
+                        )
+                    scheduleBlockJamRepository.save(
+                        ScheduleBlockJam.create(
+                            scheduleBlockId = block.id,
+                            scheduleBoardId = board.id,
+                            jamId = jam.id,
+                        ),
+                    )
+                    createdJams.add(jam)
                 }
-                jamRepository.save(jam)
             }
+        }
 
         board.confirm()
-        val confirmedAt = LocalDateTime.now()
-
         return ScheduleConfirmResponse(
-            confirmedAt = confirmedAt,
+            confirmedAt = LocalDateTime.now(),
             jamsCreated =
                 createdJams.map {
                     ScheduleConfirmResponse.JamCreatedSummary(
@@ -82,71 +129,83 @@ class ScheduleConfirmFacade(
 
     @Transactional
     fun unconfirmBoard(
-        meetingId: UUID,
+        performanceId: UUID,
         boardId: UUID,
         memberId: Long,
     ): ScheduleUnconfirmResponse {
-        scheduleAuthService.validateManager(meetingId, memberId)
-        val board = getBoardOrThrow(meetingId, boardId)
+        scheduleAuthService.validatePerformanceManager(performanceId, memberId)
+        val board = getBoardOrThrow(performanceId, boardId)
         if (!board.confirmed) {
             throw BusinessException(ErrorCode.SCHEDULE_BOARD_NOT_CONFIRMED)
         }
+
+        // 확정 시 생성된 Jam 을 정리(soft-delete + 예약 동기화)하고 추적 매핑 삭제
+        val mappings = scheduleBlockJamRepository.findAllByScheduleBoardId(boardId)
+        val jamIds = mappings.map { it.jamId }.distinct()
+        jamRepository.findAllById(jamIds).forEach { jam ->
+            jam.markAsDeleted(memberId)
+            jamReservationSyncService.sync(jam)
+        }
+        scheduleBlockJamRepository.deleteAllByScheduleBoardId(boardId)
+
         board.unconfirm()
         return ScheduleUnconfirmResponse(unconfirmedAt = LocalDateTime.now())
     }
 
+    /**
+     * 반복 블록을 발생일 목록으로 전개한다.
+     * 단발성(NONE)이면 [block.date] 1건. 반복이면 until → boardWindowTo → count 순으로 경계를 적용하며,
+     * 경계가 전혀 없으면 무한 전개를 막기 위해 단발성으로 간주한다.
+     */
+    fun expandRecurrence(
+        block: ScheduleBlock,
+        boardWindowTo: LocalDate?,
+    ): List<LocalDate> {
+        val rule = block.recurrenceRule
+        if (!rule.isRecurring) return listOf(block.date)
+
+        val stepDays =
+            when (rule.freq) {
+                RecurrenceFreq.DAILY -> 1
+                RecurrenceFreq.WEEKLY -> 7
+                RecurrenceFreq.BIWEEKLY -> 14
+                RecurrenceFreq.NONE -> return listOf(block.date)
+            } * rule.interval.coerceAtLeast(1)
+
+        val hardEnd = rule.until ?: boardWindowTo
+        val maxCount = rule.count ?: Int.MAX_VALUE
+        if (hardEnd == null && rule.count == null) return listOf(block.date)
+
+        val result = mutableListOf<LocalDate>()
+        var cur = block.date
+        while (result.size < SAFETY_CAP && result.size < maxCount) {
+            if (hardEnd != null && cur.isAfter(hardEnd)) break
+            result.add(cur)
+            cur = cur.plusDays(stepDays.toLong())
+        }
+        return result.ifEmpty { listOf(block.date) }
+    }
+
+    private fun startAtOf(
+        date: LocalDate,
+        startSlot: Int,
+    ): LocalDateTime = date.atStartOfDay().plusMinutes(startSlot.toLong() * MINUTES_PER_SLOT)
+
     private fun getBoardOrThrow(
-        meetingId: UUID,
+        performanceId: UUID,
         boardId: UUID,
     ): ScheduleBoard {
         val board =
             scheduleBoardRepository.findByIdOrNull(boardId)
                 ?: throw BusinessException(ErrorCode.SCHEDULE_BOARD_NOT_FOUND)
-        if (board.meetingId != meetingId) {
+        if (board.performanceId != performanceId) {
             throw BusinessException(ErrorCode.SCHEDULE_BOARD_NOT_FOUND)
         }
         return board
     }
 
-    private fun getMeetingOrThrow(meetingId: UUID): TrackSelection =
-        trackSelectionRepository.findByIdOrNull(meetingId)
-            ?: throw BusinessException(ErrorCode.SETLIST_MEETING_NOT_FOUND)
-
-    private fun buildJam(
-        block: ScheduleBlock,
-        item: TrackSelectionItem,
-    ): Jam {
-        val startAt = block.date.atStartOfDay().plusMinutes(block.startSlot.toLong() * MINUTES_PER_SLOT)
-        val durationMinutes = block.durationSlots * MINUTES_PER_SLOT
-        val title = block.songTitleOverride?.takeIf { it.isNotBlank() } ?: item.trackInfo.title
-        return Jam.create(
-            title = title,
-            trackInfo =
-                TrackInfo(
-                    title = item.trackInfo.title,
-                    artist = item.trackInfo.artist,
-                    album = item.trackInfo.album,
-                    duration = item.trackInfo.duration,
-                    reference = item.trackInfo.reference,
-                ),
-            startAt = startAt,
-            durationMinutes = durationMinutes,
-            venue = null,
-            note = item.note,
-            sessions =
-                item.sessions.map { def ->
-                    SessionDef(
-                        sessionId = def.sessionId,
-                        label = def.label,
-                        short = def.short,
-                        need = def.need,
-                        custom = def.custom,
-                    )
-                },
-        )
-    }
-
     companion object {
         private const val MINUTES_PER_SLOT: Int = 30
+        private const val SAFETY_CAP: Int = 366
     }
 }

--- a/src/main/kotlin/com/bandage/v1/global/error/errorcode/ErrorCode.kt
+++ b/src/main/kotlin/com/bandage/v1/global/error/errorcode/ErrorCode.kt
@@ -95,6 +95,11 @@ enum class ErrorCode(
     // availability
     AVAILABILITY_INVALID(HttpStatus.BAD_REQUEST, "가용성 정보가 올바르지 않습니다."),
 
+    // schedule (performance scope)
+    SCHEDULE_PERFORMANCE_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 공연 일정에 접근할 권한이 없습니다."),
+    SCHEDULE_BLOCK_TRACK_REQUIRED(HttpStatus.BAD_REQUEST, "블록에는 최소 1개 이상의 트랙이 필요합니다."),
+    SCHEDULE_BLOCK_TRACK_NOT_IN_PERFORMANCE(HttpStatus.BAD_REQUEST, "공연의 셋리스트에 속하지 않은 트랙입니다."),
+
     // upload
     INVALID_FILE_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "허용되지 않는 파일 타입입니다."),
     INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "허용되지 않는 파일 확장자입니다."),

--- a/src/main/resources/db/changelog/changes/010-schedule-board-performance.sql
+++ b/src/main/resources/db/changelog/changes/010-schedule-board-performance.sql
@@ -1,0 +1,14 @@
+-- BD-33 (PRD-2 Task 5): ScheduleBoard 스코프를 meeting → performance 로 이전
+-- 운영 데이터 없음 가정.
+
+ALTER TABLE public.p_schedule_board ADD COLUMN performance_id uuid;
+ALTER TABLE public.p_schedule_board ALTER COLUMN performance_id SET NOT NULL;
+
+-- 구 meeting 스코프: 마이그레이션/dual-write 기간 동안만 유지(nullable). 추후 drop.
+ALTER TABLE public.p_schedule_board ALTER COLUMN meeting_id DROP NOT NULL;
+
+-- 보드 레벨 연습 가능 날짜 범위
+ALTER TABLE public.p_schedule_board ADD COLUMN window_from date;
+ALTER TABLE public.p_schedule_board ADD COLUMN window_to date;
+
+CREATE INDEX idx_schedule_board_performance ON public.p_schedule_board (performance_id);

--- a/src/main/resources/db/changelog/changes/011-schedule-block-track.sql
+++ b/src/main/resources/db/changelog/changes/011-schedule-block-track.sql
@@ -1,0 +1,20 @@
+-- BD-33 (PRD-2 Task 6): ScheduleBlock ↔ SetlistTrack N:M 매핑 테이블 신설
+
+CREATE TABLE public.p_schedule_block_track (
+    schedule_block_track_id uuid NOT NULL,
+    schedule_block_id uuid NOT NULL,
+    setlist_track_id uuid NOT NULL,
+    ordinal integer NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    created_by bigint,
+    last_modified_at timestamp(6) without time zone NOT NULL,
+    last_modified_by bigint,
+    deleted_at timestamp(6) without time zone,
+    deleted_by bigint,
+    CONSTRAINT p_schedule_block_track_pkey PRIMARY KEY (schedule_block_track_id),
+    CONSTRAINT uk_schedule_block_track UNIQUE (schedule_block_id, setlist_track_id),
+    CONSTRAINT fk_schedule_block_track__block
+        FOREIGN KEY (schedule_block_id) REFERENCES public.p_schedule_block(schedule_block_id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_schedule_block_track__block ON public.p_schedule_block_track (schedule_block_id);

--- a/src/main/resources/db/changelog/changes/012-schedule-block-recurrence.sql
+++ b/src/main/resources/db/changelog/changes/012-schedule-block-recurrence.sql
@@ -1,0 +1,20 @@
+-- BD-33 (PRD-2 Task 6/7): ScheduleBlock 단일 songId 제거 + 반복/배치 메타데이터 추가
+-- 운영 데이터 없음 가정.
+
+-- 6) 단일 song 참조 제거 (N:M p_schedule_block_track 로 대체)
+ALTER TABLE public.p_schedule_block DROP COLUMN song_id;
+
+-- songTitleOverride → titleOverride 로 의미 일반화(블록 단위 라벨 오버라이드)
+ALTER TABLE public.p_schedule_block RENAME COLUMN song_title_override TO title_override;
+
+-- 7) 반복 배치 규칙(RecurrenceRule)
+ALTER TABLE public.p_schedule_block ADD COLUMN recurrence_freq character varying(20) NOT NULL DEFAULT 'NONE';
+ALTER TABLE public.p_schedule_block ALTER COLUMN recurrence_freq DROP DEFAULT;
+ALTER TABLE public.p_schedule_block ADD COLUMN recurrence_interval integer NOT NULL DEFAULT 1;
+ALTER TABLE public.p_schedule_block ALTER COLUMN recurrence_interval DROP DEFAULT;
+ALTER TABLE public.p_schedule_block ADD COLUMN recurrence_until date;
+ALTER TABLE public.p_schedule_block ADD COLUMN recurrence_count integer;
+
+-- 배치 출처(PlacementOrigin)
+ALTER TABLE public.p_schedule_block ADD COLUMN placement_origin character varying(20) NOT NULL DEFAULT 'MANUAL';
+ALTER TABLE public.p_schedule_block ALTER COLUMN placement_origin DROP DEFAULT;

--- a/src/main/resources/db/changelog/changes/013-schedule-block-jam.sql
+++ b/src/main/resources/db/changelog/changes/013-schedule-block-jam.sql
@@ -1,0 +1,13 @@
+-- BD-33 (PRD-2 Task 8): ScheduleBlock → 확정 생성 Jam 추적 매핑 테이블 신설
+-- 파생 추적 테이블이므로 감사/소프트삭제 필드 없음.
+
+CREATE TABLE public.p_schedule_block_jam (
+    schedule_block_jam_id uuid NOT NULL,
+    schedule_block_id uuid NOT NULL,
+    schedule_board_id uuid NOT NULL,
+    jam_id uuid NOT NULL,
+    CONSTRAINT p_schedule_block_jam_pkey PRIMARY KEY (schedule_block_jam_id)
+);
+
+CREATE INDEX idx_schedule_block_jam_block ON public.p_schedule_block_jam (schedule_block_id);
+CREATE INDEX idx_schedule_block_jam_board ON public.p_schedule_block_jam (schedule_board_id);

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -112,3 +112,52 @@ databaseChangeLog:
             splitStatements: true
             stripComments: true
             endDelimiter: ";"
+  - changeSet:
+      id: 010-schedule-board-performance
+      author: bandage
+      comment: |
+        BD-33 (PRD-2 Task 5): ScheduleBoard 스코프 meeting → performance 이전
+        - performance_id 추가(NOT NULL), meeting_id nullable 화, window_from/to 추가
+      changes:
+        - sqlFile:
+            path: changes/010-schedule-board-performance.sql
+            relativeToChangelogFile: true
+            splitStatements: true
+            stripComments: true
+            endDelimiter: ";"
+  - changeSet:
+      id: 011-schedule-block-track
+      author: bandage
+      comment: |
+        BD-33 (PRD-2 Task 6): ScheduleBlock↔SetlistTrack N:M 매핑 테이블 신설
+      changes:
+        - sqlFile:
+            path: changes/011-schedule-block-track.sql
+            relativeToChangelogFile: true
+            splitStatements: true
+            stripComments: true
+            endDelimiter: ";"
+  - changeSet:
+      id: 012-schedule-block-recurrence
+      author: bandage
+      comment: |
+        BD-33 (PRD-2 Task 6/7): ScheduleBlock song_id 제거 + 반복/배치 메타데이터 추가
+      changes:
+        - sqlFile:
+            path: changes/012-schedule-block-recurrence.sql
+            relativeToChangelogFile: true
+            splitStatements: true
+            stripComments: true
+            endDelimiter: ";"
+  - changeSet:
+      id: 013-schedule-block-jam
+      author: bandage
+      comment: |
+        BD-33 (PRD-2 Task 8): ScheduleBlock → 확정 Jam 추적 매핑 테이블 신설
+      changes:
+        - sqlFile:
+            path: changes/013-schedule-block-jam.sql
+            relativeToChangelogFile: true
+            splitStatements: true
+            stripComments: true
+            endDelimiter: ";"

--- a/src/test/kotlin/com/bandage/v1/facade/ScheduleConfirmFacadeRecurrenceTest.kt
+++ b/src/test/kotlin/com/bandage/v1/facade/ScheduleConfirmFacadeRecurrenceTest.kt
@@ -1,0 +1,97 @@
+package com.bandage.v1.facade
+
+import com.bandage.v1.domain.jam.repository.JamRepository
+import com.bandage.v1.domain.jam.service.JamReservationSyncService
+import com.bandage.v1.domain.jam.service.SetlistTrackToJamConverter
+import com.bandage.v1.domain.schedule.model.RecurrenceFreq
+import com.bandage.v1.domain.schedule.model.RecurrenceRule
+import com.bandage.v1.domain.schedule.model.ScheduleBlock
+import com.bandage.v1.domain.schedule.model.ScheduleBoard
+import com.bandage.v1.domain.schedule.repository.ScheduleBlockJamRepository
+import com.bandage.v1.domain.schedule.repository.ScheduleBlockRepository
+import com.bandage.v1.domain.schedule.repository.ScheduleBlockTrackRepository
+import com.bandage.v1.domain.schedule.repository.ScheduleBoardRepository
+import com.bandage.v1.domain.schedule.service.ScheduleAuthService
+import com.bandage.v1.domain.setlist.repository.SetlistTrackParticipantRepository
+import com.bandage.v1.domain.setlist.repository.SetlistTrackRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import java.time.LocalDate
+
+class ScheduleConfirmFacadeRecurrenceTest {
+    private val sut =
+        ScheduleConfirmFacade(
+            mock(ScheduleBoardRepository::class.java),
+            mock(ScheduleBlockRepository::class.java),
+            mock(ScheduleBlockTrackRepository::class.java),
+            mock(ScheduleBlockJamRepository::class.java),
+            mock(SetlistTrackRepository::class.java),
+            mock(SetlistTrackParticipantRepository::class.java),
+            mock(SetlistTrackToJamConverter::class.java),
+            mock(JamRepository::class.java),
+            mock(JamReservationSyncService::class.java),
+            mock(ScheduleAuthService::class.java),
+        )
+
+    private val anchor = LocalDate.of(2026, 6, 1)
+
+    private fun block(rule: RecurrenceRule): ScheduleBlock {
+        val board = ScheduleBoard.create(performanceId = java.util.UUID.randomUUID(), name = "board")
+        return ScheduleBlock.create(
+            board = board,
+            date = anchor,
+            startSlot = 36,
+            durationSlots = 4,
+            recurrenceRule = rule,
+        )
+    }
+
+    @Test
+    fun `단발성(NONE) 블록은 anchor 1건만 전개된다`() {
+        val result = sut.expandRecurrence(block(RecurrenceRule.none()), boardWindowTo = LocalDate.of(2026, 12, 31))
+        assertThat(result).containsExactly(anchor)
+    }
+
+    @Test
+    fun `WEEKLY + until 은 anchor 부터 until 까지 주 단위로 전개된다`() {
+        val rule = RecurrenceRule(freq = RecurrenceFreq.WEEKLY, interval = 1, until = LocalDate.of(2026, 6, 29))
+        val result = sut.expandRecurrence(block(rule), boardWindowTo = null)
+        assertThat(result).containsExactly(
+            LocalDate.of(2026, 6, 1),
+            LocalDate.of(2026, 6, 8),
+            LocalDate.of(2026, 6, 15),
+            LocalDate.of(2026, 6, 22),
+            LocalDate.of(2026, 6, 29),
+        )
+    }
+
+    @Test
+    fun `DAILY + count 는 count 만큼만 전개된다`() {
+        val rule = RecurrenceRule(freq = RecurrenceFreq.DAILY, interval = 1, count = 3)
+        val result = sut.expandRecurrence(block(rule), boardWindowTo = null)
+        assertThat(result).containsExactly(
+            LocalDate.of(2026, 6, 1),
+            LocalDate.of(2026, 6, 2),
+            LocalDate.of(2026, 6, 3),
+        )
+    }
+
+    @Test
+    fun `BIWEEKLY 는 보드 window 끝까지 격주로 전개된다`() {
+        val rule = RecurrenceRule(freq = RecurrenceFreq.BIWEEKLY, interval = 1)
+        val result = sut.expandRecurrence(block(rule), boardWindowTo = LocalDate.of(2026, 6, 30))
+        assertThat(result).containsExactly(
+            LocalDate.of(2026, 6, 1),
+            LocalDate.of(2026, 6, 15),
+            LocalDate.of(2026, 6, 29),
+        )
+    }
+
+    @Test
+    fun `경계(until-window-count)가 전혀 없으면 무한 전개 방지로 단발성 처리된다`() {
+        val rule = RecurrenceRule(freq = RecurrenceFreq.WEEKLY, interval = 1)
+        val result = sut.expandRecurrence(block(rule), boardWindowTo = null)
+        assertThat(result).containsExactly(anchor)
+    }
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes # BD-33 (PRD-2 Milestone 2)

📌 **작업 내용 및 특이사항**

PRD-2 **Milestone 2 — ScheduleBoard Performance 이전 및 Confirm 재작성(T5~T9)**.

> ⚠️ base 가 `feat/BD-33-m1-foundation` 인 **스택 PR** 입니다. M1(#94) 머지 후 리뷰/머지하면 diff 가 M2 분량만 보입니다.

### T5. ScheduleBoard → Performance
- `ScheduleBoard`: `performanceId`(필수), `meetingId` nullable 화(마이그레이션 기간 유지), `window_from/to` + `practiceWindowOrNull()`
- `ScheduleAuthService`: Performance 매니저/참여자 검증 추가(셋리스트→밴드 멤버 체인), 구 meeting 메서드는 MemberSchedule 폐기 전까지 유지
- `ScheduleBoardService`/`ScheduleBoardController`: performanceId 기반, 경로 `/performances/{performanceId}/schedule-boards`
- Liquibase `010`

### T6/T7. ScheduleBlock N:M + 반복/배치 메타
- `ScheduleBlock`: 단일 `song_id` 제거 → `ScheduleBlockTrack`(N:M), `RecurrenceRule`(@Embedded)/`PlacementOrigin` 추가, `songTitleOverride`→`titleOverride`
- `ScheduleBlockService`: 다중 트랙 upsert(매핑 전체 교체), 트랙의 공연 소속 검증, 보드 window 검증
- Liquibase `011`/`012`

### T8. ScheduleBlockJam 추적
- `ScheduleBlockJam`(블록→확정 Jam 매핑) + Repository, Liquibase `013`

### T9. ScheduleConfirmFacade 재작성
- `confirmBoard(performanceId)`: 블록별 트랙 × 반복 전개 → `SetlistTrackToJamConverter` 로 Jam 생성, `ScheduleBlockJam` 추적
- `unconfirmBoard`: 생성 Jam soft-delete + 예약 sync + 매핑 정리
- `expandRecurrence`: NONE/DAILY/WEEKLY/BIWEEKLY, until/window/count 경계, 무한 전개 방지

### 설계 결정
- Jam 은 단일 TrackInfo 이므로, 한 블록의 여러 트랙은 같은 시간대에 **트랙별 Jam 1건씩** 생성
- 보드 practiceWindow 는 임베디드 nullable 제약 회피를 위해 `window_from/to` 두 컬럼으로 보관

📚 **참고사항**
- 전체 `compileKotlin`/`compileTestKotlin` 성공, 단위 테스트(`ScheduleConfirmFacadeRecurrenceTest` 5케이스) GREEN
- ⚠️ Liquibase 010~013 은 실 PostgreSQL 검증 필요(테스트는 H2 ddl-auto)
- 후속: M3(AvailabilityCalculator·StrategyComposition·AutoPlacer·API) 진행 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)
