### PR TITLE
[BD-33] PRD-2 M4: MemberSchedule 폐기 전환 및 마이그레이션 계획 (T14~T15)

### DIFF
--- a/docs/migration/BD-33-schedule-migration.md
+++ b/docs/migration/BD-33-schedule-migration.md
@@ -1,0 +1,61 @@
+# BD-33 (PRD-2) 합주 스케줄링 재설계 — 마이그레이션 계획
+
+본 문서는 PRD-2 적용에 따른 DB 마이그레이션, Dual-Write, 백필, 롤백, 레거시 폐기 계획을 정리한다.
+(전제: 현재 운영 데이터 없음 — 대부분의 백필은 no-op 에 가깝다. 운영 적용 시 본 절차를 따른다.)
+
+## 1. Liquibase changelog 인벤토리
+
+| id | 내용 | 적용 |
+|----|------|------|
+| 001 | 초기 스키마 | 적용 |
+| 002 | setlist/selection 리팩토링 | 적용 |
+| 003 | DEVELOPER 시드 계정 | 적용 |
+| 004 | TrackInfo 도입 + PracticeSong 제거 (BD-70) | 적용 |
+| 005 | participant session_id + setlist_id (BD-70) | 적용 |
+| 006 | Practice → Jam 리네이밍 (BD-70) | 적용 |
+| 008 | MemberAvailability 신설 (T2) | 적용 |
+| 009 | JamReservation 신설 (T3) | 적용 |
+| 010 | ScheduleBoard performance_id/window (T5) | 적용 |
+| 011 | ScheduleBlockTrack N:M (T6) | 적용 |
+| 012 | ScheduleBlock song_id 제거 + 반복/배치 메타 (T6/T7) | 적용 |
+| 013 | ScheduleBlockJam 추적 (T8) | 적용 |
+| (deferred) | `deferred/drop-legacy-meeting-scope.sql` — meeting_id 등 레거시 컬럼 제거 | **미적용(백필 검증 후 수동 승격)** |
+
+> 007 은 BD-70 이 rename 을 006 으로 통합하여 공번이다(PRD 문서 번호 체계 정렬 목적).
+
+## 2. Dual-Write (T14.2)
+
+ScheduleBoard 는 PRD-2 에서 `performance_id`(필수) 로 스코프가 이전되었고, 구 `meeting_id` 는 **nullable** 로 유지된다.
+
+- **신규 보드**: `performance_id` 만 기록(`meeting_id = null`). 별도 Dual-Write 불필요.
+- **운영 전환 시(레거시 meeting 기반 보드가 있는 경우)**: 전환 기간 동안 보드 생성/수정 시 가능한 경우 두 값을 함께 기록(코드 레벨에서 meeting↔performance 매핑이 확보될 때). 본 PR 기준 운영 데이터가 없어 코드 경로는 performance 단일 기록이다.
+
+## 3. 백필 (T14.3)
+
+레거시 meeting 기반 보드가 존재할 경우:
+1. meeting(TrackSelection) → performance 매핑 확보(셋리스트/공연 연결 기준).
+2. `UPDATE p_schedule_board SET performance_id = :resolved WHERE performance_id IS NULL` 형태로 채움.
+3. 매핑 불가 보드는 수기 검토 대상으로 리포트.
+
+현재 운영 데이터 없음 → 백필 no-op. (스크립트는 운영 적용 시 별도 changeset 으로 추가)
+
+## 4. 롤백 계획 (T14.4)
+
+- 추가형 changelog(008~013)는 **테이블 신설/컬럼 추가** 위주로, 롤백 시 신규 테이블 drop + 추가 컬럼 drop 으로 복원 가능.
+- 파괴적 변경(`p_schedule_block.song_id` 제거 = 012)은 운영 데이터 없음 전제에서 수행. 데이터 존재 시에는 012 적용 전 `song_id → p_schedule_block_track` 백필 후 컬럼 제거할 것.
+- 레거시 컬럼 제거(meeting_id 등)는 본 PR 에서 **수행하지 않는다**. `deferred/drop-legacy-meeting-scope.sql` 로 분리하여 백필/검증 완료 후 master 에 등록한다.
+
+## 5. MemberSchedule 폐기 (T15)
+
+- **T15.1 전환**: `MemberScheduleMigrationService` 가 회의 단위 MemberSchedule 의 available/unavailable 날짜를 글로벌 `MemberAvailability` 의 전일 예외(AVAILABLE/BLOCKED)로 이관한다. 같은 날짜 충돌 시 BLOCKED 우선. 슬롯 비트맵(blocks)은 별도 정밀 이관 대상으로 본 전환에서 생략.
+- **T15.2 호환성**: `MemberScheduleController` 는 `@Deprecated` 로 표기하고 당분간 동작을 유지한다(신규 연동 금지). 글로벌 가용성은 `GET/PUT /me/availability` 사용.
+- **T15.3 가용성 출처**: 신 스케줄 보드는 Performance 스코프이므로, 가용성 판단은 글로벌 `MemberAvailability` 를 단일 출처로 사용한다. 회의 단위 MemberSchedule 로의 런타임 폴백은 스코프 불일치로 채택하지 않으며, 전환은 위 마이그레이션 서비스로 일괄 수행한다.
+- **T15.4 최종 폐기**: 모든 멤버 전환 완료 + 신 API 안정화 확인 후, `MemberSchedule` 관련 테이블/엔티티/컨트롤러를 제거하는 changeset 을 등록한다(deferred).
+
+## 6. 적용 순서 요약
+
+1. 008~013 적용(본 PR 묶음, 운영 반영)
+2. (운영 데이터 존재 시) song_id/meeting_id 백필 스크립트 추가·실행
+3. `MemberScheduleMigrationService.migrateAll()` 1회 실행
+4. 신 가용성/자동배치 API 안정화 모니터링
+5. `deferred/drop-legacy-meeting-scope.sql` 를 master 에 등록하여 레거시 컬럼/테이블 제거

