### PR TITLE
[BD-83] feat: Member/Band 프로필 이미지 삭제 API 구현

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -6011,6 +6011,39 @@
                 ]
             }
         },
+        "/api/v1/bands/{bandId}/profile-image": {
+            "delete": {
+                "description": "\ubc34\ub4dc \ud504\ub85c\ud544 \uc774\ubbf8\uc9c0\ub97c \uc81c\uac70\ud569\ub2c8\ub2e4. \ub9ac\ub354\ub9cc \uac00\ub2a5. \uc774\ubbf8\uc9c0\uac00 \uc5c6\uc5b4\ub3c4 \uc131\uacf5 \ucc98\ub9ac\ud569\ub2c8\ub2e4.",
+                "operationId": "deleteBandProfileImage",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "bandId",
+                        "required": true,
+                        "schema": {
+                            "format": "uuid",
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiResponseUnit"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    }
+                },
+                "summary": "\ubc34\ub4dc \ud504\ub85c\ud544 \uc774\ubbf8\uc9c0 \uc0ad\uc81c API",
+                "tags": [
+                    "bands"
+                ]
+            }
+        },
         "/api/v1/jams": {
             "get": {
                 "description": "\ud569\uc8fc \ubaa9\ub85d\uc744 \ucee4\uc11c \uae30\ubc18\uc73c\ub85c \uc870\ud68c\ud569\ub2c8\ub2e4. bandId \uc81c\uacf5 \uc2dc \ud574\ub2f9 \ubc34\ub4dc \uba64\ubc84\uac00 \ucc38\uc5ec \uc911\uc778 \ud569\uc8fc\ub9cc \uc870\ud68c\ud569\ub2c8\ub2e4.",
@@ -6597,6 +6630,28 @@
                     }
                 },
                 "summary": "\ud68c\uc6d0 \uba54\ud2b8\ub9ad \uc870\ud68c API",
