### PR TITLE
[BD-78] feat: 권한자 탈퇴 시 권한 자동 양도 체계 구현

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3522,6 +3522,21 @@
                 ],
                 "type": "object"
             },
+            "PerformanceOwnerDelegateRequest": {
+                "description": "\uacf5\uc5f0 \uc18c\uc720\uad8c(OWNER) \uc591\ub3c4 \uc694\uccad",
+                "properties": {
+                    "targetMemberId": {
+                        "description": "\uc18c\uc720\uad8c\uc744 \ub118\uaca8\ubc1b\uc744 \ub300\uc0c1 \uba64\ubc84 ID (\ud574\ub2f9 \uacf5\uc5f0\uc758 MANAGER \uc5ec\uc57c \ud568)",
+                        "example": 42,
+                        "format": "int64",
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "targetMemberId"
+                ],
+                "type": "object"
+            },
             "PerformancePagingQuery": {
                 "description": "\uacf5\uc5f0 \ubaa9\ub85d \uc870\ud68c \ucffc\ub9ac",
                 "properties": {
@@ -7062,6 +7077,49 @@
                     }
                 },
                 "summary": "\uacf5\uc5f0 \ucd08\ub300 \uc218\ub77d/\uac70\uc808 API",
+                "tags": [
+                    "performances"
+                ]
+            }
+        },
+        "/api/v1/performances/{performanceId}/owner": {
+            "patch": {
+                "description": "\ud604\uc7ac OWNER\uac00 \uac19\uc740 \uacf5\uc5f0\uc758 MANAGER\uc5d0\uac8c \uc18c\uc720\uad8c(OWNER)\uc744 \uc591\ub3c4\ud569\ub2c8\ub2e4. \uae30\uc874 OWNER\ub294 MANAGER\ub85c \uac15\ub4f1\ub429\ub2c8\ub2e4. OWNER\ub9cc \uc218\ud589\ud560 \uc218 \uc788\uc2b5\ub2c8\ub2e4.",
+                "operationId": "delegateOwnership",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "performanceId",
+                        "required": true,
+                        "schema": {
+                            "format": "uuid",
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PerformanceOwnerDelegateRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiResponseUnit"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    }
+                },
+                "summary": "\uacf5\uc5f0 \uc18c\uc720\uad8c \uc591\ub3c4 API",
                 "tags": [
                     "performances"
                 ]

--- a/src/main/kotlin/com/bandage/bandmanager/domain/band/repository/BandApplicationRepository.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/band/repository/BandApplicationRepository.kt
@@ -4,6 +4,8 @@ import com.bandage.bandmanager.domain.band.model.Band
 import com.bandage.bandmanager.domain.band.model.BandApplication
 import com.bandage.bandmanager.domain.band.model.enums.ApplicationStatus
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import java.util.UUID
 
@@ -27,4 +29,11 @@ interface BandApplicationRepository :
         id: UUID,
         status: ApplicationStatus,
     ): BandApplication?
+
+    /** 회원의 특정 상태 가입 신청을 밴드와 함께 일괄 조회(탈퇴 시 LEAVED 처리 배치용). */
+    @Query("SELECT a FROM BandApplication a JOIN FETCH a.band WHERE a.member = :memberId AND a.status = :status")
+    fun findAllByMemberAndStatusFetchBand(
+        @Param("memberId") memberId: Long,
+        @Param("status") status: ApplicationStatus,
+    ): List<BandApplication>
 }

--- a/src/main/kotlin/com/bandage/bandmanager/domain/band/service/BandService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/band/service/BandService.kt
@@ -20,6 +20,9 @@ import com.bandage.bandmanager.domain.band.repository.BandApplicationRepository
 import com.bandage.bandmanager.domain.band.repository.BandMemberRepository
 import com.bandage.bandmanager.domain.band.repository.BandRepository
 import com.bandage.bandmanager.domain.member.repository.MemberRepository
+import com.bandage.bandmanager.global.authority.MemberAuthorityCleanupHandler
+import com.bandage.bandmanager.global.authority.ResourceAuthorityType
+import com.bandage.bandmanager.global.authority.SuccessorSelector
 import com.bandage.bandmanager.global.common.response.CursorResponse
 import com.bandage.bandmanager.global.error.errorcode.ErrorCode
 import com.bandage.bandmanager.global.error.exception.BusinessException