--- a/src/main/kotlin/com/bandage/v1/domain/schedule/controller/MemberScheduleController.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/schedule/controller/MemberScheduleController.kt
@@ -18,7 +18,14 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
-@Tag(name = "schedule-member", description = "선곡 회의 멤버 가용 시간 API")
+@Tag(
+    name = "schedule-member",
+    description = "[DEPRECATED] 선곡 회의 멤버 가용 시간 API. 글로벌 가용성 API(/me/availability)로 대체 예정.",
+)
+@Deprecated(
+    message = "회의 단위 MemberSchedule 은 글로벌 MemberAvailability(/me/availability)로 대체됩니다. 신규 연동 금지.",
+    replaceWith = ReplaceWith("MemberAvailabilityController"),
+)
 @RestController
 @RequestMapping("$PREFIX/setlist-meetings/{meetingId}/schedules")
 class MemberScheduleController(

--- a/src/main/kotlin/com/bandage/v1/domain/schedule/repository/MemberScheduleRepository.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/schedule/repository/MemberScheduleRepository.kt
@@ -14,4 +14,7 @@ interface MemberScheduleRepository : JpaRepository<MemberSchedule, MemberSchedul
     ): MemberSchedule?
 
     fun findAllByMeetingId(meetingId: UUID): List<MemberSchedule>
+
+    // T15: MemberSchedule → MemberAvailability 마이그레이션용
+    fun findAllByUserId(userId: Long): List<MemberSchedule>
 }

