### PR TITLE
[BD-33] fix: develop 배포 동시 실행 레이스 해결 (concurrency + 잔여 컨테이너 정리)

### DIFF
--- a/.github/workflows/develop_deploy.yml
+++ b/.github/workflows/develop_deploy.yml
@@ -9,6 +9,14 @@ env:
   AWS_REGION: ap-northeast-2
   ECR_REPOSITORY: bandage-band-manager
 
+# 동일 EC2 에 대한 배포를 직렬화한다.
+# develop 에 push 가 연속 발생하면 여러 배포가 같은 호스트에서 docker compose recreate 를
+# 동시에 실행해 컨테이너 rename/삭제 레이스("No such container: <hex>_bandage-band-manager")가 난다.
+# 진행 중 배포는 끊지 않고(cancel-in-progress: false) 큐잉하여 한 번에 하나씩만 배포한다.
+concurrency:
+  group: deploy-develop-ec2
+  cancel-in-progress: false
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -120,5 +128,9 @@ jobs:
               | docker login --username AWS --password-stdin "${ECR_REGISTRY}"
 
             docker compose pull
+            # 이전 배포가 비정상 종료되어 남은(이름 충돌) app 컨테이너 정리
+            #  - 정상 컨테이너 'bandage-band-manager' 및 rename 잔여 '<hex>_bandage-band-manager' 모두 포함
+            #  - 정리 후 compose up 이 깨끗하게 재생성하므로 'No such container' 재발 방지
+            docker ps -aq --filter "name=bandage-band-manager" | xargs -r docker rm -f || true
             docker compose up -d
             docker image prune -f


### PR DESCRIPTION
## 🛠️ Issue Number
### closes # BD-33 배포 레이스

📌 **작업 내용 및 특이사항**
- 원인: develop 연속 push(PR #102~#105 연속 머지)로 다수 배포가 동일 EC2 에서 `docker compose up -d` recreate 를 동시 실행 → 컨테이너 rename/삭제 레이스로 `No such container: <hex>_bandage-band-manager` 발생. (빌드·테스트는 모두 성공)
- 수정 1) `concurrency`(group=deploy-develop-ec2, cancel-in-progress=false)로 배포 직렬화(큐잉)
- 수정 2) `docker compose up -d` 직전 이름 충돌 잔여 app 컨테이너 정리(`docker rm -f`)

📚 **참고사항**
- 본 PR 머지가 트리거하는 배포가 수정된 스크립트로 실행되어 잔여 컨테이너를 정리하고 정상화됩니다.
- (별도) dev Postgres 에 기존 데이터가 있으면 첫 Liquibase 적용(010 NOT NULL/012 drop)에서 앱 기동 실패 가능 — dev DB 상태 확인 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)