### PR TITLE
[BD-81] 알림(Notify) 도메인 구현 - AOP 트리거 + 이벤트 저장 파이프라인

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ set-env.sh
 API_*.md
 SERVICE_SPEC.md
 .taskmaster
+docs/design

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,6 +75,10 @@ dependencies {
     //liquibase
     implementation("org.springframework.boot:spring-boot-starter-liquibase")
 
+    // aop (알림 도메인 @Notify 횡단관심사 트리거)
+    // Spring Boot 4 에는 spring-boot-starter-aop 가 없어 aspectjweaver 를 직접 추가한다(버전은 BOM 관리).
+    // spring-aop 는 spring-context 의 transitive 로 이미 포함되며, AopAutoConfiguration 이 자동 활성화된다.
+    implementation("org.aspectj:aspectjweaver")
 }
 
 kotlin {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -249,6 +249,37 @@
                 ],
                 "type": "object"
             },
+            "ApiResponseCursorResponseNotificationResponseUUID": {
+                "properties": {
+                    "code": {
+                        "type": "string"
+                    },
+                    "data": {
+                        "$ref": "#/components/schemas/CursorResponseNotificationResponseUUID"
+                    },
+                    "fieldErrors": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "type": "object"
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "success": {
+                        "type": "boolean"
+                    },
+                    "timestamp": {
+                        "format": "date-time",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "success",
+                    "timestamp"
+                ],
+                "type": "object"
+            },
             "ApiResponseCursorResponsePerformanceListResponseUUID": {
                 "properties": {
                     "code": {
@@ -1538,6 +1569,37 @@
                 ],
                 "type": "object"
             },
+            "ApiResponseUnreadCountResponse": {
+                "properties": {
+                    "code": {
+                        "type": "string"
+                    },
+                    "data": {
+                        "$ref": "#/components/schemas/UnreadCountResponse"
+                    },
+                    "fieldErrors": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "type": "object"
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "success": {
+                        "type": "boolean"
+                    },
+                    "timestamp": {
+                        "format": "date-time",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "success",
+                    "timestamp"
+                ],
+                "type": "object"
+            },
             "AutoPlaceRequest": {
                 "properties": {
                     "durationSlots": {
@@ -2093,6 +2155,29 @@
                     "content": {
                         "items": {
                             "$ref": "#/components/schemas/MyBandInfoResponse"
+                        },
+                        "type": "array"
+                    },
+                    "hasNext": {
+                        "type": "boolean"
+                    },
+                    "nextCursor": {
+                        "format": "uuid",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "content",
+                    "hasNext"
+                ],
+                "type": "object"
+            },
+            "CursorResponseNotificationResponseUUID": {
+                "description": "\ucee4\uc11c \uae30\ubc18 \ud398\uc774\uc9d5 \uc751\ub2f5",
+                "properties": {
+                    "content": {
+                        "items": {
+                            "$ref": "#/components/schemas/NotificationResponse"
                         },
                         "type": "array"
                     },
@@ -3161,6 +3246,92 @@
                     "durationSlots",
                     "reason",
                     "startSlot"
+                ],
+                "type": "object"
+            },
+            "NotificationPagingQuery": {
+                "description": "\uc54c\ub9bc \ubaa9\ub85d \uc870\ud68c \ucffc\ub9ac",
+                "properties": {
+                    "lastId": {
+                        "description": "\ub9c8\uc9c0\ub9c9\uc73c\ub85c \uc870\ud68c\ub41c \uc54c\ub9bc ID (\ucee4\uc11c)",
+                        "example": "550e8400-e29b-41d4-a716-446655440000",
+                        "format": "uuid",
+                        "type": "string"
+                    },
+                    "pageSize": {
+                        "description": "\ud398\uc774\uc9c0 \ud06c\uae30",
+                        "example": 20,
+                        "format": "int32",
+                        "maximum": 100,
+                        "minimum": 1,
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "pageSize"
+                ],
+                "type": "object"
+            },
+            "NotificationResponse": {
+                "description": "\uc54c\ub9bc \uc751\ub2f5",
+                "properties": {
+                    "category": {
+                        "description": "\uc54c\ub9bc \uce74\ud14c\uace0\ub9ac (\ud504\ub860\ud2b8 \ud544\ud130 \ud0a4)",
+                        "enum": [
+                            "BAND_APPLICATION",
+                            "BAND_APPLICATION_RESULT",
+                            "AUTHORITY_PROMOTION",
+                            "JAM_UPCOMING"
+                        ],
+                        "example": "BAND_APPLICATION",
+                        "type": "string"
+                    },
+                    "createdAt": {
+                        "description": "\uc0dd\uc131 \uc2dc\uac01",
+                        "example": "2026-06-20 17:30",
+                        "format": "date-time",
+                        "type": "string"
+                    },
+                    "id": {
+                        "description": "\uc54c\ub9bc \uace0\uc720 \uc2dd\ubcc4\uc790 (UUID)",
+                        "example": "550e8400-e29b-41d4-a716-446655440000",
+                        "format": "uuid",
+                        "type": "string"
+                    },
+                    "isRead": {
+                        "description": "\uc77d\uc74c \uc5ec\ubd80",
+                        "example": false,
+                        "type": "boolean"
+                    },
+                    "message": {
+                        "description": "\uc54c\ub9bc \uba54\uc2dc\uc9c0",
+                        "example": "\ubc34\ub4dc\uc5d0 \uc0c8\ub85c\uc6b4 \uac00\uc785 \uc2e0\uccad\uc774 \uc811\uc218\ub418\uc5c8\uc2b5\ub2c8\ub2e4.",
+                        "type": "string"
+                    },
+                    "readAt": {
+                        "description": "\uc77d\uc740 \uc2dc\uac01",
+                        "example": "2026-06-20 18:00",
+                        "format": "date-time",
+                        "type": "string"
+                    },
+                    "referenceId": {
+                        "description": "\uc5f0\uad00 \ub9ac\uc18c\uc2a4 ID (\ubc34\ub4dc/\ud569\uc8fc \ub4f1, \ub525\ub9c1\ud06c\uc6a9)",
+                        "example": "550e8400-e29b-41d4-a716-446655440000",
+                        "type": "string"
+                    },
+                    "title": {
+                        "description": "\uc54c\ub9bc \uc81c\ubaa9",
+                        "example": "\uc0c8\ub85c\uc6b4 \uac00\uc785 \uc2e0\uccad",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category",
+                    "createdAt",
+                    "id",
+                    "isRead",
+                    "message",
+                    "title"
                 ],
                 "type": "object"
             },
@@ -5137,6 +5308,21 @@
                 ],
                 "type": "object"
             },
+            "UnreadCountResponse": {
+                "description": "\ubbf8\ud655\uc778 \uc54c\ub9bc \uac1c\uc218 \uc751\ub2f5",
+                "properties": {
+                    "count": {
+                        "description": "\ubbf8\ud655\uc778(\uc77d\uc9c0 \uc54a\uc740) \uc54c\ub9bc \uac1c\uc218",
+                        "example": 3,
+                        "format": "int64",
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "count"
+                ],
+                "type": "object"
+            },
             "WeeklyRuleRequest": {
                 "properties": {
                     "dayOfWeek": {
@@ -6687,6 +6873,115 @@
                 "summary": "\ud68c\uc6d0 \uac80\uc0c9 API",
                 "tags": [
                     "members"
+                ]
+            }
+        },
+        "/api/v1/notifications": {
+            "get": {
+                "description": "\ub85c\uadf8\uc778\ud55c \ud68c\uc6d0\uc758 \uc804\uccb4 \uc54c\ub9bc\uc744 \ucee4\uc11c \uae30\ubc18 \ucd5c\uc2e0\uc21c\uc73c\ub85c \uc870\ud68c\ud569\ub2c8\ub2e4. \uce74\ud14c\uace0\ub9ac \ud544\ud130\ub9c1\uc740 \ud504\ub860\ud2b8\uac00 \ucc98\ub9ac\ud569\ub2c8\ub2e4.",
+                "operationId": "getMyNotifications",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "query",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/NotificationPagingQuery"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiResponseCursorResponseNotificationResponseUUID"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    }
+                },
+                "summary": "\ub0b4 \uc54c\ub9bc \ubaa9\ub85d \uc870\ud68c API",
+                "tags": [
+                    "notifications"
+                ]
+            }
+        },
+        "/api/v1/notifications/read-all": {
+            "patch": {
+                "description": "\ub85c\uadf8\uc778\ud55c \ud68c\uc6d0\uc758 \uc77d\uc9c0 \uc54a\uc740 \ubaa8\ub4e0 \uc54c\ub9bc\uc744 \uc77c\uad04 \uc77d\uc74c \ucc98\ub9ac\ud569\ub2c8\ub2e4.",
+                "operationId": "markAllNotificationsAsRead",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiResponseUnit"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    }
+                },
+                "summary": "\uc804\uccb4 \uc54c\ub9bc \uc77d\uc74c \ucc98\ub9ac API",
+                "tags": [
+                    "notifications"
+                ]
+            }
+        },
+        "/api/v1/notifications/unread-count": {
+            "get": {
+                "description": "\ub85c\uadf8\uc778\ud55c \ud68c\uc6d0\uc758 \uc77d\uc9c0 \uc54a\uc740 \uc54c\ub9bc \uac1c\uc218\ub97c \uc870\ud68c\ud569\ub2c8\ub2e4.",
+                "operationId": "getUnreadNotificationCount",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiResponseUnreadCountResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    }
+                },
+                "summary": "\ubbf8\ud655\uc778 \uc54c\ub9bc \uac1c\uc218 \uc870\ud68c API",
+                "tags": [
+                    "notifications"
+                ]
+            }
+        },
+        "/api/v1/notifications/{notificationId}/read": {
+            "patch": {
+                "description": "\ud2b9\uc815 \uc54c\ub9bc\uc744 \uc77d\uc74c \ucc98\ub9ac\ud569\ub2c8\ub2e4. \ubcf8\uc778 \uc18c\uc720 \uc54c\ub9bc\ub9cc \ucc98\ub9ac\ud560 \uc218 \uc788\uc2b5\ub2c8\ub2e4.",
+                "operationId": "markNotificationAsRead",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "notificationId",
+                        "required": true,
+                        "schema": {
+                            "format": "uuid",
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiResponseUnit"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    }
+                },
+                "summary": "\uc54c\ub9bc \uc77d\uc74c \ucc98\ub9ac API",
+                "tags": [
+                    "notifications"
                 ]
             }
         },
@@ -9216,10 +9511,14 @@
     "servers": [
         {
             "description": "Generated server url",
-            "url": "http://bandage-band-manager:8080"
+            "url": "http://localhost:8080"
         }
     ],
     "tags": [
+        {
+            "description": "\uc54c\ub9bc API",
+            "name": "notifications"
+        },
         {
             "description": "\ud68c\uc6d0 \uc778\uc99d API",
             "name": "auth"

--- a/src/main/kotlin/com/bandage/bandmanager/domain/band/notify/AuthorityPromotionResolver.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/band/notify/AuthorityPromotionResolver.kt
@@ -1,0 +1,39 @@
+package com.bandage.bandmanager.domain.band.notify
+
+import com.bandage.bandmanager.domain.band.repository.BandMemberRepository
+import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
+import com.bandage.bandmanager.global.notify.resolver.NotificationPayload
+import com.bandage.bandmanager.global.notify.resolver.NotifyPayloadResolver
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+/**
+ * AUTHORITY_PROMOTION: 리더 승격 시 새 리더에게 알림.
+ * 트리거: BandService.changeLeader(bandId, bandMemberId, memberId) — bandMemberId 가 새 리더.
+ */
+@Component
+class AuthorityPromotionResolver(
+    private val bandMemberRepository: BandMemberRepository,
+) : NotifyPayloadResolver {
+    override val category = NotifyCategory.AUTHORITY_PROMOTION
+
+    override fun resolve(
+        args: Array<Any?>,
+        returnValue: Any?,
+    ): List<NotificationPayload> {
+        val bandId = args[0] as UUID
+        val bandMemberId = args[1] as UUID
+        val newLeader = bandMemberRepository.findByIdOrNull(bandMemberId) ?: return emptyList()
+
+        return listOf(
+            NotificationPayload(
+                recipientId = newLeader.member,
+                category = category,
+                title = "밴드 리더 승격",
+                message = "밴드의 새로운 리더로 승격되었습니다.",
+                referenceId = bandId.toString(),
+            ),
+        )
+    }
+}

--- a/src/main/kotlin/com/bandage/bandmanager/domain/band/notify/BandApplicationResolver.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/band/notify/BandApplicationResolver.kt
@@ -1,0 +1,38 @@
+package com.bandage.bandmanager.domain.band.notify
+
+import com.bandage.bandmanager.domain.band.model.enums.BandRole
+import com.bandage.bandmanager.domain.band.repository.BandMemberRepository
+import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
+import com.bandage.bandmanager.global.notify.resolver.NotificationPayload
+import com.bandage.bandmanager.global.notify.resolver.NotifyPayloadResolver
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+/**
+ * BAND_APPLICATION: 가입 신청 발생 시 밴드 리더(들)에게 알림.
+ * 트리거: BandService.createBandApplication(bandId: UUID, memberId: Long)
+ */
+@Component
+class BandApplicationResolver(
+    private val bandMemberRepository: BandMemberRepository,
+) : NotifyPayloadResolver {
+    override val category = NotifyCategory.BAND_APPLICATION
+
+    override fun resolve(
+        args: Array<Any?>,
+        returnValue: Any?,
+    ): List<NotificationPayload> {
+        val bandId = args[0] as UUID
+        return bandMemberRepository
+            .findAllByBandIdAndRole(bandId, BandRole.LEADER)
+            .map { leader ->
+                NotificationPayload(
+                    recipientId = leader.member,
+                    category = category,
+                    title = "새로운 가입 신청",
+                    message = "밴드에 새로운 가입 신청이 접수되었습니다.",
+                    referenceId = bandId.toString(),
+                )
+            }
+    }
+}

--- a/src/main/kotlin/com/bandage/bandmanager/domain/band/notify/BandApplicationResultResolver.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/band/notify/BandApplicationResultResolver.kt
@@ -1,0 +1,49 @@
+package com.bandage.bandmanager.domain.band.notify
+
+import com.bandage.bandmanager.domain.band.model.enums.ApplicationStatus
+import com.bandage.bandmanager.domain.band.repository.BandApplicationRepository
+import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
+import com.bandage.bandmanager.global.notify.resolver.NotificationPayload
+import com.bandage.bandmanager.global.notify.resolver.NotifyPayloadResolver
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+/**
+ * BAND_APPLICATION_RESULT: 가입 신청 승인/거절 결과를 신청자에게 알림.
+ * 트리거: BandService.processBandApplication(bandId, bandApplicationId, memberId, status)
+ *
+ * @AfterReturning 시점엔 신청 상태가 이미 변경되어 있으나 신청자(member)는 불변이므로 재조회로 추출한다.
+ */
+@Component
+class BandApplicationResultResolver(
+    private val applicationRepository: BandApplicationRepository,
+) : NotifyPayloadResolver {
+    override val category = NotifyCategory.BAND_APPLICATION_RESULT
+
+    override fun resolve(
+        args: Array<Any?>,
+        returnValue: Any?,
+    ): List<NotificationPayload> {
+        val bandApplicationId = args[1] as UUID
+        val status = args[3] as ApplicationStatus
+        val application = applicationRepository.findByIdOrNull(bandApplicationId) ?: return emptyList()
+
+        val (title, message) =
+            when (status) {
+                ApplicationStatus.APPROVED -> "가입 신청 승인" to "밴드 가입 신청이 승인되었습니다."
+                ApplicationStatus.REJECTED -> "가입 신청 거절" to "밴드 가입 신청이 거절되었습니다."
+                else -> return emptyList()
+            }
+
+        return listOf(
+            NotificationPayload(
+                recipientId = application.member,
+                category = category,
+                title = title,
+                message = message,
+                referenceId = application.band.id.toString(),
+            ),
+        )
+    }
+}

--- a/src/main/kotlin/com/bandage/bandmanager/domain/band/repository/BandMemberRepository.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/band/repository/BandMemberRepository.kt
@@ -65,4 +65,11 @@ interface BandMemberRepository :
     fun findAllByBand(band: Band): List<BandMember>
 
     fun countByMember(member: Long): Long
+
+    // 알림(BAND_APPLICATION) 수신자 조회: 밴드의 특정 역할 멤버 목록
+    @Query("SELECT bm FROM BandMember bm WHERE bm.band.id = :bandId AND bm.role = :role")
+    fun findAllByBandIdAndRole(
+        @Param("bandId") bandId: UUID,
+        @Param("role") role: BandRole,
+    ): List<BandMember>
 }

--- a/src/main/kotlin/com/bandage/bandmanager/domain/band/service/BandService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/band/service/BandService.kt
@@ -27,6 +27,8 @@ import com.bandage.bandmanager.global.common.response.CursorResponse
 import com.bandage.bandmanager.global.error.errorcode.ErrorCode
 import com.bandage.bandmanager.global.error.exception.BusinessException
 import com.bandage.bandmanager.global.infra.s3.CloudFrontUrlResolver
+import com.bandage.bandmanager.global.notify.annotation.Notify
+import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -64,6 +66,7 @@ class BandService(
         return BandResponse.of(band)
     }
 
+    @Notify(NotifyCategory.BAND_APPLICATION)
     @Transactional
     fun createBandApplication(
         bandId: UUID,
@@ -186,6 +189,7 @@ class BandService(
         application.updateStatus(ApplicationStatus.WITHDRAWN)
     }
 
+    @Notify(NotifyCategory.BAND_APPLICATION_RESULT)
     @Transactional
     fun processBandApplication(
         bandId: UUID,
@@ -206,7 +210,7 @@ class BandService(
         }
     }
 
-    // TODO: 알림 이벤트 publish 구현
+    @Notify(NotifyCategory.AUTHORITY_PROMOTION)
     @Transactional
     fun changeLeader(
         bandId: UUID,

--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/repository/JamRepository.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/repository/JamRepository.kt
@@ -2,10 +2,20 @@ package com.bandage.bandmanager.domain.jam.repository
 
 import com.bandage.bandmanager.domain.jam.model.Jam
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 import java.util.UUID
 
 @Repository
 interface JamRepository :
     JpaRepository<Jam, UUID>,
-    JamRepositoryCustom
+    JamRepositoryCustom {
+    // 임박 합주 알림 스케줄러용: [from, to) 구간에 시작하는 합주 조회
+    @Query("SELECT j FROM Jam j WHERE j.timeInfo.startAt >= :from AND j.timeInfo.startAt < :to")
+    fun findUpcomingBetween(
+        @Param("from") from: LocalDateTime,
+        @Param("to") to: LocalDateTime,
+    ): List<Jam>
+}

--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/scheduler/JamReminderScheduler.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/scheduler/JamReminderScheduler.kt
@@ -1,0 +1,63 @@
+package com.bandage.bandmanager.domain.jam.scheduler
+
+import com.bandage.bandmanager.domain.jam.repository.JamRepository
+import com.bandage.bandmanager.domain.notify.repository.NotificationRepository
+import com.bandage.bandmanager.global.async.publisher.EventPublisher
+import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
+import com.bandage.bandmanager.global.notify.event.NotificationCreateEvent
+import com.bandage.bandmanager.global.notify.resolver.NotificationPayload
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+/**
+ * 임박한 합주(시작 [REMIND_BEFORE_HOURS, +1h) 구간) 참여자에게 JAM_UPCOMING 알림을 생성한다.
+ *
+ * - AOP 경로가 아니므로 NotificationCreateEvent 를 직접 발행해 동일 저장 파이프라인을 재사용한다.
+ * - 멱등성: (recipientId, JAM_UPCOMING, jamId) 가 이미 있으면 제외하여 중복/재실행에도 1회만 생성.
+ * - @Transactional(readOnly): jam.participants(LAZY) 로딩 + 커밋 시 AFTER_COMMIT 핸들러 발화.
+ */
+@Component
+class JamReminderScheduler(
+    private val jamRepository: JamRepository,
+    private val notificationRepository: NotificationRepository,
+    private val eventPublisher: EventPublisher,
+) {
+    @Scheduled(cron = "0 0 * * * *")
+    @Transactional(readOnly = true)
+    fun remindUpcomingJams() {
+        val from = LocalDateTime.now().plusHours(REMIND_BEFORE_HOURS)
+        val to = from.plusHours(1)
+
+        val payloads =
+            jamRepository.findUpcomingBetween(from, to).flatMap { jam ->
+                jam.participants
+                    .map { it.member }
+                    .distinct()
+                    .filter { memberId ->
+                        !notificationRepository.existsByRecipientIdAndCategoryAndReferenceId(
+                            memberId,
+                            NotifyCategory.JAM_UPCOMING,
+                            jam.id.toString(),
+                        )
+                    }.map { memberId ->
+                        NotificationPayload(
+                            recipientId = memberId,
+                            category = NotifyCategory.JAM_UPCOMING,
+                            title = "다가오는 합주",
+                            message = "'${jam.title}' 합주가 곧 시작됩니다.",
+                            referenceId = jam.id.toString(),
+                        )
+                    }
+            }
+
+        if (payloads.isNotEmpty()) {
+            eventPublisher.publish(NotificationCreateEvent(payloads))
+        }
+    }
+
+    companion object {
+        const val REMIND_BEFORE_HOURS = 24L
+    }
+}

--- a/src/main/kotlin/com/bandage/bandmanager/domain/notify/controller/NotificationController.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/notify/controller/NotificationController.kt
@@ -1,0 +1,75 @@
+package com.bandage.bandmanager.domain.notify.controller
+
+import com.bandage.bandmanager.domain.notify.dto.req.NotificationPagingQuery
+import com.bandage.bandmanager.domain.notify.dto.res.NotificationResponse
+import com.bandage.bandmanager.domain.notify.dto.res.UnreadCountResponse
+import com.bandage.bandmanager.domain.notify.service.NotificationService
+import com.bandage.bandmanager.global.common.constants.PathPrefix.PREFIX
+import com.bandage.bandmanager.global.common.response.ApiResponse
+import com.bandage.bandmanager.global.common.response.CursorResponse
+import com.bandage.bandmanager.global.security.annotation.CurrentMemberId
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@Tag(name = "notifications", description = "알림 API")
+@RestController
+@RequestMapping("$PREFIX/notifications")
+class NotificationController(
+    private val notificationService: NotificationService,
+) {
+    @GetMapping
+    @Operation(
+        operationId = "getMyNotifications",
+        summary = "내 알림 목록 조회 API",
+        description = "로그인한 회원의 전체 알림을 커서 기반 최신순으로 조회합니다. 카테고리 필터링은 프론트가 처리합니다.",
+    )
+    fun getMyNotifications(
+        @Valid query: NotificationPagingQuery,
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<CursorResponse<NotificationResponse, UUID>> =
+        ApiResponse.success(notificationService.getMyNotifications(memberId, query))
+
+    @GetMapping("/unread-count")
+    @Operation(
+        operationId = "getUnreadNotificationCount",
+        summary = "미확인 알림 개수 조회 API",
+        description = "로그인한 회원의 읽지 않은 알림 개수를 조회합니다.",
+    )
+    fun getUnreadCount(
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<UnreadCountResponse> = ApiResponse.success(UnreadCountResponse(notificationService.getUnreadCount(memberId)))
+
+    @PatchMapping("/{notificationId}/read")
+    @Operation(
+        operationId = "markNotificationAsRead",
+        summary = "알림 읽음 처리 API",
+        description = "특정 알림을 읽음 처리합니다. 본인 소유 알림만 처리할 수 있습니다.",
+    )
+    fun markAsRead(
+        @PathVariable notificationId: UUID,
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<Unit> {
+        notificationService.markAsRead(memberId, notificationId)
+        return ApiResponse.success()
+    }
+
+    @PatchMapping("/read-all")
+    @Operation(
+        operationId = "markAllNotificationsAsRead",
+        summary = "전체 알림 읽음 처리 API",
+        description = "로그인한 회원의 읽지 않은 모든 알림을 일괄 읽음 처리합니다.",
+    )
+    fun markAllAsRead(
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<Unit> {
+        notificationService.markAllAsRead(memberId)
+        return ApiResponse.success()
+    }
+}

--- a/src/main/kotlin/com/bandage/bandmanager/domain/notify/dto/req/NotificationPagingQuery.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/notify/dto/req/NotificationPagingQuery.kt
@@ -1,0 +1,16 @@
+package com.bandage.bandmanager.domain.notify.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import java.util.UUID
+
+@Schema(description = "알림 목록 조회 쿼리")
+data class NotificationPagingQuery(
+    @Schema(description = "마지막으로 조회된 알림 ID (커서)", example = "550e8400-e29b-41d4-a716-446655440000")
+    val lastId: UUID?,
+    @field:Min(1)
+    @field:Max(100)
+    @Schema(description = "페이지 크기", example = "20")
+    val pageSize: Int = 20,
+)

--- a/src/main/kotlin/com/bandage/bandmanager/domain/notify/dto/res/NotificationResponse.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/notify/dto/res/NotificationResponse.kt
@@ -1,0 +1,44 @@
+package com.bandage.bandmanager.domain.notify.dto.res
+
+import com.bandage.bandmanager.domain.notify.model.Notification
+import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
+import com.fasterxml.jackson.annotation.JsonFormat
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Schema(description = "알림 응답")
+data class NotificationResponse(
+    @Schema(description = "알림 고유 식별자 (UUID)", example = "550e8400-e29b-41d4-a716-446655440000")
+    val id: UUID,
+    @Schema(description = "알림 카테고리 (프론트 필터 키)", example = "BAND_APPLICATION")
+    val category: NotifyCategory,
+    @Schema(description = "알림 제목", example = "새로운 가입 신청")
+    val title: String,
+    @Schema(description = "알림 메시지", example = "밴드에 새로운 가입 신청이 접수되었습니다.")
+    val message: String,
+    @Schema(description = "연관 리소스 ID (밴드/합주 등, 딥링크용)", example = "550e8400-e29b-41d4-a716-446655440000")
+    val referenceId: String?,
+    @Schema(description = "읽음 여부", example = "false")
+    val isRead: Boolean,
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm", shape = JsonFormat.Shape.STRING, timezone = "Asia/Seoul")
+    @Schema(description = "읽은 시각", example = "2026-06-20 18:00")
+    val readAt: LocalDateTime?,
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm", shape = JsonFormat.Shape.STRING, timezone = "Asia/Seoul")
+    @Schema(description = "생성 시각", example = "2026-06-20 17:30")
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun of(notification: Notification): NotificationResponse =
+            NotificationResponse(
+                id = notification.id,
+                category = notification.category,
+                title = notification.title,
+                message = notification.message,
+                referenceId = notification.referenceId,
+                isRead = notification.isRead,
+                readAt = notification.readAt,
+                createdAt = notification.createdAt,
+            )
+    }
+}

--- a/src/main/kotlin/com/bandage/bandmanager/domain/notify/dto/res/UnreadCountResponse.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/notify/dto/res/UnreadCountResponse.kt
@@ -1,0 +1,9 @@
+package com.bandage.bandmanager.domain.notify.dto.res
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "미확인 알림 개수 응답")
+data class UnreadCountResponse(
+    @Schema(description = "미확인(읽지 않은) 알림 개수", example = "3")
+    val count: Long,
+)

--- a/src/main/kotlin/com/bandage/bandmanager/domain/notify/event/NotificationEventHandler.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/notify/event/NotificationEventHandler.kt
@@ -1,0 +1,24 @@
+package com.bandage.bandmanager.domain.notify.event
+
+import com.bandage.bandmanager.domain.notify.service.NotificationService
+import com.bandage.bandmanager.global.notify.event.NotificationCreateEvent
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+/**
+ * 비즈니스 트랜잭션 커밋 후(AFTER_COMMIT) 비동기로 알림을 저장한다.
+ * - 비즈니스 롤백 시 호출되지 않아 알림이 생성되지 않는다.
+ * - @Async 별도 스레드(트랜잭션 없음)이므로 createAll 이 자체 @Transactional 로 저장한다.
+ */
+@Component
+class NotificationEventHandler(
+    private val notificationService: NotificationService,
+) {
+    @Async("notificationExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handle(event: NotificationCreateEvent) {
+        notificationService.createAll(event.payloads)
+    }
+}

--- a/src/main/kotlin/com/bandage/bandmanager/domain/notify/model/Notification.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/notify/model/Notification.kt
@@ -1,0 +1,85 @@
+package com.bandage.bandmanager.domain.notify.model
+
+import com.bandage.bandmanager.global.common.domain.BaseEntity
+import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
+import com.bandage.bandmanager.global.notify.resolver.NotificationPayload
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import org.hibernate.annotations.SQLRestriction
+import org.hibernate.annotations.UuidGenerator
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * 수신자별 1행(한 사건이 N명에게 가면 N개 row) 모델. 개인별 읽음 상태 관리를 단순화한다.
+ */
+@Entity
+@Table(
+    name = "p_notification",
+    indexes = [
+        Index(name = "idx_notification__recipient", columnList = "recipient_id, created_at"),
+        Index(name = "idx_notification__idempotency", columnList = "recipient_id, category, reference_id"),
+    ],
+)
+@SQLRestriction("deleted_at IS NULL")
+open class Notification(
+    recipientId: Long,
+    category: NotifyCategory,
+    title: String,
+    message: String,
+    referenceId: String? = null,
+) : BaseEntity() {
+    @Id
+    @Column(name = "notification_id")
+    @UuidGenerator(style = UuidGenerator.Style.VERSION_7)
+    lateinit var id: UUID
+        protected set
+
+    @Column(name = "recipient_id", nullable = false)
+    val recipientId: Long = recipientId
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false, length = 50)
+    val category: NotifyCategory = category
+
+    @Column(name = "title", nullable = false)
+    val title: String = title
+
+    @Column(name = "message", nullable = false, length = 500)
+    val message: String = message
+
+    // 연관 리소스(밴드/합주) id. 프론트 딥링크/멱등성 키.
+    @Column(name = "reference_id")
+    val referenceId: String? = referenceId
+
+    @Column(name = "is_read", nullable = false)
+    var isRead: Boolean = false
+        protected set
+
+    @Column(name = "read_at")
+    var readAt: LocalDateTime? = null
+        protected set
+
+    companion object {
+        fun create(payload: NotificationPayload): Notification =
+            Notification(
+                recipientId = payload.recipientId,
+                category = payload.category,
+                title = payload.title,
+                message = payload.message,
+                referenceId = payload.referenceId,
+            )
+    }
+
+    fun markAsRead() {
+        if (!isRead) {
+            isRead = true
+            readAt = LocalDateTime.now()
+        }
+    }
+}

--- a/src/main/kotlin/com/bandage/bandmanager/domain/notify/repository/NotificationRepository.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/notify/repository/NotificationRepository.kt
@@ -1,0 +1,35 @@
+package com.bandage.bandmanager.domain.notify.repository
+
+import com.bandage.bandmanager.domain.notify.model.Notification
+import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Repository
+interface NotificationRepository :
+    JpaRepository<Notification, UUID>,
+    NotificationRepositoryCustom {
+    fun countByRecipientIdAndIsReadFalse(recipientId: Long): Long
+
+    // 스케줄러 멱등성: 동일 (수신자, 카테고리, 리소스) 알림 존재 여부
+    fun existsByRecipientIdAndCategoryAndReferenceId(
+        recipientId: Long,
+        category: NotifyCategory,
+        referenceId: String,
+    ): Boolean
+
+    @Modifying(clearAutomatically = true)
+    @Query(
+        "UPDATE Notification n SET n.isRead = true, n.readAt = :now " +
+            "WHERE n.recipientId = :recipientId AND n.isRead = false AND n.deletedAt IS NULL",
+    )
+    fun markAllAsReadByRecipient(
+        @Param("recipientId") recipientId: Long,
+        @Param("now") now: LocalDateTime,
+    ): Int
+}

--- a/src/main/kotlin/com/bandage/bandmanager/domain/notify/repository/NotificationRepositoryCustom.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/notify/repository/NotificationRepositoryCustom.kt
@@ -1,0 +1,13 @@
+package com.bandage.bandmanager.domain.notify.repository
+
+import com.bandage.bandmanager.domain.notify.model.Notification
+import com.bandage.bandmanager.global.common.response.CursorResponse
+import java.util.UUID
+
+interface NotificationRepositoryCustom {
+    fun findAllByRecipientIdWithCursor(
+        recipientId: Long,
+        lastId: UUID?,
+        pageSize: Int,
+    ): CursorResponse<Notification, UUID>
+}

--- a/src/main/kotlin/com/bandage/bandmanager/domain/notify/repository/NotificationRepositoryImpl.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/notify/repository/NotificationRepositoryImpl.kt
@@ -1,0 +1,41 @@
+package com.bandage.bandmanager.domain.notify.repository
+
+import com.bandage.bandmanager.domain.notify.model.Notification
+import com.bandage.bandmanager.domain.notify.model.QNotification
+import com.bandage.bandmanager.global.common.response.CursorResponse
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.impl.JPAQueryFactory
+import java.util.UUID
+
+class NotificationRepositoryImpl(
+    private val queryFactory: JPAQueryFactory,
+) : NotificationRepositoryCustom {
+    override fun findAllByRecipientIdWithCursor(
+        recipientId: Long,
+        lastId: UUID?,
+        pageSize: Int,
+    ): CursorResponse<Notification, UUID> {
+        val qNotification = QNotification.notification
+
+        val contents =
+            queryFactory
+                .selectFrom(qNotification)
+                .where(qNotification.recipientId.eq(recipientId))
+                .where(ltNotificationId(lastId))
+                .orderBy(qNotification.id.desc())
+                .limit(pageSize.toLong() + 1)
+                .fetch()
+
+        val hasNext = contents.size > pageSize
+        val resultContents = if (hasNext) contents.dropLast(1) else contents
+        val nextCursor = if (hasNext) resultContents.lastOrNull()?.id else null
+
+        return CursorResponse(
+            content = resultContents,
+            nextCursor = nextCursor,
+            hasNext = hasNext,
+        )
+    }
+
+    private fun ltNotificationId(lastId: UUID?): BooleanExpression? = lastId?.let { QNotification.notification.id.lt(it) }
+}

--- a/src/main/kotlin/com/bandage/bandmanager/domain/notify/service/NotificationService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/notify/service/NotificationService.kt
@@ -1,0 +1,62 @@
+package com.bandage.bandmanager.domain.notify.service
+
+import com.bandage.bandmanager.domain.notify.dto.req.NotificationPagingQuery
+import com.bandage.bandmanager.domain.notify.dto.res.NotificationResponse
+import com.bandage.bandmanager.domain.notify.model.Notification
+import com.bandage.bandmanager.domain.notify.repository.NotificationRepository
+import com.bandage.bandmanager.global.common.response.CursorResponse
+import com.bandage.bandmanager.global.error.errorcode.ErrorCode
+import com.bandage.bandmanager.global.error.exception.BusinessException
+import com.bandage.bandmanager.global.notify.resolver.NotificationPayload
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Service
+@Transactional(readOnly = true)
+class NotificationService(
+    private val notificationRepository: NotificationRepository,
+) {
+    /**
+     * 이벤트 핸들러(@Async, AFTER_COMMIT)에서 호출. 비동기 스레드에는 트랜잭션이 없으므로
+     * 자체 @Transactional 로 저장한다. 대량 수신자는 saveAll 배치 insert.
+     */
+    @Transactional
+    fun createAll(payloads: List<NotificationPayload>) {
+        if (payloads.isEmpty()) return
+        notificationRepository.saveAll(payloads.map { Notification.create(it) })
+    }
+
+    fun getMyNotifications(
+        memberId: Long,
+        query: NotificationPagingQuery,
+    ): CursorResponse<NotificationResponse, UUID> {
+        val result = notificationRepository.findAllByRecipientIdWithCursor(memberId, query.lastId, query.pageSize)
+        return CursorResponse(
+            content = result.content.map { NotificationResponse.of(it) },
+            nextCursor = result.nextCursor,
+            hasNext = result.hasNext,
+        )
+    }
+
+    fun getUnreadCount(memberId: Long): Long = notificationRepository.countByRecipientIdAndIsReadFalse(memberId)
+
+    @Transactional
+    fun markAsRead(
+        memberId: Long,
+        notificationId: UUID,
+    ) {
+        val notification =
+            notificationRepository.findByIdOrNull(notificationId)
+                ?: throw BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND)
+        if (notification.recipientId != memberId) {
+            throw BusinessException(ErrorCode.NOTIFICATION_FORBIDDEN)
+        }
+        notification.markAsRead()
+    }
+
+    @Transactional
+    fun markAllAsRead(memberId: Long): Int = notificationRepository.markAllAsReadByRecipient(memberId, LocalDateTime.now())
+}

--- a/src/main/kotlin/com/bandage/bandmanager/global/async/event/EventType.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/global/async/event/EventType.kt
@@ -5,4 +5,5 @@ enum class EventType {
     MEMBER_LOGIN,
     MEMBER_LOGOUT,
     MEMBER_WITHDRAW,
+    NOTIFICATION_CREATE,
 }

--- a/src/main/kotlin/com/bandage/bandmanager/global/error/errorcode/ErrorCode.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/global/error/errorcode/ErrorCode.kt
@@ -111,4 +111,8 @@ enum class ErrorCode(
     INVALID_FILE_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "허용되지 않는 파일 타입입니다."),
     INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "허용되지 않는 파일 확장자입니다."),
     FILE_SIZE_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "허용된 파일 크기를 초과했습니다."),
+
+    // notify
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 알림 정보를 찾을 수 없습니다."),
+    NOTIFICATION_FORBIDDEN(HttpStatus.FORBIDDEN, "알림에 접근할 권한이 없습니다."),
 }

--- a/src/main/kotlin/com/bandage/bandmanager/global/notify/annotation/Notify.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/global/notify/annotation/Notify.kt
@@ -1,0 +1,13 @@
+package com.bandage.bandmanager.global.notify.annotation
+
+/**
+ * 서비스 메서드에 부착하면 정상 반환 시 해당 [category] 의 알림이 생성된다.
+ *
+ * 수신자/내용은 카테고리별 NotifyPayloadResolver 가 메서드 인자/반환값에서 추출한다.
+ * 부착 메서드는 반드시 @Transactional 컨텍스트여야 한다(AFTER_COMMIT 리스너 동작 보장).
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Notify(
+    val category: NotifyCategory,
+)

--- a/src/main/kotlin/com/bandage/bandmanager/global/notify/annotation/NotifyCategory.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/global/notify/annotation/NotifyCategory.kt
@@ -1,0 +1,14 @@
+package com.bandage.bandmanager.global.notify.annotation
+
+/**
+ * 알림 카테고리. 프론트 필터링 키이자 @Notify 트리거의 분류 기준.
+ *
+ * 추가/삭제가 빈번하므로 DB 에는 @Enumerated(EnumType.STRING) 으로 저장한다
+ * (ORDINAL 은 순서 변경 시 기존 데이터 의미가 깨진다).
+ */
+enum class NotifyCategory {
+    BAND_APPLICATION, // 가입 신청 발생 → 밴드 리더(들)에게
+    BAND_APPLICATION_RESULT, // 신청 승인/거절 결과 → 신청자에게
+    AUTHORITY_PROMOTION, // 권한 승격(리더 승격 등) → 승격된 멤버에게
+    JAM_UPCOMING, // 임박한 합주 → 참여자에게
+}

--- a/src/main/kotlin/com/bandage/bandmanager/global/notify/aspect/NotifyAspect.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/global/notify/aspect/NotifyAspect.kt
@@ -1,0 +1,45 @@
+package com.bandage.bandmanager.global.notify.aspect
+
+import com.bandage.bandmanager.global.async.publisher.EventPublisher
+import com.bandage.bandmanager.global.notify.annotation.Notify
+import com.bandage.bandmanager.global.notify.event.NotificationCreateEvent
+import com.bandage.bandmanager.global.notify.resolver.support.NotifyResolverRegistry
+import org.aspectj.lang.JoinPoint
+import org.aspectj.lang.annotation.AfterReturning
+import org.aspectj.lang.annotation.Aspect
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+
+/**
+ * @Notify 가 붙은 메서드가 정상 반환하면, category 의 Resolver 로 수신자/내용을 추출해
+ * NotificationCreateEvent 를 발행한다.
+ *
+ * ⚠️ 순서 제약: 트랜잭션 어드바이스(@EnableTransactionManagement(order = 0))보다 안쪽(ORDER = 100)이어야
+ * 발행이 활성 트랜잭션 내부에서 일어나, AFTER_COMMIT 핸들러가 동작한다. (NotifyAsyncConfig 참고)
+ */
+@Aspect
+@Component
+@Order(NotifyAspect.ORDER)
+class NotifyAspect(
+    private val registry: NotifyResolverRegistry,
+    private val eventPublisher: EventPublisher,
+) {
+    @AfterReturning(
+        pointcut = "@annotation(notify)",
+        returning = "returnValue",
+    )
+    fun afterReturning(
+        joinPoint: JoinPoint,
+        notify: Notify,
+        returnValue: Any?,
+    ) {
+        val payloads = registry.resolve(notify.category, joinPoint.args, returnValue)
+        if (payloads.isNotEmpty()) {
+            eventPublisher.publish(NotificationCreateEvent(payloads))
+        }
+    }
+
+    companion object {
+        const val ORDER = 100
+    }
+}

--- a/src/main/kotlin/com/bandage/bandmanager/global/notify/config/NotifyAsyncConfig.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/global/notify/config/NotifyAsyncConfig.kt
@@ -1,0 +1,32 @@
+package com.bandage.bandmanager.global.notify.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.task.TaskExecutor
+import org.springframework.scheduling.annotation.EnableScheduling
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import org.springframework.transaction.annotation.EnableTransactionManagement
+
+/**
+ * 알림 도메인 비동기/스케줄링/트랜잭션 순서 설정.
+ *
+ * - `@EnableTransactionManagement(order = 0)`: 트랜잭션 어드바이스를 가장 바깥쪽(우선순위 최상)에 둔다.
+ *   NotifyAspect(@Order(100)) 가 트랜잭션보다 안쪽에서 실행되어, 이벤트 발행이 활성 트랜잭션 내부에서
+ *   일어나도록 보장한다. 이 순서가 어긋나면 @TransactionalEventListener(AFTER_COMMIT) 가 호출되지 않는다.
+ * - `notificationExecutor`: AFTER_COMMIT 핸들러의 @Async 전용 풀.
+ */
+@Configuration
+@EnableScheduling
+@EnableTransactionManagement(order = 0)
+class NotifyAsyncConfig {
+    @Bean("notificationExecutor")
+    fun notificationExecutor(): TaskExecutor =
+        ThreadPoolTaskExecutor().apply {
+            corePoolSize = 2
+            maxPoolSize = 5
+            queueCapacity = 500
+            setThreadNamePrefix("notify-")
+            setWaitForTasksToCompleteOnShutdown(true)
+            initialize()
+        }
+}

--- a/src/main/kotlin/com/bandage/bandmanager/global/notify/event/NotificationCreateEvent.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/global/notify/event/NotificationCreateEvent.kt
@@ -1,0 +1,18 @@
+package com.bandage.bandmanager.global.notify.event
+
+import com.bandage.bandmanager.global.async.event.CommonEvent
+import com.bandage.bandmanager.global.async.event.EventType
+import com.bandage.bandmanager.global.notify.resolver.NotificationPayload
+
+/**
+ * 알림 생성 요청 이벤트. AOP 트리거(NotifyAspect)와 스케줄러가 공유하는 수렴점.
+ * AFTER_COMMIT 핸들러가 수신해 저장한다.
+ *
+ * Modulith 경계상 트리거(global)가 발행하므로 global 에 둔다(domain 은 이를 구독만).
+ */
+class NotificationCreateEvent(
+    val payloads: List<NotificationPayload>,
+) : CommonEvent(
+        eventType = EventType.NOTIFICATION_CREATE,
+        aggregateId = payloads.firstOrNull()?.recipientId?.toString() ?: "0",
+    )

--- a/src/main/kotlin/com/bandage/bandmanager/global/notify/resolver/NotificationPayload.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/global/notify/resolver/NotificationPayload.kt
@@ -1,0 +1,16 @@
+package com.bandage.bandmanager.global.notify.resolver
+
+import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
+
+/**
+ * 알림 생성 단위. "누구에게(recipientId) 무엇을(title/message)".
+ *
+ * @property referenceId 연관 리소스(밴드/합주 등) id. 프론트 딥링크/멱등성 키로 사용.
+ */
+data class NotificationPayload(
+    val recipientId: Long,
+    val category: NotifyCategory,
+    val title: String,
+    val message: String,
+    val referenceId: String? = null,
+)

--- a/src/main/kotlin/com/bandage/bandmanager/global/notify/resolver/NotifyPayloadResolver.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/global/notify/resolver/NotifyPayloadResolver.kt
@@ -1,0 +1,23 @@
+package com.bandage.bandmanager.global.notify.resolver
+
+import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
+
+/**
+ * 카테고리별 수신자/내용 추출 전략.
+ *
+ * 구현체는 해당 도메인 엔티티를 직접 다루므로 Modulith 경계를 위해 각 도메인 패키지
+ * (예: domain/band/notify/) 에 둔다. 인터페이스만 global 에 둔다(의존 방향 domain → global).
+ */
+interface NotifyPayloadResolver {
+    val category: NotifyCategory
+
+    /**
+     * @param args 대상 메서드 인자 배열(JoinPoint.args)
+     * @param returnValue 대상 메서드 반환값(void 이면 null)
+     * @return 생성할 알림 목록(수신자별 1건). 비어 있으면 알림 미생성.
+     */
+    fun resolve(
+        args: Array<Any?>,
+        returnValue: Any?,
+    ): List<NotificationPayload>
+}

--- a/src/main/kotlin/com/bandage/bandmanager/global/notify/resolver/support/NotifyResolverRegistry.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/global/notify/resolver/support/NotifyResolverRegistry.kt
@@ -1,0 +1,23 @@
+package com.bandage.bandmanager.global.notify.resolver.support
+
+import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
+import com.bandage.bandmanager.global.notify.resolver.NotificationPayload
+import com.bandage.bandmanager.global.notify.resolver.NotifyPayloadResolver
+import org.springframework.stereotype.Component
+
+/**
+ * 모든 NotifyPayloadResolver 빈을 category 로 매핑해 디스패치한다.
+ * 등록되지 않은 카테고리는 빈 리스트(알림 미생성)를 반환한다.
+ */
+@Component
+class NotifyResolverRegistry(
+    resolvers: List<NotifyPayloadResolver>,
+) {
+    private val byCategory: Map<NotifyCategory, NotifyPayloadResolver> = resolvers.associateBy { it.category }
+
+    fun resolve(
+        category: NotifyCategory,
+        args: Array<Any?>,
+        returnValue: Any?,
+    ): List<NotificationPayload> = byCategory[category]?.resolve(args, returnValue) ?: emptyList()
+}

--- a/src/main/resources/db/changelog/changes/016-notification.sql
+++ b/src/main/resources/db/changelog/changes/016-notification.sql
@@ -1,0 +1,27 @@
+-- BD-81: 알림(Notification) 도메인 테이블 신설
+-- category 는 enum 을 STRING(varchar)으로 저장한다. 알림 카테고리는 추가/삭제가 빈번하고
+-- 프론트 필터 키로 쓰이므로, 순서 변경에 취약한 smallint(ORDINAL) 대신 varchar 를 사용한다.
+
+CREATE TABLE public.p_notification (
+    notification_id uuid NOT NULL,
+    recipient_id bigint NOT NULL,
+    category character varying(50) NOT NULL,
+    title character varying(255) NOT NULL,
+    message character varying(500) NOT NULL,
+    reference_id character varying(255),
+    is_read boolean NOT NULL DEFAULT false,
+    read_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    created_by bigint,
+    last_modified_at timestamp(6) without time zone NOT NULL,
+    last_modified_by bigint,
+    deleted_at timestamp(6) without time zone,
+    deleted_by bigint,
+    CONSTRAINT p_notification_pkey PRIMARY KEY (notification_id)
+);
+
+-- 수신자별 최신순 조회
+CREATE INDEX idx_notification__recipient ON public.p_notification (recipient_id, created_at);
+
+-- 스케줄러 멱등성 조회(recipient_id + category + reference_id)
+CREATE INDEX idx_notification__idempotency ON public.p_notification (recipient_id, category, reference_id);

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -186,3 +186,17 @@ databaseChangeLog:
             splitStatements: true
             stripComments: true
             endDelimiter: ";"
+  - changeSet:
+      id: 016-notification
+      author: bandage
+      comment: |
+        BD-81: 알림(Notification) 도메인 테이블 신설
+        - p_notification (수신자별 1행, category varchar STRING, is_read/read_at 읽음 처리)
+        - 조회/멱등성 인덱스 추가
+      changes:
+        - sqlFile:
+            path: changes/016-notification.sql
+            relativeToChangelogFile: true
+            splitStatements: true
+            stripComments: true
+            endDelimiter: ";"

--- a/src/test/kotlin/com/bandage/bandmanager/domain/band/notify/AuthorityPromotionResolverTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/band/notify/AuthorityPromotionResolverTest.kt
@@ -1,0 +1,55 @@
+package com.bandage.bandmanager.domain.band.notify
+
+import com.bandage.bandmanager.domain.band.model.Band
+import com.bandage.bandmanager.domain.band.model.BandMember
+import com.bandage.bandmanager.domain.band.model.enums.BandRole
+import com.bandage.bandmanager.domain.band.repository.BandMemberRepository
+import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.util.Optional
+import java.util.UUID
+
+class AuthorityPromotionResolverTest {
+    private val bandMemberRepository = mock(BandMemberRepository::class.java)
+    private val sut = AuthorityPromotionResolver(bandMemberRepository)
+
+    @Test
+    fun `새 리더에게 승격 알림을 생성한다`() {
+        val bandId = UUID.randomUUID()
+        val bandMemberId = UUID.randomUUID()
+        val band = Band.create("밴드", "설명", null)
+        val newLeader = BandMember.create(band, 42L, BandRole.LEADER)
+        setId(newLeader, bandMemberId)
+        `when`(bandMemberRepository.findById(bandMemberId)).thenReturn(Optional.of(newLeader))
+
+        val result = sut.resolve(arrayOf<Any?>(bandId, bandMemberId, 1L), null)
+
+        assertThat(result).hasSize(1)
+        assertThat(result[0].recipientId).isEqualTo(42L)
+        assertThat(result[0].category).isEqualTo(NotifyCategory.AUTHORITY_PROMOTION)
+        assertThat(result[0].referenceId).isEqualTo(bandId.toString())
+    }
+
+    @Test
+    fun `대상 밴드멤버가 없으면 빈 리스트를 반환한다`() {
+        val bandId = UUID.randomUUID()
+        val bandMemberId = UUID.randomUUID()
+        `when`(bandMemberRepository.findById(bandMemberId)).thenReturn(Optional.empty())
+
+        val result = sut.resolve(arrayOf<Any?>(bandId, bandMemberId, 1L), null)
+
+        assertThat(result).isEmpty()
+    }
+
+    private fun setId(
+        target: Any,
+        id: UUID,
+    ) {
+        val field = target.javaClass.getDeclaredField("id")
+        field.isAccessible = true
+        field.set(target, id)
+    }
+}

--- a/src/test/kotlin/com/bandage/bandmanager/domain/band/notify/BandApplicationResolverTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/band/notify/BandApplicationResolverTest.kt
@@ -1,0 +1,48 @@
+package com.bandage.bandmanager.domain.band.notify
+
+import com.bandage.bandmanager.domain.band.model.Band
+import com.bandage.bandmanager.domain.band.model.BandMember
+import com.bandage.bandmanager.domain.band.model.enums.BandRole
+import com.bandage.bandmanager.domain.band.repository.BandMemberRepository
+import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.util.UUID
+
+class BandApplicationResolverTest {
+    private val bandMemberRepository = mock(BandMemberRepository::class.java)
+    private val sut = BandApplicationResolver(bandMemberRepository)
+
+    private val bandId: UUID = UUID.randomUUID()
+
+    private fun leader(memberId: Long): BandMember {
+        val band = Band.create("밴드", "설명", null)
+        return BandMember.create(band, memberId, BandRole.LEADER)
+    }
+
+    @Test
+    fun `밴드 리더들에게 가입신청 알림 페이로드를 생성한다`() {
+        `when`(bandMemberRepository.findAllByBandIdAndRole(bandId, BandRole.LEADER))
+            .thenReturn(listOf(leader(10L), leader(20L)))
+
+        val result = sut.resolve(arrayOf<Any?>(bandId, 5L), null)
+
+        assertThat(result).hasSize(2)
+        assertThat(result.map { it.recipientId }).containsExactlyInAnyOrder(10L, 20L)
+        assertThat(result).allSatisfy {
+            assertThat(it.category).isEqualTo(NotifyCategory.BAND_APPLICATION)
+            assertThat(it.referenceId).isEqualTo(bandId.toString())
+        }
+    }
+
+    @Test
+    fun `리더가 없으면 빈 리스트를 반환한다`() {
+        `when`(bandMemberRepository.findAllByBandIdAndRole(bandId, BandRole.LEADER)).thenReturn(emptyList())
+
+        val result = sut.resolve(arrayOf<Any?>(bandId, 5L), null)
+
+        assertThat(result).isEmpty()
+    }
+}

--- a/src/test/kotlin/com/bandage/bandmanager/domain/band/notify/BandApplicationResultResolverTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/band/notify/BandApplicationResultResolverTest.kt
@@ -1,0 +1,71 @@
+package com.bandage.bandmanager.domain.band.notify
+
+import com.bandage.bandmanager.domain.band.model.Band
+import com.bandage.bandmanager.domain.band.model.BandApplication
+import com.bandage.bandmanager.domain.band.model.enums.ApplicationStatus
+import com.bandage.bandmanager.domain.band.repository.BandApplicationRepository
+import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.util.Optional
+import java.util.UUID
+
+class BandApplicationResultResolverTest {
+    private val applicationRepository = mock(BandApplicationRepository::class.java)
+    private val sut = BandApplicationResultResolver(applicationRepository)
+
+    private val bandId: UUID = UUID.randomUUID()
+
+    private fun application(applicantId: Long): BandApplication {
+        val band = Band.create("밴드", "설명", null)
+        setId(band, bandId)
+        val application = BandApplication.create(band, applicantId)
+        setId(application, UUID.randomUUID())
+        return application
+    }
+
+    private fun setId(
+        target: Any,
+        id: UUID,
+    ) {
+        val field = target.javaClass.getDeclaredField("id")
+        field.isAccessible = true
+        field.set(target, id)
+    }
+
+    @Test
+    fun `승인 결과를 신청자에게 알림한다`() {
+        val application = application(7L)
+        `when`(applicationRepository.findById(application.id)).thenReturn(Optional.of(application))
+
+        val result = sut.resolve(arrayOf<Any?>(bandId, application.id, 1L, ApplicationStatus.APPROVED), null)
+
+        assertThat(result).hasSize(1)
+        assertThat(result[0].recipientId).isEqualTo(7L)
+        assertThat(result[0].category).isEqualTo(NotifyCategory.BAND_APPLICATION_RESULT)
+        assertThat(result[0].referenceId).isEqualTo(bandId.toString())
+    }
+
+    @Test
+    fun `거절 결과를 신청자에게 알림한다`() {
+        val application = application(7L)
+        `when`(applicationRepository.findById(application.id)).thenReturn(Optional.of(application))
+
+        val result = sut.resolve(arrayOf<Any?>(bandId, application.id, 1L, ApplicationStatus.REJECTED), null)
+
+        assertThat(result).hasSize(1)
+        assertThat(result[0].recipientId).isEqualTo(7L)
+    }
+
+    @Test
+    fun `승인거절 외 상태는 알림을 생성하지 않는다`() {
+        val application = application(7L)
+        `when`(applicationRepository.findById(application.id)).thenReturn(Optional.of(application))
+
+        val result = sut.resolve(arrayOf<Any?>(bandId, application.id, 1L, ApplicationStatus.WITHDRAWN), null)
+
+        assertThat(result).isEmpty()
+    }
+}

--- a/src/test/kotlin/com/bandage/bandmanager/domain/jam/scheduler/JamReminderSchedulerTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/jam/scheduler/JamReminderSchedulerTest.kt
@@ -1,0 +1,117 @@
+package com.bandage.bandmanager.domain.jam.scheduler
+
+import com.bandage.bandmanager.domain.jam.model.Jam
+import com.bandage.bandmanager.domain.jam.repository.JamRepository
+import com.bandage.bandmanager.domain.notify.repository.NotificationRepository
+import com.bandage.bandmanager.global.async.event.CommonEvent
+import com.bandage.bandmanager.global.async.publisher.EventPublisher
+import com.bandage.bandmanager.global.common.domain.TrackInfo
+import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
+import com.bandage.bandmanager.global.notify.event.NotificationCreateEvent
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mockito
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.time.LocalDateTime
+import java.util.UUID
+
+class JamReminderSchedulerTest {
+    private val jamRepository = mock(JamRepository::class.java)
+    private val notificationRepository = mock(NotificationRepository::class.java)
+
+    // EventPublisher 는 fake 로 두어 발행 이벤트를 직접 캡처한다(Kotlin+Mockito any() NPE 회피).
+    private val published = mutableListOf<CommonEvent>()
+    private val eventPublisher =
+        object : EventPublisher {
+            override fun publish(event: CommonEvent) {
+                published.add(event)
+            }
+        }
+    private val sut = JamReminderScheduler(jamRepository, notificationRepository, eventPublisher)
+
+    // non-null 파라미터용 매처: Mockito eq()/any() 가 null 을 반환하면 Kotlin 이 호출 지점에서
+    // null 체크를 삽입해 NPE 가 나므로 elvis 로 non-null 을 보장한다(매처는 정상 등록됨).
+    private fun anyLocalDateTime(): LocalDateTime = Mockito.any(LocalDateTime::class.java) ?: LocalDateTime.now()
+
+    private fun eqCategory(value: NotifyCategory): NotifyCategory = eq(value) ?: value
+
+    private fun jam(vararg members: Long): Jam {
+        val jam =
+            Jam.create(
+                title = "정기합주",
+                trackInfo = TrackInfo(title = "곡", artist = "아티스트"),
+                startAt = LocalDateTime.now().plusHours(24),
+                durationMinutes = 60,
+                venue = null,
+            )
+        setId(jam, UUID.randomUUID())
+        members.forEachIndexed { idx, member -> jam.addParticipant("session-$idx", member) }
+        return jam
+    }
+
+    private fun setId(
+        target: Any,
+        id: UUID,
+    ) {
+        val field = target.javaClass.getDeclaredField("id")
+        field.isAccessible = true
+        field.set(target, id)
+    }
+
+    private fun publishedRecipients(): List<Long> =
+        published.flatMap { (it as NotificationCreateEvent).payloads.map { p -> p.recipientId } }
+
+    @Test
+    fun `임박 합주 참여자에게 알림 페이로드를 발행한다`() {
+        val jam = jam(1L, 2L)
+        `when`(jamRepository.findUpcomingBetween(anyLocalDateTime(), anyLocalDateTime())).thenReturn(listOf(jam))
+        `when`(
+            notificationRepository.existsByRecipientIdAndCategoryAndReferenceId(
+                anyLong(),
+                eqCategory(NotifyCategory.JAM_UPCOMING),
+                anyString(),
+            ),
+        ).thenReturn(false)
+
+        sut.remindUpcomingJams()
+
+        assertThat(publishedRecipients()).containsExactlyInAnyOrder(1L, 2L)
+    }
+
+    @Test
+    fun `이미 알림이 있는 참여자는 제외된다(멱등성)`() {
+        val jam = jam(1L, 2L)
+        `when`(jamRepository.findUpcomingBetween(anyLocalDateTime(), anyLocalDateTime())).thenReturn(listOf(jam))
+        `when`(
+            notificationRepository.existsByRecipientIdAndCategoryAndReferenceId(
+                eq(1L),
+                eqCategory(NotifyCategory.JAM_UPCOMING),
+                anyString(),
+            ),
+        ).thenReturn(true)
+        `when`(
+            notificationRepository.existsByRecipientIdAndCategoryAndReferenceId(
+                eq(2L),
+                eqCategory(NotifyCategory.JAM_UPCOMING),
+                anyString(),
+            ),
+        ).thenReturn(false)
+
+        sut.remindUpcomingJams()
+
+        assertThat(publishedRecipients()).containsExactly(2L)
+    }
+
+    @Test
+    fun `임박 합주가 없으면 발행하지 않는다`() {
+        `when`(jamRepository.findUpcomingBetween(anyLocalDateTime(), anyLocalDateTime())).thenReturn(emptyList())
+
+        sut.remindUpcomingJams()
+
+        assertThat(published).isEmpty()
+    }
+}

--- a/src/test/kotlin/com/bandage/bandmanager/domain/notify/service/NotificationServiceTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/notify/service/NotificationServiceTest.kt
@@ -1,0 +1,93 @@
+package com.bandage.bandmanager.domain.notify.service
+
+import com.bandage.bandmanager.domain.notify.model.Notification
+import com.bandage.bandmanager.domain.notify.repository.NotificationRepository
+import com.bandage.bandmanager.global.error.errorcode.ErrorCode
+import com.bandage.bandmanager.global.error.exception.BusinessException
+import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
+import com.bandage.bandmanager.global.notify.resolver.NotificationPayload
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyIterable
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import java.util.Optional
+import java.util.UUID
+
+class NotificationServiceTest {
+    private val notificationRepository = mock(NotificationRepository::class.java)
+    private val sut = NotificationService(notificationRepository)
+
+    private fun notification(recipientId: Long): Notification {
+        val notification =
+            Notification.create(
+                NotificationPayload(
+                    recipientId = recipientId,
+                    category = NotifyCategory.BAND_APPLICATION,
+                    title = "제목",
+                    message = "메시지",
+                ),
+            )
+        val field = Notification::class.java.getDeclaredField("id")
+        field.isAccessible = true
+        field.set(notification, UUID.randomUUID())
+        return notification
+    }
+
+    @Test
+    fun `본인 알림은 읽음 처리된다`() {
+        val notification = notification(1L)
+        `when`(notificationRepository.findById(notification.id)).thenReturn(Optional.of(notification))
+
+        sut.markAsRead(1L, notification.id)
+
+        assertThat(notification.isRead).isTrue()
+        assertThat(notification.readAt).isNotNull()
+    }
+
+    @Test
+    fun `타인 알림 읽음 처리 시 NOTIFICATION_FORBIDDEN`() {
+        val notification = notification(1L)
+        `when`(notificationRepository.findById(notification.id)).thenReturn(Optional.of(notification))
+
+        assertThatThrownBy { sut.markAsRead(999L, notification.id) }
+            .isInstanceOfSatisfying(BusinessException::class.java) {
+                assertThat(it.errorCode).isEqualTo(ErrorCode.NOTIFICATION_FORBIDDEN)
+            }
+    }
+
+    @Test
+    fun `존재하지 않는 알림 읽음 처리 시 NOTIFICATION_NOT_FOUND`() {
+        val id = UUID.randomUUID()
+        `when`(notificationRepository.findById(id)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { sut.markAsRead(1L, id) }
+            .isInstanceOfSatisfying(BusinessException::class.java) {
+                assertThat(it.errorCode).isEqualTo(ErrorCode.NOTIFICATION_NOT_FOUND)
+            }
+    }
+
+    @Test
+    fun `빈 페이로드는 저장하지 않는다`() {
+        sut.createAll(emptyList())
+
+        verify(notificationRepository, never()).saveAll(anyIterable())
+    }
+
+    @Test
+    fun `페이로드가 있으면 일괄 저장한다`() {
+        sut.createAll(listOf(NotificationPayload(1L, NotifyCategory.BAND_APPLICATION, "제목", "메시지")))
+
+        verify(notificationRepository).saveAll(anyIterable())
+    }
+
+    @Test
+    fun `미확인 개수를 반환한다`() {
+        `when`(notificationRepository.countByRecipientIdAndIsReadFalse(1L)).thenReturn(3L)
+
+        assertThat(sut.getUnreadCount(1L)).isEqualTo(3L)
+    }
+}

--- a/src/test/kotlin/com/bandage/bandmanager/global/notify/aspect/NotifyAspectTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/global/notify/aspect/NotifyAspectTest.kt
@@ -1,0 +1,69 @@
+package com.bandage.bandmanager.global.notify.aspect
+
+import com.bandage.bandmanager.global.async.event.CommonEvent
+import com.bandage.bandmanager.global.async.publisher.EventPublisher
+import com.bandage.bandmanager.global.notify.annotation.Notify
+import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
+import com.bandage.bandmanager.global.notify.event.NotificationCreateEvent
+import com.bandage.bandmanager.global.notify.resolver.NotificationPayload
+import com.bandage.bandmanager.global.notify.resolver.NotifyPayloadResolver
+import com.bandage.bandmanager.global.notify.resolver.support.NotifyResolverRegistry
+import org.aspectj.lang.JoinPoint
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+class NotifyAspectTest {
+    // EventPublisher 는 mock 대신 fake 로 두어 발행 이벤트를 직접 캡처한다(Kotlin+Mockito any() NPE 회피).
+    private val published = mutableListOf<CommonEvent>()
+    private val eventPublisher =
+        object : EventPublisher {
+            override fun publish(event: CommonEvent) {
+                published.add(event)
+            }
+        }
+
+    private val joinPoint = mock(JoinPoint::class.java)
+    private val notify = mock(Notify::class.java)
+
+    private fun aspectReturning(payloads: List<NotificationPayload>): NotifyAspect {
+        val registry =
+            NotifyResolverRegistry(
+                listOf(
+                    object : NotifyPayloadResolver {
+                        override val category = NotifyCategory.BAND_APPLICATION
+
+                        override fun resolve(
+                            args: Array<Any?>,
+                            returnValue: Any?,
+                        ): List<NotificationPayload> = payloads
+                    },
+                ),
+            )
+        return NotifyAspect(registry, eventPublisher)
+    }
+
+    @Test
+    fun `payload 가 있으면 이벤트를 발행한다`() {
+        `when`(notify.category).thenReturn(NotifyCategory.BAND_APPLICATION)
+        `when`(joinPoint.args).thenReturn(arrayOf<Any?>())
+        val sut = aspectReturning(listOf(NotificationPayload(1L, NotifyCategory.BAND_APPLICATION, "제목", "메시지")))
+
+        sut.afterReturning(joinPoint, notify, null)
+
+        assertThat(published).hasSize(1)
+        assertThat(published[0]).isInstanceOf(NotificationCreateEvent::class.java)
+    }
+
+    @Test
+    fun `payload 가 비어있으면 발행하지 않는다`() {
+        `when`(notify.category).thenReturn(NotifyCategory.BAND_APPLICATION)
+        `when`(joinPoint.args).thenReturn(arrayOf<Any?>())
+        val sut = aspectReturning(emptyList())
+
+        sut.afterReturning(joinPoint, notify, null)
+
+        assertThat(published).isEmpty()
+    }
+}

--- a/src/test/kotlin/com/bandage/bandmanager/global/notify/resolver/support/NotifyResolverRegistryTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/global/notify/resolver/support/NotifyResolverRegistryTest.kt
@@ -1,0 +1,41 @@
+package com.bandage.bandmanager.global.notify.resolver.support
+
+import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
+import com.bandage.bandmanager.global.notify.resolver.NotificationPayload
+import com.bandage.bandmanager.global.notify.resolver.NotifyPayloadResolver
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class NotifyResolverRegistryTest {
+    private fun resolverOf(
+        cat: NotifyCategory,
+        payloads: List<NotificationPayload>,
+    ): NotifyPayloadResolver =
+        object : NotifyPayloadResolver {
+            override val category = cat
+
+            override fun resolve(
+                args: Array<Any?>,
+                returnValue: Any?,
+            ): List<NotificationPayload> = payloads
+        }
+
+    @Test
+    fun `카테고리에 맞는 resolver 로 디스패치한다`() {
+        val payload = NotificationPayload(1L, NotifyCategory.BAND_APPLICATION, "제목", "메시지")
+        val registry = NotifyResolverRegistry(listOf(resolverOf(NotifyCategory.BAND_APPLICATION, listOf(payload))))
+
+        val result = registry.resolve(NotifyCategory.BAND_APPLICATION, arrayOf<Any?>(), null)
+
+        assertThat(result).containsExactly(payload)
+    }
+
+    @Test
+    fun `등록되지 않은 카테고리는 빈 리스트를 반환한다`() {
+        val registry = NotifyResolverRegistry(emptyList())
+
+        val result = registry.resolve(NotifyCategory.JAM_UPCOMING, arrayOf<Any?>(), null)
+
+        assertThat(result).isEmpty()
+    }
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes # (Jira: BD-81)

📌 **작업 내용 및 특이사항**

알림(Notify) 도메인 신규 구현 — AOP 트리거 + 이벤트 저장 파이프라인

- **AOP 트리거**: `@Notify(category)` 어노테이션 + `NotifyAspect`(@AfterReturning)로 알림 생성을 횡단관심사로 분리. 비즈니스 코드는 알림 로직으로 오염되지 않음.
- **Resolver 전략**: 카테고리별 `NotifyPayloadResolver`가 메서드 인자/반환값에서 수신자·내용을 타입 안전하게 추출. Band Resolver 3종은 Modulith 경계를 위해 도메인 패키지에 배치(인터페이스만 global).
- **저장 파이프라인**: `NotificationCreateEvent` → `@TransactionalEventListener(AFTER_COMMIT)` + `@Async`로 비즈니스 트랜잭션과 분리 저장.
- **⚠️ 순서 제약**: `@EnableTransactionManagement(order=0)` + `NotifyAspect @Order(100)`으로 이벤트 발행이 활성 트랜잭션 내부에서 일어나도록 보장(AFTER_COMMIT 동작 조건).
- **조회/읽음 API**: 전체 알림 커서 조회 / 미확인 개수 / 개별·전체 읽음 처리(`is_read`/`read_at`).
- **임박 합주 알림**: `JamReminderScheduler`(@Scheduled) — 시간 기반 트리거를 동일 저장 파이프라인으로 수렴, `(recipient, category, jamId)` 멱등성 필터.
- 트리거 부착: `BandService` 가입신청 / 승인·거절 / 리더 승격 (기존 `// TODO: 알림` 제거).

**특이사항**
- Spring Boot 4 에는 `spring-boot-starter-aop`가 published 되지 않아(Maven Central 404 확인) `aspectjweaver`를 직접 추가(버전은 BOM 관리).
- `NotifyCategory`는 추가/삭제가 빈번하고 프론트 필터 키로 쓰여, 순서에 취약한 ORDINAL 대신 STRING(varchar)으로 저장.
- 실시간 전송(Redis Stream/WebSocket/Push)은 범위 밖 — `NotificationCreateEvent`에 핸들러 추가만으로 확장 가능하게 설계.

📚 **참고사항**
- Liquibase: `016-notification.sql` (`p_notification` 신설 + 조회/멱등성 인덱스)
- 단위 테스트 20개 추가 (Resolver 3종 / Service / Registry / Aspect / Scheduler)
- 전체 `./gradlew build` 통과

✅ **체크리스트**
- [x] API(Controller/DTO)를 변경한 경우 `docs/openapi.json`을 갱신했습니다 (코드-스펙 동일 PR 규약)

🤖 Generated with [Claude Code](https://claude.com/claude-code)