@@ -37,7 +40,9 @@ class BandService(
     private val bandMemberRepository: BandMemberRepository,
     private val memberRepository: MemberRepository,
     private val cloudFrontUrlResolver: CloudFrontUrlResolver,
-) {
+) : MemberAuthorityCleanupHandler {
+    override val authorityType: ResourceAuthorityType = ResourceAuthorityType.BAND_LEADERSHIP
+
     // TODO: profileImg multi-part 처리 구현
     @Transactional
     fun createBand(
@@ -324,6 +329,49 @@ class BandService(
         processBandMemberStatusAsLeaved(bandMember, band, memberId)
         validateOnlyOneLeader(band)
     }
+
+    /**
+     * 회원 탈퇴 시 호출. 회원이 속한 모든 밴드를 정리한다(leaveBand 와 동일 정책).
+     * - 마지막 멤버였던 밴드: 밴드 소프트 삭제
+     * - 리더였던 밴드: ADMIN > MEMBER 순 최고참에게 리더 자동 양도 후 탈퇴 처리
+     * - 그 외 밴드: 탈퇴 처리
+     * 모든 밴드/멤버를 fetch join 으로 일괄 조회해 밴드별 추가 쿼리를 피한다.
+     */
+    @Transactional
+    override fun cleanupOnWithdrawal(memberId: Long) {
+        val bandIds = bandMemberRepository.findAllBandIdsByMember(memberId)
+        if (bandIds.isEmpty()) return
+
+        val membersByBand = bandMemberRepository.findAllByBandIdIn(bandIds).groupBy { it.band.id }
+
+        bandIds.forEach { bandId ->
+            val members = membersByBand[bandId] ?: return@forEach
+            val leaving = members.firstOrNull { it.member == memberId } ?: return@forEach
+            val band = leaving.band
+            val remaining = members.filter { it.member != memberId }
+
+            if (remaining.isEmpty()) {
+                processBandMemberStatusAsLeaved(leaving, band, memberId)
+                band.markAsDeleted(memberId)
+                return@forEach
+            }
+
+            if (leaving.role == BandRole.LEADER) {
+                switchLeader(from = leaving, to = selectBandSuccessor(remaining))
+            }
+            processBandMemberStatusAsLeaved(leaving, band, memberId)
+        }
+    }
+
+    private fun selectBandSuccessor(candidates: List<BandMember>): BandMember =
+        SuccessorSelector.oldestFromHighestTier(
+            tiers =
+                listOf(
+                    candidates.filter { it.role == BandRole.ADMIN },
+                    candidates.filter { it.role == BandRole.MEMBER },
+                ),
+            createdAt = { it.createdAt },
+        ) ?: candidates.minByOrNull { it.createdAt }!!
 
     // --- 내부 유틸리티 메서드 ---
     private fun createBandMember(

--- a/src/main/kotlin/com/bandage/bandmanager/domain/band/service/BandService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/band/service/BandService.kt
@@ -343,6 +343,10 @@ class BandService(
         if (bandIds.isEmpty()) return
 
         val membersByBand = bandMemberRepository.findAllByBandIdIn(bandIds).groupBy { it.band.id }
+        val approvedApplicationByBand =
+            applicationRepository
+                .findAllByMemberAndStatusFetchBand(memberId, ApplicationStatus.APPROVED)
+                .associateBy { it.band.id }
 
         bandIds.forEach { bandId ->
             val members = membersByBand[bandId] ?: return@forEach
@@ -351,7 +355,7 @@ class BandService(
             val remaining = members.filter { it.member != memberId }
 
             if (remaining.isEmpty()) {
-                processBandMemberStatusAsLeaved(leaving, band, memberId)
+                markBandMemberLeaved(leaving, approvedApplicationByBand[bandId], memberId)
                 band.markAsDeleted(memberId)
                 return@forEach
             }
@@ -359,8 +363,18 @@ class BandService(
             if (leaving.role == BandRole.LEADER) {
                 switchLeader(from = leaving, to = selectBandSuccessor(remaining))
             }
-            processBandMemberStatusAsLeaved(leaving, band, memberId)
+            markBandMemberLeaved(leaving, approvedApplicationByBand[bandId], memberId)
         }
+    }
+
+    /** 사전 조회한 APPROVED 신청을 LEAVED 로 전환하고 소속을 소프트 삭제(밴드별 추가 쿼리 없음). */
+    private fun markBandMemberLeaved(
+        bandMember: BandMember,
+        approvedApplication: BandApplication?,
+        deleterId: Long,
+    ) {
+        approvedApplication?.updateStatus(ApplicationStatus.LEAVED)
+        bandMember.markAsDeleted(deleterId)
     }
 
     private fun selectBandSuccessor(candidates: List<BandMember>): BandMember =

--- a/src/main/kotlin/com/bandage/bandmanager/domain/performance/controller/PerformanceController.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/performance/controller/PerformanceController.kt
@@ -2,6 +2,7 @@ package com.bandage.bandmanager.domain.performance.controller
 
 import com.bandage.bandmanager.domain.performance.dto.req.PerformanceCreateRequest
 import com.bandage.bandmanager.domain.performance.dto.req.PerformanceInvitationCreateRequest
+import com.bandage.bandmanager.domain.performance.dto.req.PerformanceOwnerDelegateRequest
 import com.bandage.bandmanager.domain.performance.dto.req.PerformancePagingQuery
 import com.bandage.bandmanager.domain.performance.dto.req.PerformanceSearchQuery
 import com.bandage.bandmanager.domain.performance.dto.req.PerformanceSetlistAddRequest
@@ -171,6 +172,21 @@ class PerformanceController(
         @CurrentMemberId memberId: Long,
     ): ApiResponse<Unit> {
         performanceService.deletePerformance(performanceId, memberId)
+        return ApiResponse.success()
+    }
+
+    @PatchMapping("/{performanceId}/owner")
+    @Operation(
+        operationId = "delegateOwnership",
+        summary = "공연 소유권 양도 API",
+        description = "현재 OWNER가 같은 공연의 MANAGER에게 소유권(OWNER)을 양도합니다. 기존 OWNER는 MANAGER로 강등됩니다. OWNER만 수행할 수 있습니다.",
+    )
+    fun delegateOwnership(
+        @PathVariable performanceId: UUID,
+        @Valid @RequestBody request: PerformanceOwnerDelegateRequest,
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<Unit> {
+        performanceService.delegateOwnership(performanceId, request.targetMemberId, memberId)
         return ApiResponse.success()
     }
 }

--- a/src/main/kotlin/com/bandage/bandmanager/domain/performance/dto/req/PerformanceOwnerDelegateRequest.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/performance/dto/req/PerformanceOwnerDelegateRequest.kt
@@ -1,0 +1,11 @@
+package com.bandage.bandmanager.domain.performance.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
+
+@Schema(description = "공연 소유권(OWNER) 양도 요청")
+data class PerformanceOwnerDelegateRequest(
+    @field:NotNull
+    @Schema(description = "소유권을 넘겨받을 대상 멤버 ID (해당 공연의 MANAGER 여야 함)", example = "42")
+    val targetMemberId: Long,
+)

--- a/src/main/kotlin/com/bandage/bandmanager/domain/performance/model/PerformanceManager.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/performance/model/PerformanceManager.kt
@@ -42,9 +42,20 @@ open class PerformanceManager(
     val member: Long = member
 
     @Column(name = "role", nullable = false)
-    val role: PerformanceRole = role
+    var role: PerformanceRole = role
+        protected set
 
     fun isOwner(): Boolean = role == PerformanceRole.OWNER
+
+    fun promoteToOwner() {
+        require(this.role != PerformanceRole.OWNER) { "이미 OWNER 입니다." }
+        this.role = PerformanceRole.OWNER
+    }
+
+    fun demoteToManager() {
+        require(this.role == PerformanceRole.OWNER) { "OWNER 만 MANAGER 로 강등할 수 있습니다." }
+        this.role = PerformanceRole.MANAGER
+    }
 
     companion object {
         fun createOwner(

--- a/src/main/kotlin/com/bandage/bandmanager/domain/performance/repository/PerformanceManagerRepository.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/performance/repository/PerformanceManagerRepository.kt
@@ -3,6 +3,8 @@ package com.bandage.bandmanager.domain.performance.repository
 import com.bandage.bandmanager.domain.performance.model.Performance
 import com.bandage.bandmanager.domain.performance.model.PerformanceManager
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import java.util.UUID
 
@@ -17,4 +19,13 @@ interface PerformanceManagerRepository : JpaRepository<PerformanceManager, UUID>
         performance: Performance,
         member: Long,
     ): PerformanceManager?
+
+    /** 회원이 보유한 모든 공연 권한 레코드를 공연과 함께 일괄 조회(소프트삭제되지 않은 공연만). */
+    @Query("SELECT pm FROM PerformanceManager pm JOIN FETCH pm.performance WHERE pm.member = :memberId")
+    fun findAllByMemberFetchPerformance(
+        @Param("memberId") memberId: Long,
+    ): List<PerformanceManager>
+
+    /** 여러 공연의 모든 권한 레코드를 일괄 조회(후임 후보 산정용). */
+    fun findAllByPerformanceIn(performances: Collection<Performance>): List<PerformanceManager>
 }

--- a/src/main/kotlin/com/bandage/bandmanager/domain/performance/repository/PerformanceSetlistRepository.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/performance/repository/PerformanceSetlistRepository.kt
@@ -19,4 +19,7 @@ interface PerformanceSetlistRepository : JpaRepository<PerformanceSetlist, UUID>
     ): PerformanceSetlist?
 
     fun findAllBySetlistIdIn(setlistIds: Collection<UUID>): List<PerformanceSetlist>
+
+    /** 여러 공연의 참여 셋리스트를 일괄 조회(후임 후보를 위한 밴드 탐색용). */
+    fun findAllByPerformanceIn(performances: Collection<Performance>): List<PerformanceSetlist>
 }

--- a/src/main/kotlin/com/bandage/bandmanager/domain/performance/service/PerformanceService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/performance/service/PerformanceService.kt
@@ -1,5 +1,6 @@
 package com.bandage.bandmanager.domain.performance.service
 
+import com.bandage.bandmanager.domain.band.model.BandMember
 import com.bandage.bandmanager.domain.band.repository.BandMemberRepository
 import com.bandage.bandmanager.domain.band.repository.BandRepository
 import com.bandage.bandmanager.domain.member.repository.MemberRepository
@@ -22,6 +23,7 @@ import com.bandage.bandmanager.domain.performance.model.PerformanceInvitation
 import com.bandage.bandmanager.domain.performance.model.PerformanceManager
 import com.bandage.bandmanager.domain.performance.model.PerformanceSetlist
 import com.bandage.bandmanager.domain.performance.model.enums.PerformanceInvitationStatus
+import com.bandage.bandmanager.domain.performance.model.enums.PerformanceRole
 import com.bandage.bandmanager.domain.performance.repository.PerformanceInvitationRepository
 import com.bandage.bandmanager.domain.performance.repository.PerformanceManagerRepository
 import com.bandage.bandmanager.domain.performance.repository.PerformanceRepository
@@ -29,6 +31,9 @@ import com.bandage.bandmanager.domain.performance.repository.PerformanceSetlistR
 import com.bandage.bandmanager.domain.setlist.model.Setlist
 import com.bandage.bandmanager.domain.setlist.repository.SetlistBandRepository
 import com.bandage.bandmanager.domain.setlist.repository.SetlistRepository
+import com.bandage.bandmanager.global.authority.MemberAuthorityCleanupHandler
+import com.bandage.bandmanager.global.authority.ResourceAuthorityType
+import com.bandage.bandmanager.global.authority.SuccessorSelector
 import com.bandage.bandmanager.global.common.response.CursorResponse
 import com.bandage.bandmanager.global.error.errorcode.ErrorCode
 import com.bandage.bandmanager.global.error.exception.BusinessException
@@ -51,7 +56,9 @@ class PerformanceService(
     private val bandMemberRepository: BandMemberRepository,
     private val memberRepository: MemberRepository,
     private val cloudFrontUrlResolver: CloudFrontUrlResolver,
-) {
+) : MemberAuthorityCleanupHandler {
+    override val authorityType: ResourceAuthorityType = ResourceAuthorityType.PERFORMANCE_OWNERSHIP
+
     @Transactional
     fun createPerformance(
         request: PerformanceCreateRequest,
@@ -400,6 +407,115 @@ class PerformanceService(
     ) {
         if (!requireParticipant(performance, memberId).isOwner()) {
             throw BusinessException(ErrorCode.NOT_A_PERFORMANCE_OWNER)
+        }
+    }
+
+    /**
+     * 회원 탈퇴 시 호출. OWNER 인 모든 공연의 소유권을 자동 양도한다.
+     * - 티어1: 같은 공연의 MANAGER 중 최고참 승격
+     * - 티어2: 셋리스트가 속한 밴드의 일반 멤버 최고참에게 OWNER 신규 부여(가장 먼저 등록된 셋리스트의 밴드 우선)
+     * - 후보 전무: 공연 소프트 삭제
+     * 마지막으로 탈퇴 회원의 모든 공연 권한 레코드를 제거한다.
+     * 후임 산정에 필요한 매니저/셋리스트/밴드멤버를 모두 일괄 조회해 공연/밴드별 추가 쿼리를 피한다.
+     */
+    @Transactional
+    override fun cleanupOnWithdrawal(memberId: Long) {
+        val memberRows = performanceManagerRepository.findAllByMemberFetchPerformance(memberId)
+        if (memberRows.isEmpty()) return
+
+        val ownedPerformances = memberRows.filter { it.isOwner() }.map { it.performance }
+        if (ownedPerformances.isNotEmpty()) {
+            val managersByPerformance =
+                performanceManagerRepository
+                    .findAllByPerformanceIn(ownedPerformances)
+                    .groupBy { it.performance.id }
+            val fallbackContext = buildOwnerFallbackContext(ownedPerformances)
+            ownedPerformances.forEach { performance ->
+                handoverOwnership(
+                    performance = performance,
+                    leavingMemberId = memberId,
+                    managers = managersByPerformance[performance.id].orEmpty(),
+                    fallbackContext = fallbackContext,
+                )
+            }
+        }
+
+        performanceManagerRepository.deleteAll(memberRows)
+    }
+
+    private fun handoverOwnership(
+        performance: Performance,
+        leavingMemberId: Long,
+        managers: List<PerformanceManager>,
+        fallbackContext: OwnerFallbackContext,
+    ) {
+        // 티어1: 같은 공연의 MANAGER 중 최고참
+        val managerCandidates = managers.filter { it.member != leavingMemberId && it.role == PerformanceRole.MANAGER }
+        val successor = SuccessorSelector.oldestFromHighestTier(listOf(managerCandidates)) { it.createdAt }
+        if (successor != null) {
+            successor.promoteToOwner()
+            return
+        }
+        // 티어2: 셋리스트 밴드의 일반 멤버 최고참
+        val excludedMemberIds = managers.mapTo(mutableSetOf()) { it.member }.apply { add(leavingMemberId) }
+        val fallbackMemberId = fallbackContext.selectFallbackOwner(performance.id, excludedMemberIds)
+        if (fallbackMemberId != null) {
+            performanceManagerRepository.save(PerformanceManager.createOwner(performance, fallbackMemberId))
+            return
+        }
+        // 후보 전무 → 공연 소프트 삭제
+        performance.markAsDeleted(leavingMemberId)
+    }
+
+    private fun buildOwnerFallbackContext(performances: List<Performance>): OwnerFallbackContext {
+        val setlistsByPerformance =
+            performanceSetlistRepository.findAllByPerformanceIn(performances).groupBy { it.performance.id }
+        val allSetlistIds =
+            setlistsByPerformance.values
+                .flatten()
+                .map { it.setlistId }
+                .distinct()
+        val bandsBySetlist =
+            if (allSetlistIds.isEmpty()) {
+                emptyMap()
+            } else {
+                setlistBandRepository.findAllBySetlistIdIn(allSetlistIds).groupBy { it.setlistId }
+            }
+        val bandIdsByPerformance =
+            performances.associate { performance ->
+                val orderedBandIds =
+                    setlistsByPerformance[performance.id]
+                        .orEmpty()
+                        .sortedBy { it.createdAt }
+                        .flatMap { setlist ->
+                            bandsBySetlist[setlist.setlistId].orEmpty().sortedBy { it.createdAt }.map { it.bandId }
+                        }.distinct()
+                performance.id to orderedBandIds
+            }
+        val allBandIds = bandIdsByPerformance.values.flatten().distinct()
+        val membersByBand =
+            if (allBandIds.isEmpty()) {
+                emptyMap()
+            } else {
+                bandMemberRepository.findAllByBandIdIn(allBandIds).groupBy { it.band.id }
+            }
+        return OwnerFallbackContext(bandIdsByPerformance, membersByBand)
+    }
+
+    private class OwnerFallbackContext(
+        private val bandIdsByPerformance: Map<UUID, List<UUID>>,
+        private val membersByBand: Map<UUID, List<BandMember>>,
+    ) {
+        /** 우선순위 밴드 순으로 후보 그룹을 만들어, 첫 유효 밴드의 최고참 memberId 를 반환. */
+        fun selectFallbackOwner(
+            performanceId: UUID,
+            excludedMemberIds: Set<Long>,
+        ): Long? {
+            val tiers =
+                bandIdsByPerformance[performanceId].orEmpty().map { bandId ->
+                    membersByBand[bandId].orEmpty().filter { it.member !in excludedMemberIds }
+                }
+            return SuccessorSelector.oldestFromHighestTier(tiers) { it.createdAt }?.member
         }
     }
 }

--- a/src/main/kotlin/com/bandage/bandmanager/domain/performance/service/PerformanceService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/performance/service/PerformanceService.kt
@@ -194,6 +194,31 @@ class PerformanceService(
         performance.markAsDeleted(memberId)
     }
 
+    /**
+     * 공연 소유권(OWNER) 수동 양도. 현재 OWNER 가 같은 공연의 MANAGER 에게 권한을 넘긴다.
+     * 기존 OWNER 는 MANAGER 로 강등된다.
+     */
+    @Transactional
+    fun delegateOwnership(
+        performanceId: UUID,
+        targetMemberId: Long,
+        ownerId: Long,
+    ) {
+        val performance = getPerformance(performanceId)
+        val currentOwner = requireParticipant(performance, ownerId)
+        if (!currentOwner.isOwner()) {
+            throw BusinessException(ErrorCode.NOT_A_PERFORMANCE_OWNER)
+        }
+        if (targetMemberId == ownerId) {
+            throw BusinessException(ErrorCode.NO_CHANGE)
+        }
+        val target =
+            performanceManagerRepository.findByPerformanceAndMember(performance, targetMemberId)
+                ?: throw BusinessException(ErrorCode.NOT_A_PERFORMANCE_MANAGER)
+        currentOwner.demoteToManager()
+        target.promoteToOwner()
+    }
+
     @Transactional
     fun sendInvitation(
         performanceId: UUID,

--- a/src/main/kotlin/com/bandage/bandmanager/domain/selection/repository/TrackSelectionBandRepository.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/selection/repository/TrackSelectionBandRepository.kt
@@ -10,6 +10,8 @@ import java.util.UUID
 interface TrackSelectionBandRepository : JpaRepository<TrackSelectionBand, UUID> {
     fun findAllBySelection(selection: TrackSelection): List<TrackSelectionBand>
 
+    fun findAllBySelectionIn(selections: Collection<TrackSelection>): List<TrackSelectionBand>
+
     fun findAllBySelectionId(selectionId: UUID): List<TrackSelectionBand>
 
     fun existsBySelectionAndBandId(

--- a/src/main/kotlin/com/bandage/bandmanager/domain/selection/repository/TrackSelectionMemberRepository.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/selection/repository/TrackSelectionMemberRepository.kt
@@ -10,6 +10,8 @@ import java.util.UUID
 interface TrackSelectionMemberRepository : JpaRepository<TrackSelectionMember, UUID> {
     fun findAllBySelection(selection: TrackSelection): List<TrackSelectionMember>
 
+    fun findAllBySelectionIn(selections: Collection<TrackSelection>): List<TrackSelectionMember>
+
     fun findAllBySelectionId(selectionId: UUID): List<TrackSelectionMember>
 
     fun existsBySelectionAndMemberId(

--- a/src/main/kotlin/com/bandage/bandmanager/domain/selection/repository/TrackSelectionRepository.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/selection/repository/TrackSelectionRepository.kt
@@ -8,4 +8,7 @@ import java.util.UUID
 @Repository
 interface TrackSelectionRepository :
     JpaRepository<TrackSelection, UUID>,
-    TrackSelectionRepositoryCustom
+    TrackSelectionRepositoryCustom {
+    /** 회원이 매니저인 (삭제되지 않은) 선곡 회의를 일괄 조회(탈퇴 시 권한 양도용). */
+    fun findAllByManagerId(managerId: Long): List<TrackSelection>
+}

--- a/src/main/kotlin/com/bandage/bandmanager/domain/selection/service/TrackSelectionService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/selection/service/TrackSelectionService.kt
@@ -1,5 +1,6 @@
 package com.bandage.bandmanager.domain.selection.service
 
+import com.bandage.bandmanager.domain.band.repository.BandMemberRepository
 import com.bandage.bandmanager.domain.selection.dto.req.SetlistChatMessageCreateRequest
 import com.bandage.bandmanager.domain.selection.dto.req.SetlistConfirmationUpdateRequest
 import com.bandage.bandmanager.domain.selection.dto.req.SetlistParticipantsUpdateRequest
@@ -29,6 +30,9 @@ import com.bandage.bandmanager.domain.selection.repository.TrackSelectionItemCon
 import com.bandage.bandmanager.domain.selection.repository.TrackSelectionItemRepository
 import com.bandage.bandmanager.domain.selection.repository.TrackSelectionMemberRepository
 import com.bandage.bandmanager.domain.selection.repository.TrackSelectionRepository
+import com.bandage.bandmanager.global.authority.MemberAuthorityCleanupHandler
+import com.bandage.bandmanager.global.authority.ResourceAuthorityType
+import com.bandage.bandmanager.global.authority.SuccessorSelector
 import com.bandage.bandmanager.global.common.domain.TrackInfo
 import com.bandage.bandmanager.global.common.response.CursorResponse
 import com.bandage.bandmanager.global.error.errorcode.ErrorCode
@@ -48,7 +52,10 @@ class TrackSelectionService(
     private val applicantRepository: TrackSelectionItemApplicantRepository,
     private val confirmationRepository: TrackSelectionItemConfirmationRepository,
     private val chatMessageRepository: TrackSelectionItemChatMessageRepository,
-) {
+    private val bandMemberRepository: BandMemberRepository,
+) : MemberAuthorityCleanupHandler {
+    override val authorityType: ResourceAuthorityType = ResourceAuthorityType.TRACK_SELECTION_MANAGEMENT
+
     @Transactional
     fun createSelection(
         memberId: Long,
@@ -541,5 +548,61 @@ class TrackSelectionService(
             throw BusinessException(ErrorCode.SETLIST_PRACTICE_WINDOW_INVALID)
         }
         return window.toEntity()
+    }
+
+    /**
+     * 회원 탈퇴 시 호출. 회원이 매니저인 모든 선곡 회의의 매니저 권한을 자동 양도한다.
+     * - 티어1: 회의 참여자(TrackSelectionMember) 중 최고참 (이미 참여자이므로 changeManager 만으로 충분)
+     * - 티어2: 연결된 밴드(TrackSelectionBand)의 일반 멤버 중 최고참 → 신규 매니저를 참여자로도 등록
+     *          (매니저는 참여자에 포함되어야 한다는 불변식 유지)
+     * - 후보 전무: 선곡 회의 소프트 삭제 (잠긴 회의도 매니저가 사라지면 해소 불가하므로)
+     * 후임 산정에 필요한 참여자/밴드/밴드멤버를 모두 일괄 조회해 추가 쿼리를 피한다.
+     */
+    @Transactional
+    override fun cleanupOnWithdrawal(memberId: Long) {
+        val managed = selectionRepository.findAllByManagerId(memberId)
+        if (managed.isEmpty()) return
+
+        val membersBySelection = selectionMemberRepository.findAllBySelectionIn(managed).groupBy { it.selection.id }
+        val bandsBySelection = selectionBandRepository.findAllBySelectionIn(managed).groupBy { it.selection.id }
+        val allBandIds =
+            bandsBySelection.values
+                .flatten()
+                .map { it.bandId }
+                .distinct()
+        val membersByBand =
+            if (allBandIds.isEmpty()) {
+                emptyMap()
+            } else {
+                bandMemberRepository.findAllByBandIdIn(allBandIds).groupBy { it.band.id }
+            }
+
+        managed.forEach { selection ->
+            val members = membersBySelection[selection.id].orEmpty()
+
+            // 티어1: 회의 참여자 중 최고참
+            SuccessorSelector
+                .oldestFromHighestTier(listOf(members.filter { it.memberId != memberId })) { it.createdAt }
+                ?.let {
+                    selection.changeManager(it.memberId)
+                    return@forEach
+                }
+
+            // 티어2: 연결된 밴드의 일반 멤버 중 최고참(밴드 등록 순) → 참여자로도 등록
+            val excluded = members.mapTo(mutableSetOf()) { it.memberId }.apply { add(memberId) }
+            val bandTiers =
+                bandsBySelection[selection.id].orEmpty().sortedBy { it.createdAt }.map { it.bandId }.distinct().map { bandId ->
+                    membersByBand[bandId].orEmpty().filter { it.member !in excluded }
+                }
+            val bandSuccessor = SuccessorSelector.oldestFromHighestTier(bandTiers) { it.createdAt }?.member
+            if (bandSuccessor != null) {
+                selection.changeManager(bandSuccessor)
+                selectionMemberRepository.save(TrackSelectionMember.create(selection, bandSuccessor))
+                return@forEach
+            }
+
+            // 후보 전무 → 선곡 회의 소프트 삭제
+            selection.markAsDeleted(memberId)
+        }
     }
 }

--- a/src/main/kotlin/com/bandage/bandmanager/domain/setlist/repository/SetlistRepository.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/setlist/repository/SetlistRepository.kt
@@ -10,4 +10,7 @@ interface SetlistRepository :
     JpaRepository<Setlist, UUID>,
     SetlistRepositoryCustom {
     fun findAllByTrackSelectionId(trackSelectionId: UUID): List<Setlist>
+
+    /** 회원이 매니저인 (삭제되지 않은) 셋리스트를 일괄 조회(탈퇴 시 권한 양도용). */
+    fun findAllByManagerId(managerId: Long): List<Setlist>
 }

--- a/src/main/kotlin/com/bandage/bandmanager/domain/setlist/service/SetlistService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/setlist/service/SetlistService.kt
@@ -1,5 +1,7 @@
 package com.bandage.bandmanager.domain.setlist.service
 
+import com.bandage.bandmanager.domain.band.model.BandMember
+import com.bandage.bandmanager.domain.band.repository.BandMemberRepository
 import com.bandage.bandmanager.domain.setlist.dto.req.SetlistPagingQuery
 import com.bandage.bandmanager.domain.setlist.dto.req.SetlistTrackPagingQuery
 import com.bandage.bandmanager.domain.setlist.dto.req.SetlistTrackUpdateRequest
@@ -8,11 +10,16 @@ import com.bandage.bandmanager.domain.setlist.dto.res.SetlistDetailResponse
 import com.bandage.bandmanager.domain.setlist.dto.res.SetlistResponse
 import com.bandage.bandmanager.domain.setlist.dto.res.SetlistTrackResponse
 import com.bandage.bandmanager.domain.setlist.model.Setlist
+import com.bandage.bandmanager.domain.setlist.model.SetlistBand
 import com.bandage.bandmanager.domain.setlist.model.SetlistTrack
+import com.bandage.bandmanager.domain.setlist.model.SetlistTrackParticipant
 import com.bandage.bandmanager.domain.setlist.repository.SetlistBandRepository
 import com.bandage.bandmanager.domain.setlist.repository.SetlistRepository
 import com.bandage.bandmanager.domain.setlist.repository.SetlistTrackParticipantRepository
 import com.bandage.bandmanager.domain.setlist.repository.SetlistTrackRepository
+import com.bandage.bandmanager.global.authority.MemberAuthorityCleanupHandler
+import com.bandage.bandmanager.global.authority.ResourceAuthorityType
+import com.bandage.bandmanager.global.authority.SuccessorSelector
 import com.bandage.bandmanager.global.common.response.CursorResponse
 import com.bandage.bandmanager.global.error.errorcode.ErrorCode
 import com.bandage.bandmanager.global.error.exception.BusinessException
@@ -28,7 +35,10 @@ class SetlistService(
     private val setlistBandRepository: SetlistBandRepository,
     private val setlistTrackRepository: SetlistTrackRepository,
     private val setlistTrackParticipantRepository: SetlistTrackParticipantRepository,
-) {
+    private val bandMemberRepository: BandMemberRepository,
+) : MemberAuthorityCleanupHandler {
+    override val authorityType: ResourceAuthorityType = ResourceAuthorityType.SETLIST_MANAGEMENT
+
     fun getSetlist(
         setlistId: UUID,
         memberId: Long,
@@ -176,5 +186,77 @@ class SetlistService(
         memberId: Long,
     ) {
         if (setlist.managerId != memberId) throw BusinessException(ErrorCode.SETLIST_NOT_MANAGER)
+    }
+
+    /**
+     * 회원 탈퇴 시 호출. 회원이 매니저인 모든 셋리스트의 매니저 권한을 자동 양도한다.
+     * - 티어1: 셋리스트 참여자(SetlistTrackParticipant) 중 최고참
+     * - 티어2: 연결된 밴드(SetlistBand)의 일반 멤버 중 최고참(밴드 등록 순)
+     * - 후보 전무: 셋리스트 소프트 삭제
+     * 후임 산정에 필요한 트랙/참여자/밴드/밴드멤버를 모두 일괄 조회해 추가 쿼리를 피한다.
+     */
+    @Transactional
+    override fun cleanupOnWithdrawal(memberId: Long) {
+        val managed = setlistRepository.findAllByManagerId(memberId)
+        if (managed.isEmpty()) return
+
+        val setlistIds = managed.map { it.id }
+        val tracks = setlistTrackRepository.findAllBySetlistIdIn(setlistIds)
+        val setlistIdByTrackId = tracks.associate { it.id to it.setlist.id }
+        val participantsBySetlist =
+            if (tracks.isEmpty()) {
+                emptyMap()
+            } else {
+                setlistTrackParticipantRepository
+                    .findAllByTrackIn(tracks)
+                    .groupBy { setlistIdByTrackId[it.track.id] }
+            }
+        val bandsBySetlist = setlistBandRepository.findAllBySetlistIdIn(setlistIds).groupBy { it.setlistId }
+        val allBandIds =
+            bandsBySetlist.values
+                .flatten()
+                .map { it.bandId }
+                .distinct()
+        val membersByBand =
+            if (allBandIds.isEmpty()) {
+                emptyMap()
+            } else {
+                bandMemberRepository.findAllByBandIdIn(allBandIds).groupBy { it.band.id }
+            }
+
+        managed.forEach { setlist ->
+            val successor =
+                selectSetlistSuccessor(
+                    participants = participantsBySetlist[setlist.id].orEmpty(),
+                    bands = bandsBySetlist[setlist.id].orEmpty(),
+                    membersByBand = membersByBand,
+                    leavingMemberId = memberId,
+                )
+            if (successor != null) {
+                setlist.changeManager(successor)
+            } else {
+                setlist.markAsDeleted(memberId)
+            }
+        }
+    }
+
+    private fun selectSetlistSuccessor(
+        participants: List<SetlistTrackParticipant>,
+        bands: List<SetlistBand>,
+        membersByBand: Map<UUID, List<BandMember>>,
+        leavingMemberId: Long,
+    ): Long? {
+        // 티어1: 셋리스트 참여자 중 최고참
+        SuccessorSelector
+            .oldestFromHighestTier(listOf(participants.filter { it.memberId != leavingMemberId })) { it.createdAt }
+            ?.let { return it.memberId }
+
+        // 티어2: 연결된 밴드의 일반 멤버 중 최고참(밴드 등록 순)
+        val excluded = participants.mapTo(mutableSetOf()) { it.memberId }.apply { add(leavingMemberId) }
+        val bandTiers =
+            bands.sortedBy { it.createdAt }.map { it.bandId }.distinct().map { bandId ->
+                membersByBand[bandId].orEmpty().filter { it.member !in excluded }
+            }
+        return SuccessorSelector.oldestFromHighestTier(bandTiers) { it.createdAt }?.member
     }
 }

--- a/src/main/kotlin/com/bandage/bandmanager/facade/MemberWithdrawFacade.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/facade/MemberWithdrawFacade.kt
@@ -2,6 +2,7 @@ package com.bandage.bandmanager.facade
 
 import com.bandage.bandmanager.domain.auth.service.MemberAuthService
 import com.bandage.bandmanager.domain.member.service.MemberService
+import com.bandage.bandmanager.global.authority.MemberAuthorityCleanupService
 import com.bandage.bandmanager.global.security.jwt.RefreshTokenRepository
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
@@ -11,9 +12,12 @@ class MemberWithdrawFacade(
     private val memberService: MemberService,
     private val memberAuthService: MemberAuthService,
     private val refreshTokenRepository: RefreshTokenRepository,
+    private val memberAuthorityCleanupService: MemberAuthorityCleanupService,
 ) {
     @Transactional
     fun withdrawMember(memberId: Long) {
+        // 회원 삭제 전, 보유 권한을 후임자에게 자동 양도/정리해 데드락을 방지한다(동일 트랜잭션).
+        memberAuthorityCleanupService.cleanupAll(memberId)
         memberService.deleteMember(memberId)
         memberAuthService.deleteMemberAuth(memberId)
         refreshTokenRepository.delete(memberId)

--- a/src/main/kotlin/com/bandage/bandmanager/global/authority/MemberAuthorityCleanupHandler.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/global/authority/MemberAuthorityCleanupHandler.kt
@@ -1,0 +1,25 @@
+package com.bandage.bandmanager.global.authority
+
+/**
+ * 회원 탈퇴/삭제 시 해당 회원이 보유한 권한과 소속을 도메인별로 정리하는 포트.
+ *
+ * 권한 양도 데드락(권한자가 탈퇴하면 누구도 리소스에 접근하지 못하는 현상)을 막기 위해,
+ * 회원이 최상위 권한(예: 밴드 LEADER, 공연 OWNER)을 보유한 리소스는 후임자에게 자동 양도하고,
+ * 후임 후보가 전혀 없으면 리소스를 소프트 삭제한다.
+ *
+ * 각 권한 도메인이 이 인터페이스를 구현하면 Spring 이 모든 구현체를
+ * [MemberAuthorityCleanupService] 에 List 로 주입하므로, 새 권한 도메인은 구현만 하면 자동 등록된다.
+ */
+interface MemberAuthorityCleanupHandler {
+    /** 이 핸들러가 책임지는 권한 종류 (로깅/식별용). */
+    val authorityType: ResourceAuthorityType
+
+    /**
+     * [memberId] 가 참여한 이 도메인의 모든 리소스를 정리한다.
+     * - 최상위 권한 보유 리소스: 후임자에게 자동 양도, 후임 없으면 리소스 소프트 삭제
+     * - 그 외 소속 레코드: 제거
+     *
+     * 회원 삭제 트랜잭션 내부에서 호출되므로, 실패 시 탈퇴 전체가 롤백된다.
+     */
+    fun cleanupOnWithdrawal(memberId: Long)
+}

--- a/src/main/kotlin/com/bandage/bandmanager/global/authority/MemberAuthorityCleanupService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/global/authority/MemberAuthorityCleanupService.kt
@@ -1,0 +1,20 @@
+package com.bandage.bandmanager.global.authority
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 회원 탈퇴 시 등록된 모든 [MemberAuthorityCleanupHandler] 를 순회 호출하는 오케스트레이터.
+ *
+ * 회원 삭제와 동일한 트랜잭션에서 권한 양도/정리를 수행하기 위해, 회원 삭제 이전에 호출한다.
+ * 핸들러가 비어 있어도(권한 도메인 미존재) 무해하게 동작한다.
+ */
+@Service
+class MemberAuthorityCleanupService(
+    private val handlers: List<MemberAuthorityCleanupHandler>,
+) {
+    @Transactional
+    fun cleanupAll(memberId: Long) {
+        handlers.forEach { it.cleanupOnWithdrawal(memberId) }
+    }
+}

--- a/src/main/kotlin/com/bandage/bandmanager/global/authority/ResourceAuthorityType.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/global/authority/ResourceAuthorityType.kt
@@ -7,4 +7,6 @@ package com.bandage.bandmanager.global.authority
 enum class ResourceAuthorityType {
     BAND_LEADERSHIP,
     PERFORMANCE_OWNERSHIP,
+    SETLIST_MANAGEMENT,
+    TRACK_SELECTION_MANAGEMENT,
 }

--- a/src/main/kotlin/com/bandage/bandmanager/global/authority/ResourceAuthorityType.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/global/authority/ResourceAuthorityType.kt
@@ -1,0 +1,10 @@
+package com.bandage.bandmanager.global.authority
+
+/**
+ * 회원 이탈 시 자동 양도 대상이 되는 '최상위 권한(소유권)'의 종류.
+ * 새로운 권한 도메인을 추가할 때 항목을 확장한다.
+ */
+enum class ResourceAuthorityType {
+    BAND_LEADERSHIP,
+    PERFORMANCE_OWNERSHIP,
+}

--- a/src/main/kotlin/com/bandage/bandmanager/global/authority/SuccessorSelector.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/global/authority/SuccessorSelector.kt
@@ -1,0 +1,22 @@
+package com.bandage.bandmanager.global.authority
+
+import java.time.LocalDateTime
+
+/**
+ * 계층형 권한 체계에서 후임 권한자를 선정하는 공통 정책.
+ *
+ * 상위 우선순위부터 정렬된 후보 그룹들을 받아, 비어있지 않은 첫 그룹에서
+ * 가장 오래 전 생성된(createdAt 최소) 후보를 후임으로 반환한다.
+ *
+ * 예) 밴드: [ADMIN 멤버들, MEMBER 멤버들] → ADMIN 이 있으면 그중 최고참, 없으면 MEMBER 중 최고참
+ *     공연: [MANAGER 들, 셋리스트 밴드의 일반 멤버들] → MANAGER 우선, 없으면 밴드 멤버 최고참
+ */
+object SuccessorSelector {
+    fun <T> oldestFromHighestTier(
+        tiers: List<List<T>>,
+        createdAt: (T) -> LocalDateTime,
+    ): T? =
+        tiers
+            .firstOrNull { it.isNotEmpty() }
+            ?.minByOrNull(createdAt)
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,6 +6,14 @@ spring:
       local: [local, default-datasource, swagger, redis, security, s3]
       dev: [dev, dev-datasource, swagger, redis, security, s3]
     active: ${PROFILE_ACTIVE:local}
+  jpa:
+    properties:
+      hibernate:
+        # 회원 탈퇴 시 다수 리소스의 권한 양도(update/insert/soft-delete)를 묶어 flush
+        jdbc:
+          batch_size: 50
+        order_inserts: true
+        order_updates: true
 
 springdoc:
   api-docs:

--- a/src/test/kotlin/com/bandage/bandmanager/domain/band/service/BandServiceCleanupTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/band/service/BandServiceCleanupTest.kt
@@ -1,0 +1,133 @@
+package com.bandage.bandmanager.domain.band.service
+
+import com.bandage.bandmanager.domain.band.model.Band
+import com.bandage.bandmanager.domain.band.model.BandMember
+import com.bandage.bandmanager.domain.band.model.enums.ApplicationStatus
+import com.bandage.bandmanager.domain.band.model.enums.BandRole
+import com.bandage.bandmanager.domain.band.repository.BandApplicationRepository
+import com.bandage.bandmanager.domain.band.repository.BandMemberRepository
+import com.bandage.bandmanager.domain.band.repository.BandRepository
+import com.bandage.bandmanager.domain.member.repository.MemberRepository
+import com.bandage.bandmanager.global.infra.s3.CloudFrontUrlResolver
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.time.LocalDateTime
+import java.util.UUID
+
+class BandServiceCleanupTest {
+    private val bandRepository = mock(BandRepository::class.java)
+    private val applicationRepository = mock(BandApplicationRepository::class.java)
+    private val bandMemberRepository = mock(BandMemberRepository::class.java)
+    private val memberRepository = mock(MemberRepository::class.java)
+    private val cloudFrontUrlResolver = mock(CloudFrontUrlResolver::class.java)
+
+    private val sut =
+        BandService(
+            bandRepository,
+            applicationRepository,
+            bandMemberRepository,
+            memberRepository,
+            cloudFrontUrlResolver,
+        )
+
+    private val bandId: UUID = UUID.fromString("00000000-0000-0000-0000-0000000000a1")
+    private val base: LocalDateTime = LocalDateTime.of(2024, 1, 1, 0, 0)
+
+    private fun band(): Band {
+        val band = Band.create(name = "밴드", description = "설명", profileImg = null)
+        setEntityId(band, bandId)
+        return band
+    }
+
+    private fun member(
+        band: Band,
+        memberId: Long,
+        role: BandRole,
+        createdAt: LocalDateTime,
+    ): BandMember {
+        val bandMember = BandMember.create(band, memberId, role)
+        bandMember.createdAt = createdAt
+        return bandMember
+    }
+
+    private fun stub(
+        members: List<BandMember>,
+        leavingId: Long,
+    ) {
+        `when`(bandMemberRepository.findAllBandIdsByMember(leavingId)).thenReturn(listOf(bandId))
+        `when`(bandMemberRepository.findAllByBandIdIn(listOf(bandId))).thenReturn(members)
+        `when`(applicationRepository.findAllByMemberAndStatusFetchBand(leavingId, ApplicationStatus.APPROVED))
+            .thenReturn(emptyList())
+    }
+
+    private fun setEntityId(
+        target: Any,
+        id: UUID,
+    ) {
+        val field = target.javaClass.getDeclaredField("id")
+        field.isAccessible = true
+        field.set(target, id)
+    }
+
+    @Test
+    fun `리더 탈퇴 시 ADMIN 이 MEMBER 보다 우선해 리더를 승계한다`() {
+        val band = band()
+        val leaving = member(band, 1L, BandRole.LEADER, base)
+        val oldestMember = member(band, 2L, BandRole.MEMBER, base.minusDays(5)) // 더 오래됐지만 일반 멤버
+        val admin = member(band, 3L, BandRole.ADMIN, base.plusDays(1)) // 더 최근이지만 상위 티어
+
+        stub(listOf(leaving, oldestMember, admin), 1L)
+
+        sut.cleanupOnWithdrawal(1L)
+
+        assertThat(admin.role).isEqualTo(BandRole.LEADER)
+        assertThat(leaving.role).isEqualTo(BandRole.MEMBER)
+        assertThat(leaving.deletedAt).isNotNull()
+    }
+
+    @Test
+    fun `리더 탈퇴 시 ADMIN 이 없으면 가장 오래된 MEMBER 가 승계한다`() {
+        val band = band()
+        val leaving = member(band, 1L, BandRole.LEADER, base)
+        val newer = member(band, 2L, BandRole.MEMBER, base.plusDays(2))
+        val oldest = member(band, 3L, BandRole.MEMBER, base.plusDays(1))
+
+        stub(listOf(leaving, newer, oldest), 1L)
+
+        sut.cleanupOnWithdrawal(1L)
+
+        assertThat(oldest.role).isEqualTo(BandRole.LEADER)
+        assertThat(newer.role).isEqualTo(BandRole.MEMBER)
+        assertThat(leaving.deletedAt).isNotNull()
+    }
+
+    @Test
+    fun `마지막 멤버인 밴드는 소프트 삭제된다`() {
+        val band = band()
+        val leaving = member(band, 1L, BandRole.LEADER, base)
+
+        stub(listOf(leaving), 1L)
+
+        sut.cleanupOnWithdrawal(1L)
+
+        assertThat(band.deletedAt).isNotNull()
+        assertThat(leaving.deletedAt).isNotNull()
+    }
+
+    @Test
+    fun `리더가 아니면 양도 없이 본인만 정리된다`() {
+        val band = band()
+        val leader = member(band, 1L, BandRole.LEADER, base)
+        val leaving = member(band, 2L, BandRole.MEMBER, base.plusDays(1))
+
+        stub(listOf(leader, leaving), 2L)
+
+        sut.cleanupOnWithdrawal(2L)
+
+        assertThat(leader.role).isEqualTo(BandRole.LEADER)
+        assertThat(leaving.deletedAt).isNotNull()
+        assertThat(band.deletedAt).isNull()
+    }
+}

--- a/src/test/kotlin/com/bandage/bandmanager/domain/performance/service/PerformanceServiceCleanupTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/performance/service/PerformanceServiceCleanupTest.kt
@@ -1,0 +1,221 @@
+package com.bandage.bandmanager.domain.performance.service
+
+import com.bandage.bandmanager.domain.band.model.Band
+import com.bandage.bandmanager.domain.band.model.BandMember
+import com.bandage.bandmanager.domain.band.model.enums.BandRole
+import com.bandage.bandmanager.domain.band.repository.BandMemberRepository
+import com.bandage.bandmanager.domain.band.repository.BandRepository
+import com.bandage.bandmanager.domain.member.repository.MemberRepository
+import com.bandage.bandmanager.domain.performance.model.Performance
+import com.bandage.bandmanager.domain.performance.model.PerformanceManager
+import com.bandage.bandmanager.domain.performance.model.PerformanceSetlist
+import com.bandage.bandmanager.domain.performance.model.enums.PerformanceRole
+import com.bandage.bandmanager.domain.performance.repository.PerformanceInvitationRepository
+import com.bandage.bandmanager.domain.performance.repository.PerformanceManagerRepository
+import com.bandage.bandmanager.domain.performance.repository.PerformanceRepository
+import com.bandage.bandmanager.domain.performance.repository.PerformanceSetlistRepository
+import com.bandage.bandmanager.domain.setlist.model.SetlistBand
+import com.bandage.bandmanager.domain.setlist.repository.SetlistBandRepository
+import com.bandage.bandmanager.domain.setlist.repository.SetlistRepository
+import com.bandage.bandmanager.global.error.errorcode.ErrorCode
+import com.bandage.bandmanager.global.error.exception.BusinessException
+import com.bandage.bandmanager.global.infra.s3.CloudFrontUrlResolver
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyCollection
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import java.time.LocalDateTime
+import java.util.Optional
+import java.util.UUID
+
+class PerformanceServiceCleanupTest {
+    private val performanceRepository = mock(PerformanceRepository::class.java)
+    private val performanceSetlistRepository = mock(PerformanceSetlistRepository::class.java)
+    private val performanceManagerRepository = mock(PerformanceManagerRepository::class.java)
+    private val performanceInvitationRepository = mock(PerformanceInvitationRepository::class.java)
+    private val setlistRepository = mock(SetlistRepository::class.java)
+    private val setlistBandRepository = mock(SetlistBandRepository::class.java)
+    private val bandRepository = mock(BandRepository::class.java)
+    private val bandMemberRepository = mock(BandMemberRepository::class.java)
+    private val memberRepository = mock(MemberRepository::class.java)
+    private val cloudFrontUrlResolver = mock(CloudFrontUrlResolver::class.java)
+
+    private val sut =
+        PerformanceService(
+            performanceRepository,
+            performanceSetlistRepository,
+            performanceManagerRepository,
+            performanceInvitationRepository,
+            setlistRepository,
+            setlistBandRepository,
+            bandRepository,
+            bandMemberRepository,
+            memberRepository,
+            cloudFrontUrlResolver,
+        )
+
+    private val performanceId: UUID = UUID.fromString("00000000-0000-0000-0000-0000000000a1")
+    private val setlistId: UUID = UUID.fromString("00000000-0000-0000-0000-0000000000b1")
+    private val bandId: UUID = UUID.fromString("00000000-0000-0000-0000-0000000000c1")
+    private val ownerId = 1L
+    private val managerId = 2L
+    private val base: LocalDateTime = LocalDateTime.of(2024, 1, 1, 0, 0)
+
+    private fun performance(): Performance {
+        val performance =
+            Performance.create(title = "공연", startAt = base.plusDays(10), durationMinutes = 60, venue = null)
+        setEntityId(performance, performanceId)
+        `when`(performanceRepository.findById(performanceId)).thenReturn(Optional.of(performance))
+        return performance
+    }
+
+    private fun owner(
+        performance: Performance,
+        memberId: Long,
+        createdAt: LocalDateTime,
+    ): PerformanceManager {
+        val manager = PerformanceManager.createOwner(performance, memberId)
+        manager.createdAt = createdAt
+        return manager
+    }
+
+    private fun manager(
+        performance: Performance,
+        memberId: Long,
+        createdAt: LocalDateTime,
+    ): PerformanceManager {
+        val manager = PerformanceManager.createManager(performance, memberId)
+        manager.createdAt = createdAt
+        return manager
+    }
+
+    private fun bandMember(
+        band: Band,
+        memberId: Long,
+        createdAt: LocalDateTime,
+    ): BandMember {
+        val bandMember = BandMember.create(band, memberId, BandRole.MEMBER)
+        bandMember.createdAt = createdAt
+        return bandMember
+    }
+
+    private fun setEntityId(
+        target: Any,
+        id: UUID,
+    ) {
+        val field = target.javaClass.getDeclaredField("id")
+        field.isAccessible = true
+        field.set(target, id)
+    }
+
+    @Test
+    fun `OWNER 탈퇴 시 최고참 MANAGER 가 OWNER 로 승격된다`() {
+        val performance = performance()
+        val ownerRow = owner(performance, ownerId, base)
+        val newerManager = manager(performance, 5L, base.plusDays(2))
+        val olderManager = manager(performance, 6L, base.plusDays(1))
+        `when`(performanceManagerRepository.findAllByMemberFetchPerformance(ownerId)).thenReturn(listOf(ownerRow))
+        `when`(performanceManagerRepository.findAllByPerformanceIn(listOf(performance)))
+            .thenReturn(listOf(ownerRow, newerManager, olderManager))
+        `when`(performanceSetlistRepository.findAllByPerformanceIn(listOf(performance))).thenReturn(emptyList())
+
+        sut.cleanupOnWithdrawal(ownerId)
+
+        assertThat(olderManager.role).isEqualTo(PerformanceRole.OWNER)
+        assertThat(newerManager.role).isEqualTo(PerformanceRole.MANAGER)
+        verify(performanceManagerRepository).deleteAll(listOf(ownerRow))
+        verify(performanceManagerRepository, never()).save(any())
+    }
+
+    @Test
+    fun `MANAGER 가 없으면 셋리스트 밴드의 최고참 멤버에게 OWNER 가 부여된다`() {
+        val performance = performance()
+        val ownerRow = owner(performance, ownerId, base)
+        `when`(performanceManagerRepository.findAllByMemberFetchPerformance(ownerId)).thenReturn(listOf(ownerRow))
+        `when`(performanceManagerRepository.findAllByPerformanceIn(listOf(performance))).thenReturn(listOf(ownerRow))
+        `when`(performanceSetlistRepository.findAllByPerformanceIn(listOf(performance)))
+            .thenReturn(listOf(PerformanceSetlist.create(performance, setlistId)))
+        `when`(setlistBandRepository.findAllBySetlistIdIn(listOf(setlistId)))
+            .thenReturn(listOf(SetlistBand.create(bandId, setlistId)))
+
+        val band = Band.create(name = "밴드", description = "설명", profileImg = null)
+        setEntityId(band, bandId)
+        val newer = bandMember(band, 11L, base.plusDays(1))
+        val oldest = bandMember(band, 10L, base)
+        `when`(bandMemberRepository.findAllByBandIdIn(listOf(bandId))).thenReturn(listOf(newer, oldest))
+
+        var saved: PerformanceManager? = null
+        `when`(performanceManagerRepository.save(any())).thenAnswer {
+            saved = it.arguments[0] as PerformanceManager
+            saved
+        }
+
+        sut.cleanupOnWithdrawal(ownerId)
+
+        assertThat(saved).isNotNull()
+        assertThat(saved!!.member).isEqualTo(10L)
+        assertThat(saved!!.role).isEqualTo(PerformanceRole.OWNER)
+        verify(performanceManagerRepository).deleteAll(listOf(ownerRow))
+    }
+
+    @Test
+    fun `후임 후보가 전무하면 공연이 소프트 삭제된다`() {
+        val performance = performance()
+        val ownerRow = owner(performance, ownerId, base)
+        `when`(performanceManagerRepository.findAllByMemberFetchPerformance(ownerId)).thenReturn(listOf(ownerRow))
+        `when`(performanceManagerRepository.findAllByPerformanceIn(listOf(performance))).thenReturn(listOf(ownerRow))
+        `when`(performanceSetlistRepository.findAllByPerformanceIn(listOf(performance))).thenReturn(emptyList())
+
+        sut.cleanupOnWithdrawal(ownerId)
+
+        assertThat(performance.deletedAt).isNotNull()
+        verify(performanceManagerRepository, never()).save(any())
+        verify(performanceManagerRepository).deleteAll(listOf(ownerRow))
+    }
+
+    @Test
+    fun `MANAGER 만 보유한 회원은 양도 없이 권한 레코드만 제거된다`() {
+        val performance = performance()
+        val managerRow = manager(performance, managerId, base)
+        `when`(performanceManagerRepository.findAllByMemberFetchPerformance(managerId)).thenReturn(listOf(managerRow))
+
+        sut.cleanupOnWithdrawal(managerId)
+
+        verify(performanceManagerRepository).deleteAll(listOf(managerRow))
+        verify(performanceManagerRepository, never()).findAllByPerformanceIn(anyCollection())
+        verify(performanceManagerRepository, never()).save(any())
+    }
+
+    @Test
+    fun `delegateOwnership - OWNER 가 MANAGER 에게 양도하면 역할이 교체된다`() {
+        val performance = performance()
+        val ownerRow = owner(performance, ownerId, base)
+        val target = manager(performance, managerId, base.plusDays(1))
+        `when`(performanceManagerRepository.findByPerformanceAndMember(performance, ownerId)).thenReturn(ownerRow)
+        `when`(performanceManagerRepository.findByPerformanceAndMember(performance, managerId)).thenReturn(target)
+
+        sut.delegateOwnership(performanceId, managerId, ownerId)
+
+        assertThat(ownerRow.role).isEqualTo(PerformanceRole.MANAGER)
+        assertThat(target.role).isEqualTo(PerformanceRole.OWNER)
+    }
+
+    @Test
+    fun `delegateOwnership - 대상이 참가자가 아니면 NOT_A_PERFORMANCE_MANAGER`() {
+        val performance = performance()
+        val ownerRow = owner(performance, ownerId, base)
+        `when`(performanceManagerRepository.findByPerformanceAndMember(performance, ownerId)).thenReturn(ownerRow)
+        `when`(performanceManagerRepository.findByPerformanceAndMember(performance, managerId)).thenReturn(null)
+
+        val ex =
+            assertThrows<BusinessException> {
+                sut.delegateOwnership(performanceId, managerId, ownerId)
+            }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.NOT_A_PERFORMANCE_MANAGER)
+    }
+}

--- a/src/test/kotlin/com/bandage/bandmanager/domain/selection/service/TrackSelectionServiceCleanupTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/selection/service/TrackSelectionServiceCleanupTest.kt
@@ -1,0 +1,157 @@
+package com.bandage.bandmanager.domain.selection.service
+
+import com.bandage.bandmanager.domain.band.model.Band
+import com.bandage.bandmanager.domain.band.model.BandMember
+import com.bandage.bandmanager.domain.band.model.enums.BandRole
+import com.bandage.bandmanager.domain.band.repository.BandMemberRepository
+import com.bandage.bandmanager.domain.selection.model.PracticeWindow
+import com.bandage.bandmanager.domain.selection.model.TrackSelection
+import com.bandage.bandmanager.domain.selection.model.TrackSelectionBand
+import com.bandage.bandmanager.domain.selection.model.TrackSelectionMember
+import com.bandage.bandmanager.domain.selection.repository.TrackSelectionBandRepository
+import com.bandage.bandmanager.domain.selection.repository.TrackSelectionItemApplicantRepository
+import com.bandage.bandmanager.domain.selection.repository.TrackSelectionItemChatMessageRepository
+import com.bandage.bandmanager.domain.selection.repository.TrackSelectionItemConfirmationRepository
+import com.bandage.bandmanager.domain.selection.repository.TrackSelectionItemRepository
+import com.bandage.bandmanager.domain.selection.repository.TrackSelectionMemberRepository
+import com.bandage.bandmanager.domain.selection.repository.TrackSelectionRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+class TrackSelectionServiceCleanupTest {
+    private val selectionRepository = mock(TrackSelectionRepository::class.java)
+    private val selectionMemberRepository = mock(TrackSelectionMemberRepository::class.java)
+    private val selectionBandRepository = mock(TrackSelectionBandRepository::class.java)
+    private val itemRepository = mock(TrackSelectionItemRepository::class.java)
+    private val applicantRepository = mock(TrackSelectionItemApplicantRepository::class.java)
+    private val confirmationRepository = mock(TrackSelectionItemConfirmationRepository::class.java)
+    private val chatMessageRepository = mock(TrackSelectionItemChatMessageRepository::class.java)
+    private val bandMemberRepository = mock(BandMemberRepository::class.java)
+
+    private val sut =
+        TrackSelectionService(
+            selectionRepository,
+            selectionMemberRepository,
+            selectionBandRepository,
+            itemRepository,
+            applicantRepository,
+            confirmationRepository,
+            chatMessageRepository,
+            bandMemberRepository,
+        )
+
+    private val selectionId: UUID = UUID.fromString("00000000-0000-0000-0000-0000000000a1")
+    private val bandId: UUID = UUID.fromString("00000000-0000-0000-0000-0000000000c1")
+    private val managerId = 1L
+    private val base: LocalDateTime = LocalDateTime.of(2024, 1, 1, 0, 0)
+
+    private fun selection(): TrackSelection {
+        val selection =
+            TrackSelection.create(
+                title = "선곡 회의",
+                managerId = managerId,
+                practiceWindow = PracticeWindow(from = LocalDate.of(2024, 2, 1), to = LocalDate.of(2024, 2, 10)),
+            )
+        setEntityId(selection, selectionId)
+        `when`(selectionRepository.findAllByManagerId(managerId)).thenReturn(listOf(selection))
+        return selection
+    }
+
+    private fun member(
+        selection: TrackSelection,
+        memberId: Long,
+        createdAt: LocalDateTime,
+    ): TrackSelectionMember {
+        val member = TrackSelectionMember.create(selection, memberId)
+        member.createdAt = createdAt
+        return member
+    }
+
+    private fun band(): Band {
+        val band = Band.create(name = "밴드", description = "설명", profileImg = null)
+        setEntityId(band, bandId)
+        return band
+    }
+
+    private fun bandMember(
+        band: Band,
+        memberId: Long,
+        createdAt: LocalDateTime,
+    ): BandMember {
+        val bandMember = BandMember.create(band, memberId, BandRole.MEMBER)
+        bandMember.createdAt = createdAt
+        return bandMember
+    }
+
+    private fun setEntityId(
+        target: Any,
+        id: UUID,
+    ) {
+        val field = target.javaClass.getDeclaredField("id")
+        field.isAccessible = true
+        field.set(target, id)
+    }
+
+    @Test
+    fun `매니저 탈퇴 시 회의 참여자 최고참이 매니저를 승계한다`() {
+        val selection = selection()
+        `when`(selectionMemberRepository.findAllBySelectionIn(listOf(selection)))
+            .thenReturn(
+                listOf(
+                    member(selection, managerId, base),
+                    member(selection, 5L, base.plusDays(2)),
+                    member(selection, 6L, base.plusDays(1)),
+                ),
+            )
+
+        sut.cleanupOnWithdrawal(managerId)
+
+        assertThat(selection.managerId).isEqualTo(6L)
+        assertThat(selection.deletedAt).isNull()
+        verify(selectionMemberRepository, never()).save(any())
+    }
+
+    @Test
+    fun `참여자가 매니저뿐이면 밴드 멤버가 승계하고 참여자로 등록된다`() {
+        val selection = selection()
+        `when`(selectionMemberRepository.findAllBySelectionIn(listOf(selection)))
+            .thenReturn(listOf(member(selection, managerId, base)))
+        `when`(selectionBandRepository.findAllBySelectionIn(listOf(selection)))
+            .thenReturn(listOf(TrackSelectionBand.create(selection = selection, bandId = bandId)))
+        val band = band()
+        `when`(bandMemberRepository.findAllByBandIdIn(listOf(bandId)))
+            .thenReturn(listOf(bandMember(band, 10L, base), bandMember(band, 11L, base.plusDays(1))))
+
+        var saved: TrackSelectionMember? = null
+        `when`(selectionMemberRepository.save(any())).thenAnswer {
+            saved = it.arguments[0] as TrackSelectionMember
+            saved
+        }
+
+        sut.cleanupOnWithdrawal(managerId)
+
+        assertThat(selection.managerId).isEqualTo(10L)
+        assertThat(saved).isNotNull()
+        assertThat(saved!!.memberId).isEqualTo(10L)
+    }
+
+    @Test
+    fun `후보가 전무하면 선곡 회의가 소프트 삭제된다`() {
+        val selection = selection()
+        `when`(selectionMemberRepository.findAllBySelectionIn(listOf(selection)))
+            .thenReturn(listOf(member(selection, managerId, base)))
+
+        sut.cleanupOnWithdrawal(managerId)
+
+        assertThat(selection.deletedAt).isNotNull()
+        verify(selectionMemberRepository, never()).save(any())
+    }
+}

--- a/src/test/kotlin/com/bandage/bandmanager/domain/setlist/service/SetlistServiceCleanupTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/setlist/service/SetlistServiceCleanupTest.kt
@@ -1,0 +1,130 @@
+package com.bandage.bandmanager.domain.setlist.service
+
+import com.bandage.bandmanager.domain.band.model.Band
+import com.bandage.bandmanager.domain.band.model.BandMember
+import com.bandage.bandmanager.domain.band.model.enums.BandRole
+import com.bandage.bandmanager.domain.band.repository.BandMemberRepository
+import com.bandage.bandmanager.domain.setlist.model.Setlist
+import com.bandage.bandmanager.domain.setlist.model.SetlistBand
+import com.bandage.bandmanager.domain.setlist.model.SetlistTrack
+import com.bandage.bandmanager.domain.setlist.model.SetlistTrackParticipant
+import com.bandage.bandmanager.domain.setlist.repository.SetlistBandRepository
+import com.bandage.bandmanager.domain.setlist.repository.SetlistRepository
+import com.bandage.bandmanager.domain.setlist.repository.SetlistTrackParticipantRepository
+import com.bandage.bandmanager.domain.setlist.repository.SetlistTrackRepository
+import com.bandage.bandmanager.global.common.domain.TrackInfo
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.time.LocalDateTime
+import java.util.UUID
+
+class SetlistServiceCleanupTest {
+    private val setlistRepository = mock(SetlistRepository::class.java)
+    private val setlistBandRepository = mock(SetlistBandRepository::class.java)
+    private val setlistTrackRepository = mock(SetlistTrackRepository::class.java)
+    private val setlistTrackParticipantRepository = mock(SetlistTrackParticipantRepository::class.java)
+    private val bandMemberRepository = mock(BandMemberRepository::class.java)
+
+    private val sut =
+        SetlistService(
+            setlistRepository,
+            setlistBandRepository,
+            setlistTrackRepository,
+            setlistTrackParticipantRepository,
+            bandMemberRepository,
+        )
+
+    private val setlistId: UUID = UUID.fromString("00000000-0000-0000-0000-0000000000a1")
+    private val trackId: UUID = UUID.fromString("00000000-0000-0000-0000-0000000000b1")
+    private val bandId: UUID = UUID.fromString("00000000-0000-0000-0000-0000000000c1")
+    private val managerId = 1L
+    private val base: LocalDateTime = LocalDateTime.of(2024, 1, 1, 0, 0)
+
+    private fun setlist(): Setlist {
+        val setlist = Setlist.create(trackSelectionId = UUID.randomUUID(), title = "셋리스트", managerId = managerId)
+        setEntityId(setlist, setlistId)
+        `when`(setlistRepository.findAllByManagerId(managerId)).thenReturn(listOf(setlist))
+        return setlist
+    }
+
+    private fun track(setlist: Setlist): SetlistTrack {
+        val track = SetlistTrack.create(setlist, TrackInfo(title = "곡", artist = "아티스트"), note = null, sessions = emptyList())
+        setEntityId(track, trackId)
+        return track
+    }
+
+    private fun participant(
+        track: SetlistTrack,
+        memberId: Long,
+        createdAt: LocalDateTime,
+    ): SetlistTrackParticipant {
+        val participant = SetlistTrackParticipant.create(track, sessionId = "vocal", memberId = memberId)
+        participant.createdAt = createdAt
+        return participant
+    }
+
+    private fun band(): Band {
+        val band = Band.create(name = "밴드", description = "설명", profileImg = null)
+        setEntityId(band, bandId)
+        return band
+    }
+
+    private fun bandMember(
+        band: Band,
+        memberId: Long,
+        createdAt: LocalDateTime,
+    ): BandMember {
+        val bandMember = BandMember.create(band, memberId, BandRole.MEMBER)
+        bandMember.createdAt = createdAt
+        return bandMember
+    }
+
+    private fun setEntityId(
+        target: Any,
+        id: UUID,
+    ) {
+        val field = target.javaClass.getDeclaredField("id")
+        field.isAccessible = true
+        field.set(target, id)
+    }
+
+    @Test
+    fun `매니저 탈퇴 시 셋리스트 참여자 최고참이 매니저를 승계한다`() {
+        val setlist = setlist()
+        val track = track(setlist)
+        `when`(setlistTrackRepository.findAllBySetlistIdIn(listOf(setlistId))).thenReturn(listOf(track))
+        `when`(setlistTrackParticipantRepository.findAllByTrackIn(listOf(track)))
+            .thenReturn(listOf(participant(track, 5L, base.plusDays(2)), participant(track, 6L, base.plusDays(1))))
+
+        sut.cleanupOnWithdrawal(managerId)
+
+        assertThat(setlist.managerId).isEqualTo(6L)
+        assertThat(setlist.deletedAt).isNull()
+    }
+
+    @Test
+    fun `참여자가 없으면 연결된 밴드의 최고참 멤버가 매니저를 승계한다`() {
+        val setlist = setlist()
+        `when`(setlistBandRepository.findAllBySetlistIdIn(listOf(setlistId)))
+            .thenReturn(listOf(SetlistBand.create(bandId, setlistId)))
+        val band = band()
+        `when`(bandMemberRepository.findAllByBandIdIn(listOf(bandId)))
+            .thenReturn(listOf(bandMember(band, 11L, base.plusDays(1)), bandMember(band, 10L, base)))
+
+        sut.cleanupOnWithdrawal(managerId)
+
+        assertThat(setlist.managerId).isEqualTo(10L)
+        assertThat(setlist.deletedAt).isNull()
+    }
+
+    @Test
+    fun `후보가 전무하면 셋리스트가 소프트 삭제된다`() {
+        val setlist = setlist()
+
+        sut.cleanupOnWithdrawal(managerId)
+
+        assertThat(setlist.deletedAt).isNotNull()
+    }
+}

--- a/src/test/kotlin/com/bandage/bandmanager/global/authority/SuccessorSelectorTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/global/authority/SuccessorSelectorTest.kt
@@ -1,0 +1,49 @@
+package com.bandage.bandmanager.global.authority
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class SuccessorSelectorTest {
+    private data class Candidate(
+        val name: String,
+        val createdAt: LocalDateTime,
+    )
+
+    private val base: LocalDateTime = LocalDateTime.of(2024, 1, 1, 0, 0)
+
+    @Test
+    fun `상위 그룹이 비어있지 않으면 하위 그룹보다 우선해 상위 그룹의 최고참을 선택한다`() {
+        val upper =
+            listOf(
+                Candidate("upperNew", base.plusDays(2)),
+                Candidate("upperOld", base.plusDays(1)),
+            )
+        val lower = listOf(Candidate("lowerOldest", base))
+
+        val result = SuccessorSelector.oldestFromHighestTier(listOf(upper, lower)) { it.createdAt }
+
+        assertThat(result?.name).isEqualTo("upperOld")
+    }
+
+    @Test
+    fun `상위 그룹이 비어있으면 다음 그룹의 최고참을 선택한다`() {
+        val lower =
+            listOf(
+                Candidate("a", base.plusDays(1)),
+                Candidate("b", base),
+            )
+
+        val result = SuccessorSelector.oldestFromHighestTier(listOf(emptyList(), lower)) { it.createdAt }
+
+        assertThat(result?.name).isEqualTo("b")
+    }
+
+    @Test
+    fun `모든 그룹이 비어있으면 null 을 반환한다`() {
+        val result =
+            SuccessorSelector.oldestFromHighestTier<Candidate>(listOf(emptyList(), emptyList())) { it.createdAt }
+
+        assertThat(result).isNull()
+    }
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #
> Jira: BD-78

📌 **작업 내용 및 특이사항**

권한자(밴드 LEADER, 공연 OWNER, 셋리스트/선곡 회의 MANAGER)가 탈퇴/삭제되면 누구도 해당 리소스를 관리할 수 없는 **권한 데드락**을 해소합니다.

**핵심 변경**
- `global/authority` 에 범용 인프라 추가 (`MemberAuthorityCleanupHandler` 포트 · `SuccessorSelector` 계층형 후임 선정 유틸 · `MemberAuthorityCleanupService` 오케스트레이터). 새 권한 도메인은 포트만 구현하면 자동 등록됩니다.
- **밴드**: `BandService` 가 핸들러 구현. 리더 탈퇴 시 `ADMIN > MEMBER` 순 최고참에게 자동 양도, 마지막 멤버면 밴드 소프트 삭제. 수동 양도(`changeLeader`)는 기존 유지.
- **공연**: 소유권 수동 양도 API(`PATCH /performances/{id}/owner`) 신규 추가. 자동 양도는 티어1=MANAGER 최고참 승격 → 티어2=셋리스트가 속한 밴드의 일반 멤버 최고참에게 OWNER 부여 → 후보 전무 시 소프트 삭제. `PerformanceManager.role` 가변 전환 + `promoteToOwner`/`demoteToManager`.
- **셋리스트 / 선곡 회의**: `SetlistService` · `TrackSelectionService` 가 핸들러 구현. 매니저 탈퇴 시 티어1=참여자(SetlistTrackParticipant / TrackSelectionMember) 최고참 → 티어2=연결 밴드 멤버 최고참 → 후보 전무 시 리소스 소프트 삭제. 수동 양도(`changeManager`)는 기존 유지. 선곡 회의는 밴드 폴백 시 신규 매니저를 참여자로도 등록(매니저 ∈ 참여자 불변식 유지). *(선곡 회의는 `lockedAt` 잠금 상태가 있어 매니저 부재 시 영구 잠금 위험이 있었음)*
- **탈퇴 흐름 연결**: `MemberWithdrawFacade` 가 회원 삭제 **이전**에 `cleanupAll` 호출(동일 트랜잭션, 원자적). 등록된 4개 도메인 핸들러를 순회.

**성능 / 규모 대응 (동기 + 원자성 유지)**
- 권한 양도 쓰기 비용은 "회원이 멤버로 속한 수"가 아니라 "최상위 권한 보유 리소스 수"에만 비례(리소스당 멤버 수와 무관).
- 후임 산정에 필요한 멤버/매니저/참여자/셋리스트/밴드를 모두 **fetch join · IN 쿼리로 일괄 조회**하고 인메모리로 처리해 리소스별 추가 쿼리를 제거.
- `BandApplication` LEAVED 처리 조회 IN 쿼리 배치화(N+1 제거), Hibernate JDBC batch(`batch_size=50`, `order_inserts/updates`) 활성화.

**설계 결정**
- 후임 후보 전무 시 리소스 소프트 삭제(기존 `leaveBand` 동작과 일관).
- 비동기 대신 동기+원자성 채택: 비동기는 양도 완료 전까지 데드락 창이 재발하고, 기존 이벤트 인프라가 `@Deprecated` 상태라 재구축이 필요하기 때문.

📚 **참고사항**
- `PerformanceManager` 는 소프트삭제 미적용(유니크 제약 `(performance_id, member_id)` 충돌 방지) → 탈퇴 회원 레코드는 hard-delete, 공연 자체는 소프트 삭제.
- 단위 테스트 19건 추가(`SuccessorSelector`, 밴드/공연/셋리스트/선곡 cleanup, `delegateOwnership`). `./gradlew build` 전체 통과.
- 셋리스트/선곡은 내부 핸들러·리포지터리만 추가되어 API 변경이 없으므로 `docs/openapi.json` 변경은 공연 양도 API에 한정됩니다.

✅ **체크리스트**
- [x] API(Controller/DTO)를 변경한 경우 `docs/openapi.json`을 갱신했습니다 (코드-스펙 동일 PR 규약)