--- a/src/main/kotlin/com/bandage/v1/domain/schedule/service/MemberScheduleMigrationService.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/schedule/service/MemberScheduleMigrationService.kt
@@ -1,0 +1,67 @@
+package com.bandage.v1.domain.schedule.service
+
+import com.bandage.v1.domain.availability.model.AvailabilityException
+import com.bandage.v1.domain.availability.model.AvailabilityKind
+import com.bandage.v1.domain.availability.model.MemberAvailability
+import com.bandage.v1.domain.availability.repository.MemberAvailabilityRepository
+import com.bandage.v1.domain.schedule.repository.MemberScheduleRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 레거시 MemberSchedule(회의 단위 가용성) → MemberAvailability(글로벌 가용성) 전환 서비스 (PRD-2 T15).
+ *
+ * 회의별로 흩어진 availableDates/unavailableDates 를 멤버 단위로 모아 날짜별 전일(AVAILABLE/BLOCKED) 예외로 옮긴다.
+ * 같은 날짜가 가용/불가에 동시에 존재하면 보수적으로 BLOCKED 가 우선한다.
+ *
+ * 주의: 슬롯 단위 blocks(hex 비트맵)는 본 마이그레이션에서 전일 예외로 단순화하지 않고 생략한다(별도 정밀 이관 대상).
+ * 운영 데이터가 비어 있는 현 시점에서는 일괄 실행이 no-op 에 가깝다.
+ */
+@Service
+class MemberScheduleMigrationService(
+    private val memberScheduleRepository: MemberScheduleRepository,
+    private val memberAvailabilityRepository: MemberAvailabilityRepository,
+) {
+    /** 단일 멤버 전환. 전환된 예외 개수를 반환. */
+    @Transactional
+    fun migrateMember(memberId: Long): Int {
+        val schedules = memberScheduleRepository.findAllByUserId(memberId)
+        if (schedules.isEmpty()) return 0
+
+        val unavailable = schedules.flatMap { it.unavailableDates }.toSet()
+        val available = schedules.flatMap { it.availableDates }.toSet() - unavailable
+
+        val migratedExceptions =
+            available.map { AvailabilityException(it, AvailabilityKind.AVAILABLE, null, null) } +
+                unavailable.map { AvailabilityException(it, AvailabilityKind.BLOCKED, null, null) }
+        if (migratedExceptions.isEmpty()) return 0
+
+        val availability =
+            memberAvailabilityRepository.findByMemberId(memberId)
+                ?: MemberAvailability.create(memberId)
+
+        // 기존 예외와 날짜+종류 기준으로 중복 제거 병합
+        val existingKeys = availability.exceptions.map { it.date to it.kind }.toSet()
+        val merged =
+            availability.exceptions +
+                migratedExceptions.filter { (it.date to it.kind) !in existingKeys }
+        availability.updateExceptions(merged)
+
+        memberAvailabilityRepository.save(availability)
+        return migratedExceptions.size
+    }
+
+    /** 전체 멤버 일괄 전환. (멤버 수, 전환 예외 총합) 반환. */
+    @Transactional
+    fun migrateAll(): MigrationResult {
+        val memberIds = memberScheduleRepository.findAll().map { it.userId }.distinct()
+        var totalExceptions = 0
+        memberIds.forEach { totalExceptions += migrateMember(it) }
+        return MigrationResult(migratedMembers = memberIds.size, migratedExceptions = totalExceptions)
+    }
+
+    data class MigrationResult(
+        val migratedMembers: Int,
+        val migratedExceptions: Int,
+    )
+}

--- a/src/main/resources/db/changelog/deferred/drop-legacy-meeting-scope.sql
+++ b/src/main/resources/db/changelog/deferred/drop-legacy-meeting-scope.sql
@@ -1,0 +1,14 @@
+-- BD-33 (PRD-2 T14.4 / T15.4): 레거시 meeting 스코프 및 MemberSchedule 제거 (지연 실행)
+--
+-- ⚠️ 이 스크립트는 db.changelog-master.yaml 에 등록되어 있지 않다(자동 적용 안 됨).
+--    백필/전환 검증 완료 후, 정식 changeId(예: 014-drop-legacy-meeting-scope)로 master 에 승격하여 적용한다.
+--    적용 전 반드시: (1) p_schedule_board.meeting_id 의존 코드 제거, (2) MemberScheduleMigrationService 전환 완료 확인.
+
+-- 1) ScheduleBoard 의 구 meeting 스코프 컬럼 제거
+ALTER TABLE public.p_schedule_board DROP COLUMN IF EXISTS meeting_id;
+
+-- 2) MemberSchedule(회의 단위 가용성) 폐기 — MemberAvailability 로 전환 완료 후
+DROP TABLE IF EXISTS public.p_member_schedule_blocks;
+DROP TABLE IF EXISTS public.p_member_schedule_available_dates;
+DROP TABLE IF EXISTS public.p_member_schedule_unavailable_dates;
+DROP TABLE IF EXISTS public.p_member_schedule;