+                "tags": [
+                    "members"
+                ]
+            }
+        },
+        "/api/v1/members/me/profile-image": {
+            "delete": {
+                "description": "\ud68c\uc6d0 \ubcf8\uc778\uc758 \ud504\ub85c\ud544 \uc774\ubbf8\uc9c0\ub97c \uc81c\uac70\ud569\ub2c8\ub2e4. \uc774\ubbf8\uc9c0\uac00 \uc5c6\uc5b4\ub3c4 \uc131\uacf5 \ucc98\ub9ac\ud569\ub2c8\ub2e4.",
+                "operationId": "deleteMemberProfileImage",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiResponseUnit"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    }
+                },
+                "summary": "\ud68c\uc6d0 \ud504\ub85c\ud544 \uc774\ubbf8\uc9c0 \uc0ad\uc81c API",
                 "tags": [
                     "members"
                 ]

--- a/src/main/kotlin/com/bandage/bandmanager/domain/band/controller/BandController.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/band/controller/BandController.kt
@@ -168,6 +168,20 @@ class BandController(
         @CurrentMemberId memberId: Long,
     ): ApiResponse<BandResponse> = ApiResponse.success(bandService.updateBand(bandId, request, memberId))
 
+    @DeleteMapping("/{bandId}/profile-image")
+    @Operation(
+        operationId = "deleteBandProfileImage",
+        summary = "밴드 프로필 이미지 삭제 API",
+        description = "밴드 프로필 이미지를 제거합니다. 리더만 가능. 이미지가 없어도 성공 처리합니다.",
+    )
+    fun deleteBandProfileImage(
+        @PathVariable bandId: UUID,
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<Unit> {
+        bandService.deleteProfileImage(bandId, memberId)
+        return ApiResponse.success()
+    }
+
     @DeleteMapping("/{bandId}")
     @Operation(operationId = "deleteBand", summary = "밴드 삭제 API", description = "밴드를 소프트 삭제합니다. 리더만 가능.")
     fun deleteBand(

--- a/src/main/kotlin/com/bandage/bandmanager/domain/band/model/Band.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/band/model/Band.kt
@@ -66,6 +66,10 @@ open class Band(
         this.profileImg = newImg
     }
 
+    fun deleteImg() {
+        this.profileImg = null
+    }
+
     fun updateName(newName: String) {
         this.name = newName
     }

--- a/src/main/kotlin/com/bandage/bandmanager/domain/band/service/BandService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/band/service/BandService.kt
@@ -252,6 +252,16 @@ class BandService(
     }
 
     @Transactional
+    fun deleteProfileImage(
+        bandId: UUID,
+        memberId: Long,
+    ) {
+        val band = getBand(bandId)
+        validateMemberIsBandLeader(band, memberId)
+        band.deleteImg()
+    }
+
+    @Transactional
     fun deleteBand(
         bandId: UUID,
         memberId: Long,

--- a/src/main/kotlin/com/bandage/bandmanager/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/member/controller/MemberController.kt
@@ -65,6 +65,19 @@ class MemberController(
         return ApiResponse.success()
     }
 
+    @DeleteMapping("/me/profile-image")
+    @Operation(
+        operationId = "deleteMemberProfileImage",
+        summary = "회원 프로필 이미지 삭제 API",
+        description = "회원 본인의 프로필 이미지를 제거합니다. 이미지가 없어도 성공 처리합니다.",
+    )
+    fun deleteMemberProfileImage(
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<Unit> {
+        memberService.deleteProfileImage(memberId)
+        return ApiResponse.success()
+    }
+
     @GetMapping("/me/metrics")
     @Operation(operationId = "getMemberStats", summary = "회원 메트릭 조회 API", description = "본인의 밴드 수, 다가오는 합주/공연 수, 합주 세션 수를 조회합니다.")
     fun getMemberStats(

--- a/src/main/kotlin/com/bandage/bandmanager/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/member/service/MemberService.kt
@@ -81,6 +81,12 @@ class MemberService(
         }
     }
 
+    @Transactional
+    fun deleteProfileImage(memberId: Long) {
+        val member = getMember(memberId)
+        member.updateProfileImg(null)
+    }
+
     fun searchMembers(
         keyword: String,
         excludeMemberId: Long?,

--- a/src/test/kotlin/com/bandage/bandmanager/domain/band/service/BandServiceProfileImageTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/band/service/BandServiceProfileImageTest.kt
@@ -1,0 +1,106 @@
+package com.bandage.bandmanager.domain.band.service
+
+import com.bandage.bandmanager.domain.band.model.Band
+import com.bandage.bandmanager.domain.band.model.enums.BandRole
+import com.bandage.bandmanager.domain.band.repository.BandApplicationRepository
+import com.bandage.bandmanager.domain.band.repository.BandMemberRepository
+import com.bandage.bandmanager.domain.band.repository.BandRepository
+import com.bandage.bandmanager.domain.member.repository.MemberRepository
+import com.bandage.bandmanager.global.error.errorcode.ErrorCode
+import com.bandage.bandmanager.global.error.exception.BusinessException
+import com.bandage.bandmanager.global.infra.s3.CloudFrontUrlResolver
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.util.Optional
+import java.util.UUID
+
+class BandServiceProfileImageTest {
+    private val bandRepository = mock(BandRepository::class.java)
+    private val applicationRepository = mock(BandApplicationRepository::class.java)
+    private val bandMemberRepository = mock(BandMemberRepository::class.java)
+    private val memberRepository = mock(MemberRepository::class.java)
+    private val cloudFrontUrlResolver = mock(CloudFrontUrlResolver::class.java)
+
+    private val sut =
+        BandService(
+            bandRepository,
+            applicationRepository,
+            bandMemberRepository,
+            memberRepository,
+            cloudFrontUrlResolver,
+        )
+
+    private val bandId: UUID = UUID.fromString("00000000-0000-0000-0000-0000000000a1")
+    private val leaderId = 1L
+    private val nonLeaderId = 2L
+
+    private fun bandWithProfile(profileImg: String?): Band {
+        val band =
+            Band.create(
+                name = "테스트밴드",
+                description = "설명",
+                profileImg = profileImg,
+            )
+        setEntityId(band, bandId)
+        `when`(bandRepository.findById(bandId)).thenReturn(Optional.of(band))
+        return band
+    }
+
+    private fun stubLeader(
+        band: Band,
+        memberId: Long,
+        isLeader: Boolean,
+    ) {
+        `when`(bandMemberRepository.existsByBandAndMemberAndRole(band, memberId, BandRole.LEADER)).thenReturn(isLeader)
+    }
+
+    private fun setEntityId(
+        target: Any,
+        id: UUID,
+    ) {
+        val field = target.javaClass.getDeclaredField("id")
+        field.isAccessible = true
+        field.set(target, id)
+    }
+
+    @Test
+    fun `deleteProfileImage - 리더가 호출하면 프로필 이미지가 null로 변경된다`() {
+        val band = bandWithProfile("profile/band/$bandId/abc.jpg")
+        stubLeader(band, leaderId, isLeader = true)
+
+        sut.deleteProfileImage(bandId, leaderId)
+
+        assertThat(band.profileImg).isNull()
+    }
+
+    @Test
+    fun `deleteProfileImage - 이미 null이어도 멱등하게 성공한다`() {
+        val band = bandWithProfile(null)
+        stubLeader(band, leaderId, isLeader = true)
+
+        sut.deleteProfileImage(bandId, leaderId)
+
+        assertThat(band.profileImg).isNull()
+    }
+
+    @Test
+    fun `deleteProfileImage - 리더가 아니면 NOT_A_LEADER`() {
+        val band = bandWithProfile("profile/band/$bandId/abc.jpg")
+        stubLeader(band, nonLeaderId, isLeader = false)
+
+        val ex = assertThrows<BusinessException> { sut.deleteProfileImage(bandId, nonLeaderId) }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.NOT_A_LEADER)
+        assertThat(band.profileImg).isEqualTo("profile/band/$bandId/abc.jpg")
+    }
+
+    @Test
+    fun `deleteProfileImage - 존재하지 않는 밴드면 BAND_NOT_FOUND`() {
+        `when`(bandRepository.findById(bandId)).thenReturn(Optional.empty())
+
+        val ex = assertThrows<BusinessException> { sut.deleteProfileImage(bandId, leaderId) }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.BAND_NOT_FOUND)
+    }
+}

--- a/src/test/kotlin/com/bandage/bandmanager/domain/member/service/MemberServiceProfileImageTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/member/service/MemberServiceProfileImageTest.kt
@@ -1,0 +1,70 @@
+package com.bandage.bandmanager.domain.member.service
+
+import com.bandage.bandmanager.domain.band.repository.BandMemberRepository
+import com.bandage.bandmanager.domain.jam.repository.JamParticipantRepository
+import com.bandage.bandmanager.domain.member.model.Member
+import com.bandage.bandmanager.domain.member.repository.MemberRepository
+import com.bandage.bandmanager.global.error.errorcode.ErrorCode
+import com.bandage.bandmanager.global.error.exception.BusinessException
+import com.bandage.bandmanager.global.infra.s3.CloudFrontUrlResolver
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.util.Optional
+
+class MemberServiceProfileImageTest {
+    private val memberRepository = mock(MemberRepository::class.java)
+    private val bandMemberRepository = mock(BandMemberRepository::class.java)
+    private val jamParticipantRepository = mock(JamParticipantRepository::class.java)
+    private val cloudFrontUrlResolver = mock(CloudFrontUrlResolver::class.java)
+
+    private val sut =
+        MemberService(
+            memberRepository,
+            bandMemberRepository,
+            jamParticipantRepository,
+            cloudFrontUrlResolver,
+        )
+
+    private val memberId = 1L
+
+    private fun memberWithProfile(profileImg: String?): Member {
+        val member =
+            Member.create(
+                email = "test@bandage.com",
+                name = "테스터",
+                contact = "010-0000-0000",
+                profileImg = profileImg,
+            )
+        `when`(memberRepository.findById(memberId)).thenReturn(Optional.of(member))
+        return member
+    }
+
+    @Test
+    fun `deleteProfileImage - 프로필 이미지가 있으면 null로 변경된다`() {
+        val member = memberWithProfile("profile/member/1/abc.jpg")
+
+        sut.deleteProfileImage(memberId)
+
+        assertThat(member.profileImg).isNull()
+    }
+
+    @Test
+    fun `deleteProfileImage - 이미 null이어도 멱등하게 성공한다`() {
+        val member = memberWithProfile(null)
+
+        sut.deleteProfileImage(memberId)
+
+        assertThat(member.profileImg).isNull()
+    }
+
+    @Test
+    fun `deleteProfileImage - 존재하지 않는 회원이면 MEMBER_NOT_FOUND`() {
+        `when`(memberRepository.findById(memberId)).thenReturn(Optional.empty())
+
+        val ex = assertThrows<BusinessException> { sut.deleteProfileImage(memberId) }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.MEMBER_NOT_FOUND)
+    }
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #

> Jira: BD-83

📌 **작업 내용 및 특이사항**

Member/Band 프로필 이미지를 삭제하는 전용 DELETE API를 추가했습니다.

| Method | Endpoint | 권한 |
|--------|----------|------|
| DELETE | `/api/v1/members/me/profile-image` | 본인 |
| DELETE | `/api/v1/bands/{bandId}/profile-image` | 리더만 |

- 기존 PATCH API는 부분 수정 방식이라 `profileImg = null`을 "변경 없음"으로 해석해 **이미지 비우기(삭제) 의도를 표현할 수 없던 문제**를 전용 엔드포인트로 해결
- `Band.deleteImg()` 추가 (Member는 기존 `updateProfileImg(null)` 재사용)
- `MemberService.deleteProfileImage`, `BandService.deleteProfileImage` 추가 — Band는 기존 리더 검증(`validateMemberIsBandLeader`) 재사용
- **이미지가 없어도 멱등 성공(200)** 처리
- Service 단위 테스트 7건 추가 (정상 삭제 / 멱등 / 권한 거부 / 미존재)
- `docs/openapi.json` 갱신 (operationId 2건 추가, **추가만 — non-breaking**)

**설계 결정**
- S3 원본 객체는 **삭제하지 않고 DB 필드만 null** 처리 (현재 S3 인프라에 DeleteObject 미구현)

📚 **참고사항**

- S3 고아 객체(미참조)는 추후 S3 라이프사이클 정책/배치로 정리 필요 (이번 범위 밖)
- 신규 경로 `/{bandId}/profile-image`는 기존 `/{bandId}`(밴드 삭제)와 세그먼트 수가 달라 라우팅 충돌 없음
- `./gradlew build` 전체 통과 (신규 7건 + OpenApiSpecGenerationTest 코드-스펙 동기화 검증 포함)

✅ **체크리스트**
- [x] API(Controller/DTO)를 변경한 경우 `docs/openapi.json`을 갱신했습니다 (코드-스펙 동일 PR 규약)

🤖 Generated with [Claude Code](https://claude.com/claude-code)