### PR TITLE
[BD-78] feat: 공연 매니저 역할(OWNER/MANAGER) 및 초대/수락 + 셋리스트 접근 제어

### DIFF
--- a/src/main/kotlin/com/bandage/v1/domain/performance/controller/PerformanceController.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/controller/PerformanceController.kt
@@ -1,14 +1,17 @@
 package com.bandage.v1.domain.performance.controller
 
 import com.bandage.v1.domain.performance.dto.req.PerformanceCreateRequest
+import com.bandage.v1.domain.performance.dto.req.PerformanceInvitationCreateRequest
 import com.bandage.v1.domain.performance.dto.req.PerformancePagingQuery
 import com.bandage.v1.domain.performance.dto.req.PerformanceSearchQuery
 import com.bandage.v1.domain.performance.dto.req.PerformanceSetlistAddRequest
 import com.bandage.v1.domain.performance.dto.req.PerformanceUpdateRequest
 import com.bandage.v1.domain.performance.dto.res.PerformanceDetailResponse
+import com.bandage.v1.domain.performance.dto.res.PerformanceInvitationResponse
 import com.bandage.v1.domain.performance.dto.res.PerformanceListResponse
 import com.bandage.v1.domain.performance.dto.res.PerformanceResponse
 import com.bandage.v1.domain.performance.dto.res.PerformanceSetlistResponse
+import com.bandage.v1.domain.performance.model.enums.PerformanceInvitationStatus
 import com.bandage.v1.domain.performance.service.PerformanceService
 import com.bandage.v1.global.common.constants.PathPrefix.PREFIX
 import com.bandage.v1.global.common.response.ApiResponse
@@ -78,7 +81,7 @@ class PerformanceController(
     ): ApiResponse<PerformanceDetailResponse> = ApiResponse.success(performanceService.getPerformanceDetail(performanceId))
 
     @PatchMapping("/{performanceId}")