--- a/src/test/kotlin/com/bandage/v1/domain/schedule/service/MemberScheduleMigrationServiceTest.kt
+++ b/src/test/kotlin/com/bandage/v1/domain/schedule/service/MemberScheduleMigrationServiceTest.kt
@@ -1,0 +1,55 @@
+package com.bandage.v1.domain.schedule.service
+
+import com.bandage.v1.domain.availability.model.MemberAvailability
+import com.bandage.v1.domain.availability.repository.MemberAvailabilityRepository
+import com.bandage.v1.domain.schedule.model.MemberSchedule
+import com.bandage.v1.domain.schedule.repository.MemberScheduleRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.time.LocalDate
+
+class MemberScheduleMigrationServiceTest {
+    private val memberScheduleRepository = mock(MemberScheduleRepository::class.java)
+    private val memberAvailabilityRepository = mock(MemberAvailabilityRepository::class.java)
+    private val sut = MemberScheduleMigrationService(memberScheduleRepository, memberAvailabilityRepository)
+
+    private fun schedule(
+        meetingId: java.util.UUID,
+        userId: Long,
+        available: Set<LocalDate>,
+        unavailable: Set<LocalDate>,
+    ): MemberSchedule =
+        MemberSchedule.create(meetingId = meetingId, userId = userId).apply {
+            updateAvailability(availableDates = available, unavailableDates = unavailable, blocks = null)
+        }
+
+    @Test
+    fun `available_unavailable 날짜가 전일 예외로 전환되고 BLOCKED 가 우선한다`() {
+        val d1 = LocalDate.of(2026, 6, 1)
+        val d2 = LocalDate.of(2026, 6, 2)
+        val conflict = LocalDate.of(2026, 6, 3)
+        `when`(memberScheduleRepository.findAllByUserId(1L)).thenReturn(
+            listOf(
+                schedule(java.util.UUID.randomUUID(), 1L, available = setOf(d1, conflict), unavailable = setOf(d2)),
+                schedule(java.util.UUID.randomUUID(), 1L, available = emptySet(), unavailable = setOf(conflict)),
+            ),
+        )
+        `when`(memberAvailabilityRepository.findByMemberId(1L)).thenReturn(null)
+        `when`(memberAvailabilityRepository.save(any(MemberAvailability::class.java)))
+            .thenAnswer { it.getArgument(0) }
+
+        val migrated = sut.migrateMember(1L)
+
+        // d1=AVAILABLE, d2=BLOCKED, conflict=BLOCKED (available 에서 제외) → 총 3건
+        assertThat(migrated).isEqualTo(3)
+    }
+
+    @Test
+    fun `스케줄이 없으면 0건 전환`() {
+        `when`(memberScheduleRepository.findAllByUserId(99L)).thenReturn(emptyList())
+        assertThat(sut.migrateMember(99L)).isEqualTo(0)
+    }
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes # BD-33 (PRD-2 Milestone 4)

📌 **작업 내용 및 특이사항**

PRD-2 **Milestone 4 — 마이그레이션/레거시 폐기(T14~T15)**.

> ⚠️ base 가 `feat/BD-33-m3-auto-placement` 인 **스택 PR**. M1(#94)→M2(#95)→M3(#96)→M4 순으로 머지.

### T15. MemberSchedule 폐기 전환
- `MemberScheduleMigrationService`: 회의 단위 available/unavailable 날짜 → 글로벌 `MemberAvailability` 전일 예외(AVAILABLE/BLOCKED)로 이관. 충돌 시 BLOCKED 우선. `migrateMember`/`migrateAll`
- `MemberScheduleController` `@Deprecated`(호환성 유지, `/me/availability` 로 유도)
- `MemberScheduleRepository.findAllByUserId` 추가

### T14. Liquibase / Dual-Write / 롤백
- `docs/migration/BD-33-schedule-migration.md`: changelog 인벤토리(001~013, 007 공번), dual-write·백필·롤백·폐기 계획·적용 순서
- `deferred/drop-legacy-meeting-scope.sql`: 레거시 `meeting_id`/MemberSchedule 제거 스크립트 — **master 미등록**(백필/전환 검증 후 정식 changeId 로 승격)

### 설계 결정
- 운영 데이터 없음 전제 → dual-write/백필은 현재 no-op, 계획 문서로 절차화
- 가용성 단일 출처는 글로벌 MemberAvailability. 회의 스코프 런타임 폴백(T15.3)은 스코프 불일치로 미채택, 마이그레이션 서비스로 일괄 전환

📚 **참고사항**
- `MemberScheduleMigrationServiceTest` GREEN, 전체 단위 테스트 통과
- 파괴적 변경(meeting_id/MemberSchedule drop)은 자동 적용하지 않음 — 안전 절차 후 수동 승격
- 🎉 본 PR 머지 시 PRD-2(합주 스케줄링 재설계) 전체 15개 태스크 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)
