### PR TITLE
[BD-84] refactor: Member contact 필드 제거

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2762,11 +2762,6 @@
             "MemberInfoResponse": {
                 "description": "\ud68c\uc6d0 \uc815\ubcf4 \uc870\ud68c \uc751\ub2f5",
                 "properties": {
-                    "contact": {
-                        "description": "\ud68c\uc6d0 \uc5f0\ub77d\ucc98 (\uc18c\uc15c \ub85c\uadf8\uc778 \uac00\uc785 \uc2dc null)",
-                        "example": "010-7707-5859",
-                        "type": "string"
-                    },
                     "email": {
                         "description": "\ud68c\uc6d0 \uc774\uba54\uc77c",
                         "example": "member@google.com",
@@ -2805,9 +2800,6 @@
             },
             "MemberInfoUpdateRequest": {
                 "properties": {
-                    "contact": {
-                        "type": "string"
-                    },
                     "name": {
                         "type": "string"
                     },
@@ -2820,12 +2812,6 @@
             "MemberJoinRequest": {
                 "description": "\ud68c\uc6d0 \uac00\uc785 \uc694\uccad",
                 "properties": {
-                    "contact": {
-                        "description": "\ud68c\uc6d0 \uc5f0\ub77d\ucc98",
-                        "example": "010-1234-5678",
-                        "minLength": 1,
-                        "type": "string"
-                    },
                     "email": {
                         "description": "\ud68c\uc6d0 \uc774\uba54\uc77c",
                         "example": "member@google.com",
@@ -2847,7 +2833,6 @@
                     }
                 },
                 "required": [
-                    "contact",
                     "email",
                     "name",
                     "password"

--- a/src/main/kotlin/com/bandage/bandmanager/domain/member/dto/req/MemberCreateRequest.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/member/dto/req/MemberCreateRequest.kt
@@ -3,5 +3,4 @@ package com.bandage.bandmanager.domain.member.dto.req
 data class MemberCreateRequest(
     val email: String,
     val name: String,
-    val contact: String,
 )

--- a/src/main/kotlin/com/bandage/bandmanager/domain/member/dto/req/MemberInfoUpdateRequest.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/member/dto/req/MemberInfoUpdateRequest.kt
@@ -4,6 +4,5 @@ import jakarta.annotation.Nullable
 
 data class MemberInfoUpdateRequest(
     @Nullable val name: String?,
-    @Nullable val contact: String?,
     @Nullable val profileImg: String?,
 )

--- a/src/main/kotlin/com/bandage/bandmanager/domain/member/dto/res/MemberInfoResponse.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/member/dto/res/MemberInfoResponse.kt
@@ -13,8 +13,6 @@ data class MemberInfoResponse(
     val email: String,
     @Schema(description = "회원 이름", example = "홍길동")
     val name: String,
-    @Schema(description = "회원 연락처 (소셜 로그인 가입 시 null)", example = "010-7707-5859")
-    val contact: String?,
     @Schema(description = "프로필 이미지 URL (CloudFront, 없으면 null)", example = "https://cdn.example.com/profile/member/1/uuid.jpg")
     val profileImg: String? = null,
 ) {
@@ -28,7 +26,6 @@ data class MemberInfoResponse(
                 memberId = member.id,
                 email = member.email,
                 name = member.name,
-                contact = member.contact,
                 profileImg = profileImgUrl,
             )
     }

--- a/src/main/kotlin/com/bandage/bandmanager/domain/member/model/Member.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/member/model/Member.kt
@@ -15,7 +15,6 @@ import org.hibernate.annotations.SQLRestriction
 open class Member(
     email: String,
     name: String,
-    contact: String?,
     profileImg: String? = null,
 ) : BaseTimeEntity() {
     @Id
@@ -31,10 +30,6 @@ open class Member(
     var name: String = name
         protected set
 
-    @Column(name = "contact", nullable = true)
-    var contact: String? = contact
-        protected set
-
     @Column(name = "profile_img")
     var profileImg: String? = profileImg
         protected set
@@ -43,13 +38,11 @@ open class Member(
         fun create(
             email: String,
             name: String,
-            contact: String,
             profileImg: String? = null,
         ): Member =
             Member(
                 email = email,
                 name = name,
-                contact = contact,
                 profileImg = profileImg,
             )
 
@@ -61,17 +54,12 @@ open class Member(
             Member(
                 email = email,
                 name = name,
-                contact = null,
                 profileImg = profileImg,
             )
     }
 
     fun updateName(newName: String) {
         this.name = newName
-    }
-
-    fun updateContact(newContact: String?) {
-        this.contact = newContact
     }
 
     fun updateProfileImg(newProfileImg: String?) {

--- a/src/main/kotlin/com/bandage/bandmanager/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/member/service/MemberService.kt
@@ -30,7 +30,6 @@ class MemberService(
             Member.create(
                 email = request.email,
                 name = request.name,
-                contact = request.contact,
             ),
         )
     }
@@ -52,7 +51,7 @@ class MemberService(
         request: MemberInfoUpdateRequest,
         memberId: Long,
     ) {
-        if (request.name == null && request.contact == null && request.profileImg == null) {
+        if (request.name == null && request.profileImg == null) {
             throw BusinessException(ErrorCode.NO_CHANGE)
         }
         val member = getMember(memberId)
@@ -62,12 +61,6 @@ class MemberService(
             ?.takeIf { it != member.name }
             ?.let {
                 member.updateName(it)
-                isChanged = true
-            }
-        request.contact
-            ?.takeIf { it != member.contact }
-            ?.let {
-                member.updateContact(it)
                 isChanged = true
             }
         request.profileImg

--- a/src/main/kotlin/com/bandage/bandmanager/facade/dto/MemberJoinRequest.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/facade/dto/MemberJoinRequest.kt
@@ -16,14 +16,11 @@ data class MemberJoinRequest(
     val password: String,
     @NotBlank @Schema(description = "회원 이름", example = "홍길동")
     val name: String,
-    @NotBlank @Schema(description = "회원 연락처", example = "010-1234-5678")
-    val contact: String,
 ) {
     fun toMemberCreateRequest(): MemberCreateRequest =
         MemberCreateRequest(
             email = this.email,
             name = this.name,
-            contact = this.contact,
         )
 
     fun toMemberAuthCreateRequest(memberId: Long): MemberAuthCreateRequest =

--- a/src/main/resources/db/changelog/changes/015-drop-member-contact.sql
+++ b/src/main/resources/db/changelog/changes/015-drop-member-contact.sql
@@ -1,0 +1,4 @@
+-- BD-84: Member contact 컬럼 제거 (개인정보 노출 포인트 제거, 미사용 필드)
+
+ALTER TABLE public.p_member
+    DROP COLUMN contact;

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -173,3 +173,16 @@ databaseChangeLog:
             splitStatements: true
             stripComments: true
             endDelimiter: ";"
+  - changeSet:
+      id: 015-drop-member-contact
+      author: bandage
+      comment: |
+        BD-84: Member contact 컬럼 제거
+        - p_member.contact 컬럼 DROP (개인정보 노출 포인트 제거, 미사용 필드)
+      changes:
+        - sqlFile:
+            path: changes/015-drop-member-contact.sql
+            relativeToChangelogFile: true
+            splitStatements: true
+            stripComments: true
+            endDelimiter: ";"

--- a/src/test/kotlin/com/bandage/bandmanager/domain/member/service/MemberServiceProfileImageTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/member/service/MemberServiceProfileImageTest.kt
@@ -35,7 +35,6 @@ class MemberServiceProfileImageTest {
             Member.create(
                 email = "test@bandage.com",
                 name = "테스터",
-                contact = "010-0000-0000",
                 profileImg = profileImg,
             )
         `when`(memberRepository.findById(memberId)).thenReturn(Optional.of(member))


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #BD-84

📌 **작업 내용 및 특이사항**

Member 도메인의 `contact` 필드를 전 레이어에서 제거합니다. 시스템에서 실제로 활용되는 곳이 없는데도 회원 연락처(전화번호)가 응답/저장에 노출되어 개인정보 유출 포인트가 되고 있어 제거합니다.

**코드 레이어**
- `Member` 엔티티: `contact` 프로퍼티 / 생성자 파라미터 / `updateContact()` 제거
- `MemberCreateRequest`, `MemberInfoUpdateRequest`: `contact` 입력 필드 제거
- `MemberInfoResponse`: `contact` 응답 필드 제거 (연락처 미노출)
- `MemberJoinRequest`(facade): `contact` 입력 필드 및 매핑 제거
- `MemberService`: `createMember` / `updateMemberInfo`의 `contact` 처리 제거

**DB (Liquibase)**
- `015-drop-member-contact.sql`: `ALTER TABLE p_member DROP COLUMN contact`
- `db.changelog-master.yaml`에 `015` changeset 등록
- 적용 순서상 `003` 시드 changeset 실행 시점에는 컬럼이 존재하므로 `003`은 수정하지 않음 (적용된 changeset 불변 유지)

**스펙**
- `docs/openapi.json` 갱신: `MemberInfoResponse` / `MemberInfoUpdateRequest` / `MemberJoinRequest` 스키마에서 `contact` 제거, `MemberJoinRequest.required`에서 `contact` 제거

📚 **참고사항**

- ⚠️ **Breaking Change**: 회원 가입(`POST /members/join`) 요청에서 `contact`가 더 이상 허용/요구되지 않으며, 회원 정보 조회(`GET /members/me`) 응답에서 `contact`가 사라집니다. FE 영향평가 필요.
- `./gradlew build` 전체 통과 (43 tests). `OpenApiSpecGenerationTest`로 코드-스펙 동기화 검증됨.

✅ **체크리스트**
- [x] API(Controller/DTO)를 변경한 경우 `docs/openapi.json`을 갱신했습니다 (코드-스펙 동일 PR 규약)