-    @Operation(summary = "공연 정보 수정 API", description = "공연 제목, 일정, 장소를 수정합니다. PerformanceManager만 수행할 수 있습니다.")
+    @Operation(summary = "공연 정보 수정 API", description = "공연 제목, 일정, 장소를 수정합니다. OWNER 또는 MANAGER만 수행할 수 있습니다.")
     fun updatePerformance(
         @PathVariable performanceId: UUID,
         @Valid @RequestBody request: PerformanceUpdateRequest,
@@ -91,7 +94,7 @@ class PerformanceController(
     @PostMapping("/{performanceId}/setlists/batch")
     @Operation(
         summary = "공연 참여 셋리스트 일괄 추가 API",
-        description = "공연에 참여 셋리스트를 append 시맨틱으로 다중 추가합니다. PerformanceManager만 가능. 이미 등록된 셋리스트는 응답에서 제외.",
+        description = "공연에 참여 셋리스트를 append 시맨틱으로 다중 추가합니다. OWNER/MANAGER가 본인이 소유/참여한 셋리스트만 추가할 수 있습니다. 이미 등록된 셋리스트는 응답에서 제외.",
     )
     fun addSetlists(
         @PathVariable performanceId: UUID,
@@ -100,7 +103,10 @@ class PerformanceController(
     ): ApiResponse<List<PerformanceSetlistResponse>> = ApiResponse.success(performanceService.addSetlists(performanceId, request, memberId))
 
     @DeleteMapping("/{performanceId}/setlists/{setlistId}")
-    @Operation(summary = "공연 참여 셋리스트 단건 제거 API", description = "공연에서 특정 참여 셋리스트를 제거합니다. PerformanceManager만 가능.")
+    @Operation(
+        summary = "공연 참여 셋리스트 단건 제거 API",
+        description = "공연에서 특정 참여 셋리스트를 제거합니다. OWNER는 모든 셋리스트를, MANAGER는 본인이 소유/참여한 셋리스트만 제거할 수 있습니다.",
+    )
     fun removeSetlist(
         @PathVariable performanceId: UUID,
         @PathVariable setlistId: UUID,
@@ -110,8 +116,47 @@ class PerformanceController(
         return ApiResponse.success()
     }
 
+    @PostMapping("/{performanceId}/invitations")
+    @Operation(
+        summary = "공연 매니저 초대 발송 API",
+        description = "특정 멤버를 공연 MANAGER로 초대합니다. OWNER만 가능하며, 수락 시 MANAGER로 추가됩니다.",
+    )
+    fun sendInvitation(
+        @PathVariable performanceId: UUID,
+        @Valid @RequestBody request: PerformanceInvitationCreateRequest,
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<PerformanceInvitationResponse> = ApiResponse.success(performanceService.sendInvitation(performanceId, request, memberId))
+
+    @GetMapping("/{performanceId}/invitations")
+    @Operation(summary = "공연 초대 목록 조회 API", description = "공연에 발송된 초대 목록을 조회합니다. OWNER만 가능.")
+    fun getInvitations(
+        @PathVariable performanceId: UUID,
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<List<PerformanceInvitationResponse>> = ApiResponse.success(performanceService.getInvitations(performanceId, memberId))
+
+    @GetMapping("/invitations/me")
+    @Operation(summary = "내 공연 초대 목록 조회 API", description = "본인이 받은 대기 중(PENDING) 공연 초대 목록을 조회합니다.")
+    fun getMyInvitations(
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<List<PerformanceInvitationResponse>> = ApiResponse.success(performanceService.getMyInvitations(memberId))
+
+    @PatchMapping("/{performanceId}/invitations/{invitationId}")
+    @Operation(
+        summary = "공연 초대 수락/거절 API",
+        description = "받은 공연 초대를 수락(ACCEPTED) 또는 거절(REJECTED)합니다. 초대 수신자 본인만 가능. 수락 시 MANAGER로 추가됩니다.",
+    )
+    fun respondInvitation(
+        @PathVariable performanceId: UUID,
+        @PathVariable invitationId: UUID,
+        @RequestParam status: PerformanceInvitationStatus,
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<Unit> {
+        performanceService.respondInvitation(performanceId, invitationId, memberId, status)
+        return ApiResponse.success()
+    }
+
     @DeleteMapping("/{performanceId}")
-    @Operation(summary = "공연 삭제 API", description = "공연을 삭제합니다. PerformanceManager만 수행할 수 있습니다.")
+    @Operation(summary = "공연 삭제 API", description = "공연을 삭제합니다. OWNER만 수행할 수 있습니다.")
     fun deletePerformance(
         @PathVariable performanceId: UUID,
         @CurrentMemberId memberId: Long,

--- a/src/main/kotlin/com/bandage/v1/domain/performance/dto/req/PerformanceInvitationCreateRequest.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/dto/req/PerformanceInvitationCreateRequest.kt
@@ -1,0 +1,11 @@
+package com.bandage.v1.domain.performance.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
+
+@Schema(description = "공연 매니저 초대 요청")
+data class PerformanceInvitationCreateRequest(
+    @field:NotNull
+    @Schema(description = "초대할 멤버 ID", example = "42")
+    val memberId: Long,
+)

--- a/src/main/kotlin/com/bandage/v1/domain/performance/dto/res/PerformanceInvitationResponse.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/dto/res/PerformanceInvitationResponse.kt
@@ -1,0 +1,45 @@
+package com.bandage.v1.domain.performance.dto.res
+
+import com.bandage.v1.domain.performance.model.PerformanceInvitation
+import com.bandage.v1.domain.performance.model.enums.PerformanceInvitationStatus
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Schema(description = "공연 매니저 초대 응답")
+data class PerformanceInvitationResponse(
+    @Schema(description = "초대 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+    val invitationId: UUID,
+    @Schema(description = "공연 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+    val performanceId: UUID,
+    @Schema(description = "공연 제목", example = "정기 공연 2026")
+    val performanceTitle: String,
+    @Schema(description = "초대받은 멤버 ID", example = "42")
+    val invitedMemberId: Long,
+    @Schema(description = "초대받은 멤버 이름", example = "홍길동")
+    val invitedMemberName: String?,
+    @Schema(description = "초대받은 멤버 프로필 이미지 URL")
+    val invitedMemberProfileImg: String?,
+    @Schema(description = "초대 상태", example = "PENDING")
+    val status: PerformanceInvitationStatus,
+    @Schema(description = "초대 생성 시각")
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun of(
+            invitation: PerformanceInvitation,
+            invitedMemberName: String?,
+            invitedMemberProfileImg: String?,
+        ): PerformanceInvitationResponse =
+            PerformanceInvitationResponse(
+                invitationId = invitation.id,
+                performanceId = invitation.performance.id,
+                performanceTitle = invitation.performance.title,
+                invitedMemberId = invitation.invitedMember,
+                invitedMemberName = invitedMemberName,
+                invitedMemberProfileImg = invitedMemberProfileImg,
+                status = invitation.status,
+                createdAt = invitation.createdAt,
+            )
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/performance/model/PerformanceInvitation.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/model/PerformanceInvitation.kt
@@ -1,0 +1,74 @@
+package com.bandage.v1.domain.performance.model
+
+import com.bandage.v1.domain.performance.model.enums.PerformanceInvitationStatus
+import com.bandage.v1.global.common.domain.BaseEntity
+import com.bandage.v1.global.error.errorcode.ErrorCode
+import com.bandage.v1.global.error.exception.BusinessException
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import org.hibernate.annotations.SQLRestriction
+import org.hibernate.annotations.UuidGenerator
+import java.util.UUID
+
+@Entity
+@Table(name = "p_performance_invitation")
+@SQLRestriction("deleted_at IS NULL")
+open class PerformanceInvitation(
+    performance: Performance,
+    invitedMember: Long,
+    invitedBy: Long,
+    status: PerformanceInvitationStatus = PerformanceInvitationStatus.PENDING,
+) : BaseEntity() {
+    @Id
+    @Column(name = "performance_invitation_id")
+    @UuidGenerator(style = UuidGenerator.Style.VERSION_7)
+    lateinit var id: UUID
+        protected set
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "performance_id", nullable = false)
+    val performance: Performance = performance
+
+    @Column(name = "invited_member_id", nullable = false)
+    val invitedMember: Long = invitedMember
+
+    @Column(name = "invited_by", nullable = false)
+    val invitedBy: Long = invitedBy
+
+    @Column(name = "status", nullable = false)
+    var status: PerformanceInvitationStatus = status
+        protected set
+
+    @Column(name = "processed_by")
+    var processedBy: Long? = null
+        protected set
+
+    fun updateStatus(newStatus: PerformanceInvitationStatus) {
+        if (newStatus == this.status) {
+            throw BusinessException(ErrorCode.INVALID_INPUT_VALUE)
+        }
+        this.status = newStatus
+    }
+
+    fun markProcessedBy(memberId: Long) {
+        this.processedBy = memberId
+    }
+
+    companion object {
+        fun create(
+            performance: Performance,
+            invitedMember: Long,
+            invitedBy: Long,
+        ): PerformanceInvitation =
+            PerformanceInvitation(
+                performance = performance,
+                invitedMember = invitedMember,
+                invitedBy = invitedBy,
+            )
+    }
+}

--- a/src/main/kotlin/com/bandage/v1/domain/performance/model/PerformanceManager.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/model/PerformanceManager.kt
@@ -1,5 +1,6 @@
 package com.bandage.v1.domain.performance.model
 
+import com.bandage.v1.domain.performance.model.enums.PerformanceRole
 import com.bandage.v1.global.common.domain.BaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -8,14 +9,24 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
 import org.hibernate.annotations.UuidGenerator
 import java.util.UUID
 
 @Entity
-@Table(name = "p_performance_manager")
+@Table(
+    name = "p_performance_manager",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_performance_manager",
+            columnNames = ["performance_id", "member_id"],
+        ),
+    ],
+)
 open class PerformanceManager(
     performance: Performance,
     member: Long,
+    role: PerformanceRole,
 ) : BaseEntity() {
     @Id
     @Column(name = "performance_manager_id")
@@ -30,14 +41,30 @@ open class PerformanceManager(
     @Column(name = "member_id", nullable = false)
     val member: Long = member
 
+    @Column(name = "role", nullable = false)
+    val role: PerformanceRole = role
+
+    fun isOwner(): Boolean = role == PerformanceRole.OWNER
+
     companion object {
-        fun create(
+        fun createOwner(
             performance: Performance,
             member: Long,
         ): PerformanceManager =
             PerformanceManager(
                 performance = performance,
                 member = member,
+                role = PerformanceRole.OWNER,
+            )
+
+        fun createManager(
+            performance: Performance,
+            member: Long,
+        ): PerformanceManager =
+            PerformanceManager(
+                performance = performance,
+                member = member,
+                role = PerformanceRole.MANAGER,
             )
     }
 }

--- a/src/main/kotlin/com/bandage/v1/domain/performance/model/enums/PerformanceInvitationStatus.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/model/enums/PerformanceInvitationStatus.kt
@@ -1,0 +1,8 @@
+package com.bandage.v1.domain.performance.model.enums
+
+enum class PerformanceInvitationStatus {
+    PENDING,
+    ACCEPTED,
+    REJECTED,
+    CANCELED,
+}

--- a/src/main/kotlin/com/bandage/v1/domain/performance/model/enums/PerformanceRole.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/model/enums/PerformanceRole.kt
@@ -1,0 +1,6 @@
+package com.bandage.v1.domain.performance.model.enums
+
+enum class PerformanceRole {
+    OWNER,
+    MANAGER,
+}

--- a/src/main/kotlin/com/bandage/v1/domain/performance/repository/PerformanceInvitationRepository.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/repository/PerformanceInvitationRepository.kt
@@ -1,0 +1,29 @@
+package com.bandage.v1.domain.performance.repository
+
+import com.bandage.v1.domain.performance.model.Performance
+import com.bandage.v1.domain.performance.model.PerformanceInvitation
+import com.bandage.v1.domain.performance.model.enums.PerformanceInvitationStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface PerformanceInvitationRepository : JpaRepository<PerformanceInvitation, UUID> {
+    fun existsByPerformanceAndInvitedMemberAndStatus(
+        performance: Performance,
+        invitedMember: Long,
+        status: PerformanceInvitationStatus,
+    ): Boolean
+
+    fun findByIdAndStatus(
+        id: UUID,
+        status: PerformanceInvitationStatus,
+    ): PerformanceInvitation?
+
+    fun findAllByPerformanceOrderByCreatedAtDesc(performance: Performance): List<PerformanceInvitation>
+
+    fun findAllByInvitedMemberAndStatusOrderByCreatedAtDesc(
+        invitedMember: Long,
+        status: PerformanceInvitationStatus,
+    ): List<PerformanceInvitation>
+}

--- a/src/main/kotlin/com/bandage/v1/domain/performance/repository/PerformanceManagerRepository.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/repository/PerformanceManagerRepository.kt
@@ -12,4 +12,9 @@ interface PerformanceManagerRepository : JpaRepository<PerformanceManager, UUID>
         performance: Performance,
         member: Long,
     ): Boolean
+
+    fun findByPerformanceAndMember(
+        performance: Performance,
+        member: Long,
+    ): PerformanceManager?
 }

--- a/src/main/kotlin/com/bandage/v1/domain/performance/service/PerformanceService.kt
+++ b/src/main/kotlin/com/bandage/v1/domain/performance/service/PerformanceService.kt
@@ -4,6 +4,7 @@ import com.bandage.v1.domain.band.repository.BandMemberRepository
 import com.bandage.v1.domain.band.repository.BandRepository
 import com.bandage.v1.domain.member.repository.MemberRepository
 import com.bandage.v1.domain.performance.dto.req.PerformanceCreateRequest
+import com.bandage.v1.domain.performance.dto.req.PerformanceInvitationCreateRequest
 import com.bandage.v1.domain.performance.dto.req.PerformancePagingQuery
 import com.bandage.v1.domain.performance.dto.req.PerformanceSearchQuery
 import com.bandage.v1.domain.performance.dto.req.PerformanceSetlistAddRequest
@@ -11,13 +12,17 @@ import com.bandage.v1.domain.performance.dto.req.PerformanceUpdateRequest
 import com.bandage.v1.domain.performance.dto.res.PerformanceBandMemberSummary
 import com.bandage.v1.domain.performance.dto.res.PerformanceBandSummary
 import com.bandage.v1.domain.performance.dto.res.PerformanceDetailResponse
+import com.bandage.v1.domain.performance.dto.res.PerformanceInvitationResponse
 import com.bandage.v1.domain.performance.dto.res.PerformanceListResponse
 import com.bandage.v1.domain.performance.dto.res.PerformanceResponse
 import com.bandage.v1.domain.performance.dto.res.PerformanceSetlistResponse
 import com.bandage.v1.domain.performance.dto.res.PerformanceSetlistSummary
 import com.bandage.v1.domain.performance.model.Performance
+import com.bandage.v1.domain.performance.model.PerformanceInvitation
 import com.bandage.v1.domain.performance.model.PerformanceManager
 import com.bandage.v1.domain.performance.model.PerformanceSetlist
+import com.bandage.v1.domain.performance.model.enums.PerformanceInvitationStatus
+import com.bandage.v1.domain.performance.repository.PerformanceInvitationRepository
 import com.bandage.v1.domain.performance.repository.PerformanceManagerRepository
 import com.bandage.v1.domain.performance.repository.PerformanceRepository
 import com.bandage.v1.domain.performance.repository.PerformanceSetlistRepository
@@ -39,6 +44,7 @@ class PerformanceService(
     private val performanceRepository: PerformanceRepository,
     private val performanceSetlistRepository: PerformanceSetlistRepository,
     private val performanceManagerRepository: PerformanceManagerRepository,
+    private val performanceInvitationRepository: PerformanceInvitationRepository,
     private val setlistRepository: SetlistRepository,
     private val setlistBandRepository: SetlistBandRepository,
     private val bandRepository: BandRepository,
@@ -62,9 +68,10 @@ class PerformanceService(
             )
         (request.setlistIds ?: emptyList()).distinct().forEach { setlistId ->
             requireSetlist(setlistId)
+            validateSetlistAccessible(setlistId, memberId)
             performanceSetlistRepository.save(PerformanceSetlist.create(performance = performance, setlistId = setlistId))
         }
-        performanceManagerRepository.save(PerformanceManager.create(performance = performance, member = memberId))
+        performanceManagerRepository.save(PerformanceManager.createOwner(performance = performance, member = memberId))
         return PerformanceResponse.of(performance)
     }
 
@@ -131,7 +138,7 @@ class PerformanceService(
         memberId: Long,
     ) {
         val performance = getPerformance(performanceId)
-        validateIsManager(performance, memberId)
+        validateParticipant(performance, memberId)
         request.title?.let { performance.updateTitle(it) }
         if (request.startAt != null || request.durationMinutes != null) {
             performance.updateTimeInfo(
@@ -149,10 +156,11 @@ class PerformanceService(
         memberId: Long,
     ): List<PerformanceSetlistResponse> {
         val performance = getPerformance(performanceId)
-        validateIsManager(performance, memberId)
+        validateParticipant(performance, memberId)
         return request.setlistIds.distinct().mapNotNull { setlistId ->
             if (performanceSetlistRepository.existsByPerformanceAndSetlistId(performance, setlistId)) return@mapNotNull null
             requireSetlist(setlistId)
+            validateSetlistAccessible(setlistId, memberId)
             val saved = performanceSetlistRepository.save(PerformanceSetlist.create(performance = performance, setlistId = setlistId))
             PerformanceSetlistResponse.of(saved)
         }
@@ -165,10 +173,14 @@ class PerformanceService(
         memberId: Long,
     ) {
         val performance = getPerformance(performanceId)
-        validateIsManager(performance, memberId)
+        val participant = requireParticipant(performance, memberId)
         val ps =
             performanceSetlistRepository.findByPerformanceAndSetlistId(performance, setlistId)
                 ?: throw BusinessException(ErrorCode.PERFORMANCE_SETLIST_NOT_FOUND)
+        // OWNER 는 공연 내 모든 셋리스트를 제거할 수 있고, MANAGER 는 본인이 접근 가능한 셋리스트만 제거할 수 있다.
+        if (!participant.isOwner()) {
+            validateSetlistAccessible(setlistId, memberId)
+        }
         performanceSetlistRepository.delete(ps)
     }
 
@@ -178,8 +190,92 @@ class PerformanceService(
         memberId: Long,
     ) {
         val performance = getPerformance(performanceId)
-        validateIsManager(performance, memberId)
+        validateOwner(performance, memberId)
         performance.markAsDeleted(memberId)
+    }
+
+    @Transactional
+    fun sendInvitation(
+        performanceId: UUID,
+        request: PerformanceInvitationCreateRequest,
+        ownerId: Long,
+    ): PerformanceInvitationResponse {
+        val performance = getPerformance(performanceId)
+        validateOwner(performance, ownerId)
+        val invitedMemberId = request.memberId
+        if (!memberRepository.existsById(invitedMemberId)) {
+            throw BusinessException(ErrorCode.MEMBER_NOT_FOUND)
+        }
+        if (performanceManagerRepository.existsByPerformanceAndMember(performance, invitedMemberId)) {
+            throw BusinessException(ErrorCode.ALREADY_PERFORMANCE_MANAGER)
+        }
+        if (performanceInvitationRepository.existsByPerformanceAndInvitedMemberAndStatus(
+                performance,
+                invitedMemberId,
+                PerformanceInvitationStatus.PENDING,
+            )
+        ) {
+            throw BusinessException(ErrorCode.PERFORMANCE_INVITATION_ALREADY_EXISTS)
+        }
+        val saved =
+            performanceInvitationRepository.save(
+                PerformanceInvitation.create(
+                    performance = performance,
+                    invitedMember = invitedMemberId,
+                    invitedBy = ownerId,
+                ),
+            )
+        return toInvitationResponses(listOf(saved)).first()
+    }
+
+    fun getInvitations(
+        performanceId: UUID,
+        ownerId: Long,
+    ): List<PerformanceInvitationResponse> {
+        val performance = getPerformance(performanceId)
+        validateOwner(performance, ownerId)
+        return toInvitationResponses(performanceInvitationRepository.findAllByPerformanceOrderByCreatedAtDesc(performance))
+    }
+
+    fun getMyInvitations(memberId: Long): List<PerformanceInvitationResponse> =
+        toInvitationResponses(
+            performanceInvitationRepository.findAllByInvitedMemberAndStatusOrderByCreatedAtDesc(
+                memberId,
+                PerformanceInvitationStatus.PENDING,
+            ),
+        )
+
+    @Transactional
+    fun respondInvitation(
+        performanceId: UUID,
+        invitationId: UUID,
+        memberId: Long,
+        status: PerformanceInvitationStatus,
+    ) {
+        val performance = getPerformance(performanceId)
+        val invitation =
+            performanceInvitationRepository.findByIdAndStatus(invitationId, PerformanceInvitationStatus.PENDING)
+                ?: throw BusinessException(ErrorCode.PERFORMANCE_INVITATION_NOT_FOUND)
+        if (invitation.performance.id != performance.id) {
+            throw BusinessException(ErrorCode.PERFORMANCE_INVITATION_NOT_FOUND)
+        }
+        if (invitation.invitedMember != memberId) {
+            throw BusinessException(ErrorCode.PERFORMANCE_INVITATION_FORBIDDEN)
+        }
+        when (status) {
+            PerformanceInvitationStatus.ACCEPTED -> {
+                invitation.updateStatus(PerformanceInvitationStatus.ACCEPTED)
+                invitation.markProcessedBy(memberId)
+                if (!performanceManagerRepository.existsByPerformanceAndMember(performance, memberId)) {
+                    performanceManagerRepository.save(PerformanceManager.createManager(performance = performance, member = memberId))
+                }
+            }
+            PerformanceInvitationStatus.REJECTED -> {
+                invitation.updateStatus(PerformanceInvitationStatus.REJECTED)
+                invitation.markProcessedBy(memberId)
+            }
+            else -> throw BusinessException(ErrorCode.INVALID_INPUT_VALUE)
+        }
     }
 
     private fun buildSetlistSummaries(setlistIds: Collection<UUID>): Map<UUID, PerformanceSetlistSummary> {
@@ -229,6 +325,19 @@ class PerformanceService(
         }
     }
 
+    private fun toInvitationResponses(invitations: List<PerformanceInvitation>): List<PerformanceInvitationResponse> {
+        if (invitations.isEmpty()) return emptyList()
+        val members = memberRepository.findAllById(invitations.map { it.invitedMember }.toSet()).associateBy { it.id }
+        return invitations.map { invitation ->
+            val member = members[invitation.invitedMember]
+            PerformanceInvitationResponse.of(
+                invitation = invitation,
+                invitedMemberName = member?.name,
+                invitedMemberProfileImg = cloudFrontUrlResolver.resolveOrNull(member?.profileImg),
+            )
+        }
+    }
+
     fun getPerformance(performanceId: UUID): Performance =
         performanceRepository.findByIdOrNull(performanceId)
             ?: throw BusinessException(ErrorCode.PERFORMANCE_NOT_FOUND)
@@ -237,12 +346,35 @@ class PerformanceService(
         setlistRepository.findByIdOrNull(setlistId)
             ?: throw BusinessException(ErrorCode.SETLIST_NOT_FOUND)
 
-    fun validateIsManager(
+    private fun validateSetlistAccessible(
+        setlistId: UUID,
+        memberId: Long,
+    ) {
+        if (!setlistRepository.isAccessibleMember(setlistId, memberId)) {
+            throw BusinessException(ErrorCode.SETLIST_FORBIDDEN)
+        }
+    }
+
+    private fun requireParticipant(
+        performance: Performance,
+        memberId: Long,
+    ): PerformanceManager =
+        performanceManagerRepository.findByPerformanceAndMember(performance, memberId)
+            ?: throw BusinessException(ErrorCode.NOT_A_PERFORMANCE_MANAGER)
+
+    private fun validateParticipant(
         performance: Performance,
         memberId: Long,
     ) {
-        if (!performanceManagerRepository.existsByPerformanceAndMember(performance, memberId)) {
-            throw BusinessException(ErrorCode.NOT_A_PERFORMANCE_MANAGER)
+        requireParticipant(performance, memberId)
+    }
+
+    private fun validateOwner(
+        performance: Performance,
+        memberId: Long,
+    ) {
+        if (!requireParticipant(performance, memberId).isOwner()) {
+            throw BusinessException(ErrorCode.NOT_A_PERFORMANCE_OWNER)
         }
     }
 }

--- a/src/main/kotlin/com/bandage/v1/global/error/errorcode/ErrorCode.kt
+++ b/src/main/kotlin/com/bandage/v1/global/error/errorcode/ErrorCode.kt
@@ -53,7 +53,12 @@ enum class ErrorCode(
     // performance
     PERFORMANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 공연 정보를 찾을 수 없습니다."),
     NOT_A_PERFORMANCE_MANAGER(HttpStatus.FORBIDDEN, "공연 매니저만 수행할 수 있는 작업입니다."),
+    NOT_A_PERFORMANCE_OWNER(HttpStatus.FORBIDDEN, "공연 소유자(OWNER)만 수행할 수 있는 작업입니다."),
     PERFORMANCE_SETLIST_NOT_FOUND(HttpStatus.NOT_FOUND, "공연에 연결된 셋리스트 정보를 찾을 수 없습니다."),
+    ALREADY_PERFORMANCE_MANAGER(HttpStatus.CONFLICT, "이미 공연에 참여 중인 멤버입니다."),
+    PERFORMANCE_INVITATION_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 공연 초대 정보를 찾을 수 없습니다."),
+    PERFORMANCE_INVITATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 발송되어 대기 중인 초대입니다."),
+    PERFORMANCE_INVITATION_FORBIDDEN(HttpStatus.FORBIDDEN, "공연 초대를 처리할 권한이 없습니다."),
 
     // setlist meeting
     SETLIST_MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 선곡 회의 정보를 찾을 수 없습니다."),

--- a/src/main/resources/db/changelog/changes/014-performance-manager-role-and-invitation.sql
+++ b/src/main/resources/db/changelog/changes/014-performance-manager-role-and-invitation.sql
@@ -1,0 +1,49 @@
+-- BD-78: 공연 매니저 역할(OWNER/MANAGER) 컬럼 + 공연 초대 테이블 신설
+
+-- 1) p_performance_manager 에 역할 컬럼 추가 (0=OWNER, 1=MANAGER)
+ALTER TABLE public.p_performance_manager
+    ADD COLUMN role smallint;
+
+-- 기존 매니저 행은 모두 공연 생성자이므로 OWNER(0) 로 백필
+UPDATE public.p_performance_manager
+SET role = 0
+WHERE role IS NULL;
+
+ALTER TABLE public.p_performance_manager
+    ALTER COLUMN role SET NOT NULL;
+
+ALTER TABLE public.p_performance_manager
+    ADD CONSTRAINT p_performance_manager_role_check CHECK (role IN (0, 1));
+
+-- 동일 공연-멤버 매니저 중복 방지
+ALTER TABLE public.p_performance_manager
+    ADD CONSTRAINT uk_performance_manager UNIQUE (performance_id, member_id);
+
+-- 2) 공연 초대 테이블 (0=PENDING, 1=ACCEPTED, 2=REJECTED, 3=CANCELED)
+CREATE TABLE public.p_performance_invitation (
+    performance_invitation_id uuid NOT NULL,
+    performance_id uuid NOT NULL,
+    invited_member_id bigint NOT NULL,
+    invited_by bigint NOT NULL,
+    status smallint NOT NULL,
+    processed_by bigint,
+    created_at timestamp(6) without time zone NOT NULL,
+    created_by bigint,
+    last_modified_at timestamp(6) without time zone NOT NULL,
+    last_modified_by bigint,
+    deleted_at timestamp(6) without time zone,
+    deleted_by bigint,
+    CONSTRAINT p_performance_invitation_pkey PRIMARY KEY (performance_invitation_id),
+    CONSTRAINT p_performance_invitation_status_check CHECK (status >= 0 AND status <= 3),
+    CONSTRAINT fk_performance_invitation__performance
+        FOREIGN KEY (performance_id) REFERENCES public.p_performance(performance_id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_performance_invitation__performance ON public.p_performance_invitation (performance_id);
+
+CREATE INDEX idx_performance_invitation__invited_member ON public.p_performance_invitation (invited_member_id);
+
+-- 동일 공연에 대한 동일 멤버의 PENDING 초대 중복 방지 (취소/처리된 건 재초대 허용)
+CREATE UNIQUE INDEX uk_performance_invitation_pending
+    ON public.p_performance_invitation (performance_id, invited_member_id)
+    WHERE status = 0 AND deleted_at IS NULL;

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -161,3 +161,15 @@ databaseChangeLog:
             splitStatements: true
             stripComments: true
             endDelimiter: ";"
+  - changeSet:
+      id: 014-performance-manager-role-and-invitation
+      author: bandage
+      comment: |
+        BD-78: 공연 매니저 역할(OWNER/MANAGER) 컬럼 추가 + 공연 초대 테이블 신설
+      changes:
+        - sqlFile:
+            path: changes/014-performance-manager-role-and-invitation.sql
+            relativeToChangelogFile: true
+            splitStatements: true
+            stripComments: true
+            endDelimiter: ";"

--- a/src/test/kotlin/com/bandage/v1/domain/performance/service/PerformanceServiceTest.kt
+++ b/src/test/kotlin/com/bandage/v1/domain/performance/service/PerformanceServiceTest.kt
@@ -1,0 +1,293 @@
+package com.bandage.v1.domain.performance.service
+
+import com.bandage.v1.domain.band.repository.BandMemberRepository
+import com.bandage.v1.domain.band.repository.BandRepository
+import com.bandage.v1.domain.member.repository.MemberRepository
+import com.bandage.v1.domain.performance.dto.req.PerformanceInvitationCreateRequest
+import com.bandage.v1.domain.performance.dto.req.PerformanceSetlistAddRequest
+import com.bandage.v1.domain.performance.dto.req.PerformanceUpdateRequest
+import com.bandage.v1.domain.performance.model.Performance
+import com.bandage.v1.domain.performance.model.PerformanceInvitation
+import com.bandage.v1.domain.performance.model.PerformanceManager
+import com.bandage.v1.domain.performance.model.PerformanceSetlist
+import com.bandage.v1.domain.performance.model.enums.PerformanceInvitationStatus
+import com.bandage.v1.domain.performance.repository.PerformanceInvitationRepository
+import com.bandage.v1.domain.performance.repository.PerformanceManagerRepository
+import com.bandage.v1.domain.performance.repository.PerformanceRepository
+import com.bandage.v1.domain.performance.repository.PerformanceSetlistRepository
+import com.bandage.v1.domain.setlist.model.Setlist
+import com.bandage.v1.domain.setlist.repository.SetlistBandRepository
+import com.bandage.v1.domain.setlist.repository.SetlistRepository
+import com.bandage.v1.global.error.errorcode.ErrorCode
+import com.bandage.v1.global.error.exception.BusinessException
+import com.bandage.v1.global.infra.s3.CloudFrontUrlResolver
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import java.time.LocalDateTime
+import java.util.Optional
+import java.util.UUID
+
+class PerformanceServiceTest {
+    private val performanceRepository = mock(PerformanceRepository::class.java)
+    private val performanceSetlistRepository = mock(PerformanceSetlistRepository::class.java)
+    private val performanceManagerRepository = mock(PerformanceManagerRepository::class.java)
+    private val performanceInvitationRepository = mock(PerformanceInvitationRepository::class.java)
+    private val setlistRepository = mock(SetlistRepository::class.java)
+    private val setlistBandRepository = mock(SetlistBandRepository::class.java)
+    private val bandRepository = mock(BandRepository::class.java)
+    private val bandMemberRepository = mock(BandMemberRepository::class.java)
+    private val memberRepository = mock(MemberRepository::class.java)
+    private val cloudFrontUrlResolver = mock(CloudFrontUrlResolver::class.java)
+
+    private val sut =
+        PerformanceService(
+            performanceRepository,
+            performanceSetlistRepository,
+            performanceManagerRepository,
+            performanceInvitationRepository,
+            setlistRepository,
+            setlistBandRepository,
+            bandRepository,
+            bandMemberRepository,
+            memberRepository,
+            cloudFrontUrlResolver,
+        )
+
+    private val performanceId: UUID = UUID.fromString("00000000-0000-0000-0000-0000000000a1")
+    private val setlistId: UUID = UUID.fromString("00000000-0000-0000-0000-0000000000b1")
+    private val ownerId = 1L
+    private val managerId = 2L
+    private val invitedId = 3L
+
+    private fun registeredPerformance(): Performance {
+        val performance =
+            Performance.create(
+                title = "정기공연",
+                startAt = LocalDateTime.now().plusDays(1),
+                durationMinutes = 90,
+                venue = null,
+            )
+        setEntityId(performance, performanceId)
+        `when`(performanceRepository.findById(performanceId)).thenReturn(Optional.of(performance))
+        return performance
+    }
+
+    private fun stubParticipant(
+        performance: Performance,
+        memberId: Long,
+        owner: Boolean,
+    ) {
+        val manager =
+            if (owner) {
+                PerformanceManager.createOwner(performance, memberId)
+            } else {
+                PerformanceManager.createManager(performance, memberId)
+            }
+        `when`(performanceManagerRepository.findByPerformanceAndMember(performance, memberId)).thenReturn(manager)
+    }
+
+    private fun setEntityId(
+        target: Any,
+        id: UUID,
+    ) {
+        val field = target.javaClass.getDeclaredField("id")
+        field.isAccessible = true
+        field.set(target, id)
+    }
+
+    @Test
+    fun `addSetlists - 본인이 접근 불가한 셋리스트는 SETLIST_FORBIDDEN`() {
+        val performance = registeredPerformance()
+        stubParticipant(performance, managerId, owner = false)
+        `when`(performanceSetlistRepository.existsByPerformanceAndSetlistId(performance, setlistId)).thenReturn(false)
+        `when`(setlistRepository.findById(setlistId)).thenReturn(Optional.of(mock(Setlist::class.java)))
+        `when`(setlistRepository.isAccessibleMember(setlistId, managerId)).thenReturn(false)
+
+        val ex =
+            assertThrows<BusinessException> {
+                sut.addSetlists(performanceId, PerformanceSetlistAddRequest(setlistIds = listOf(setlistId)), managerId)
+            }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.SETLIST_FORBIDDEN)
+        verify(performanceSetlistRepository, never()).save(any())
+    }
+
+    @Test
+    fun `removeSetlist - MANAGER가 접근 불가한 셋리스트 제거 시 거부된다`() {
+        val performance = registeredPerformance()
+        stubParticipant(performance, managerId, owner = false)
+        `when`(performanceSetlistRepository.findByPerformanceAndSetlistId(performance, setlistId))
+            .thenReturn(PerformanceSetlist.create(performance, setlistId))
+        `when`(setlistRepository.isAccessibleMember(setlistId, managerId)).thenReturn(false)
+
+        val ex = assertThrows<BusinessException> { sut.removeSetlist(performanceId, setlistId, managerId) }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.SETLIST_FORBIDDEN)
+        verify(performanceSetlistRepository, never()).delete(any())
+    }
+
+    @Test
+    fun `removeSetlist - OWNER는 접근 불가한 셋리스트도 제거할 수 있다`() {
+        val performance = registeredPerformance()
+        stubParticipant(performance, ownerId, owner = true)
+        val ps = PerformanceSetlist.create(performance, setlistId)
+        `when`(performanceSetlistRepository.findByPerformanceAndSetlistId(performance, setlistId)).thenReturn(ps)
+
+        sut.removeSetlist(performanceId, setlistId, ownerId)
+
+        verify(performanceSetlistRepository).delete(ps)
+        verify(setlistRepository, never()).isAccessibleMember(setlistId, ownerId)
+    }
+
+    @Test
+    fun `deletePerformance - MANAGER는 OWNER 권한이 아니어서 거부된다`() {
+        val performance = registeredPerformance()
+        stubParticipant(performance, managerId, owner = false)
+
+        val ex = assertThrows<BusinessException> { sut.deletePerformance(performanceId, managerId) }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.NOT_A_PERFORMANCE_OWNER)
+    }
+
+    @Test
+    fun `deletePerformance - OWNER는 삭제할 수 있다`() {
+        val performance = registeredPerformance()
+        stubParticipant(performance, ownerId, owner = true)
+
+        sut.deletePerformance(performanceId, ownerId)
+
+        assertThat(performance.deletedAt).isNotNull()
+    }
+
+    @Test
+    fun `updatePerformance - MANAGER도 수정할 수 있다`() {
+        val performance = registeredPerformance()
+        stubParticipant(performance, managerId, owner = false)
+
+        sut.updatePerformance(performanceId, PerformanceUpdateRequest(title = "수정된 제목"), managerId)
+
+        assertThat(performance.title).isEqualTo("수정된 제목")
+    }
+
+    @Test
+    fun `sendInvitation - OWNER가 아니면 거부된다`() {
+        val performance = registeredPerformance()
+        stubParticipant(performance, managerId, owner = false)
+
+        val ex =
+            assertThrows<BusinessException> {
+                sut.sendInvitation(performanceId, PerformanceInvitationCreateRequest(memberId = invitedId), managerId)
+            }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.NOT_A_PERFORMANCE_OWNER)
+    }
+
+    @Test
+    fun `sendInvitation - 존재하지 않는 멤버면 MEMBER_NOT_FOUND`() {
+        val performance = registeredPerformance()
+        stubParticipant(performance, ownerId, owner = true)
+        `when`(memberRepository.existsById(invitedId)).thenReturn(false)
+
+        val ex =
+            assertThrows<BusinessException> {
+                sut.sendInvitation(performanceId, PerformanceInvitationCreateRequest(memberId = invitedId), ownerId)
+            }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.MEMBER_NOT_FOUND)
+    }
+
+    @Test
+    fun `sendInvitation - 이미 공연 참가자면 ALREADY_PERFORMANCE_MANAGER`() {
+        val performance = registeredPerformance()
+        stubParticipant(performance, ownerId, owner = true)
+        `when`(memberRepository.existsById(invitedId)).thenReturn(true)
+        `when`(performanceManagerRepository.existsByPerformanceAndMember(performance, invitedId)).thenReturn(true)
+
+        val ex =
+            assertThrows<BusinessException> {
+                sut.sendInvitation(performanceId, PerformanceInvitationCreateRequest(memberId = invitedId), ownerId)
+            }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.ALREADY_PERFORMANCE_MANAGER)
+    }
+
+    @Test
+    fun `sendInvitation - 대기 중 초대가 이미 있으면 거부된다`() {
+        val performance = registeredPerformance()
+        stubParticipant(performance, ownerId, owner = true)
+        `when`(memberRepository.existsById(invitedId)).thenReturn(true)
+        `when`(performanceManagerRepository.existsByPerformanceAndMember(performance, invitedId)).thenReturn(false)
+        `when`(
+            performanceInvitationRepository.existsByPerformanceAndInvitedMemberAndStatus(
+                performance,
+                invitedId,
+                PerformanceInvitationStatus.PENDING,
+            ),
+        ).thenReturn(true)
+
+        val ex =
+            assertThrows<BusinessException> {
+                sut.sendInvitation(performanceId, PerformanceInvitationCreateRequest(memberId = invitedId), ownerId)
+            }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.PERFORMANCE_INVITATION_ALREADY_EXISTS)
+    }
+
+    @Test
+    fun `sendInvitation - 정상 발송 시 PENDING 초대를 반환한다`() {
+        val performance = registeredPerformance()
+        stubParticipant(performance, ownerId, owner = true)
+        `when`(memberRepository.existsById(invitedId)).thenReturn(true)
+        `when`(performanceManagerRepository.existsByPerformanceAndMember(performance, invitedId)).thenReturn(false)
+        `when`(
+            performanceInvitationRepository.existsByPerformanceAndInvitedMemberAndStatus(
+                performance,
+                invitedId,
+                PerformanceInvitationStatus.PENDING,
+            ),
+        ).thenReturn(false)
+        `when`(performanceInvitationRepository.save(any())).thenAnswer {
+            val saved = it.arguments[0] as PerformanceInvitation
+            setEntityId(saved, UUID.fromString("00000000-0000-0000-0000-0000000000d1"))
+            saved
+        }
+        `when`(memberRepository.findAllById(setOf(invitedId))).thenReturn(emptyList())
+
+        val response = sut.sendInvitation(performanceId, PerformanceInvitationCreateRequest(memberId = invitedId), ownerId)
+
+        assertThat(response.invitedMemberId).isEqualTo(invitedId)
+        assertThat(response.status).isEqualTo(PerformanceInvitationStatus.PENDING)
+        assertThat(response.performanceId).isEqualTo(performanceId)
+    }
+
+    @Test
+    fun `respondInvitation - ACCEPTED 시 MANAGER로 추가되고 상태가 전이된다`() {
+        val performance = registeredPerformance()
+        val invitationId = UUID.fromString("00000000-0000-0000-0000-0000000000c1")
+        val invitation = PerformanceInvitation.create(performance, invitedMember = invitedId, invitedBy = ownerId)
+        `when`(performanceInvitationRepository.findByIdAndStatus(invitationId, PerformanceInvitationStatus.PENDING))
+            .thenReturn(invitation)
+        `when`(performanceManagerRepository.existsByPerformanceAndMember(performance, invitedId)).thenReturn(false)
+
+        sut.respondInvitation(performanceId, invitationId, invitedId, PerformanceInvitationStatus.ACCEPTED)
+
+        assertThat(invitation.status).isEqualTo(PerformanceInvitationStatus.ACCEPTED)
+        assertThat(invitation.processedBy).isEqualTo(invitedId)
+        verify(performanceManagerRepository).save(any())
+    }
+
+    @Test
+    fun `respondInvitation - 수신자가 아니면 거부된다`() {
+        val performance = registeredPerformance()
+        val invitationId = UUID.fromString("00000000-0000-0000-0000-0000000000c2")
+        val invitation = PerformanceInvitation.create(performance, invitedMember = invitedId, invitedBy = ownerId)
+        `when`(performanceInvitationRepository.findByIdAndStatus(invitationId, PerformanceInvitationStatus.PENDING))
+            .thenReturn(invitation)
+
+        val ex =
+            assertThrows<BusinessException> {
+                sut.respondInvitation(performanceId, invitationId, 999L, PerformanceInvitationStatus.ACCEPTED)
+            }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.PERFORMANCE_INVITATION_FORBIDDEN)
+        verify(performanceManagerRepository, never()).save(any())
+    }
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #BD-78

📌 **작업 내용 및 특이사항**

공연(Performance)에 셋리스트를 연결할 때 기존에는 "공연 매니저 여부 + 셋리스트 존재 여부"만 검증하여, 매니저면 **본인과 무관한 남의 셋리스트도 공연에 추가**할 수 있는 데이터 노출 갭이 있었습니다. 이를 역할 기반 권한 + 초대 플로우로 해결합니다.

**1) 매니저 역할 분리 (OWNER / MANAGER)**
- `PerformanceManager`에 `role` 컬럼 추가, 공연 생성자는 `OWNER`로 등록
- `(performance_id, member_id)` 유니크 제약 추가(중복 매니저 방지)

**2) 초대/수락 플로우**
- `OWNER`만 특정 멤버를 초대 발송 → 멤버 본인이 수락 시 `MANAGER`로 추가
- 신규 엔드포인트
  - `POST /performances/{id}/invitations` (OWNER 발송)
  - `GET /performances/{id}/invitations` (OWNER 조회)
  - `GET /performances/invitations/me` (수신자 대기 목록)
  - `PATCH /performances/{id}/invitations/{invitationId}?status=ACCEPTED|REJECTED` (수신자 수락/거절)

**3) 셋리스트 접근 제어**
- 추가/제거 모두 **본인이 소유·참여한 셋리스트**(`isAccessibleMember`)로 제한
- 단, OWNER는 제거 시 공연 내 모든 셋리스트 제거 가능

**4) 권한 매트릭스**

| 액션 | OWNER | MANAGER |
|---|---|---|
| 공연 수정 | ✅ | ✅ |
| 공연 삭제 | ✅ | ❌ |
| 초대 발송 | ✅ | ❌ |
| 셋리스트 추가 | ✅(본인분) | ✅(본인분) |
| 셋리스트 제거 | ✅(전체) | ✅(본인분) |

**5) 기타**
- Liquibase `014` 마이그레이션: `role` 컬럼 백필(기존 매니저→OWNER), 유니크 제약, `p_performance_invitation` 테이블(PENDING 중복 방지 부분 유니크 인덱스 포함)
- `PerformanceService` 인가/초대 로직 단위 테스트 13개 추가

📚 **참고사항**
- 멤버 식별자는 코드베이스 관례대로 `Long memberId` 사용
- 범위 외(후속): 매니저 제거/OWNER 위임, 초대 발송 시 알림 이벤트 연동

🤖 Generated with [Claude Code](https://claude.com/claude-code)
