### PR TITLE
[BD-14] fix: soft delete 리소스 unique 제약을 partial unique index로 전환

### DIFF
--- a/src/main/kotlin/com/bandage/bandmanager/domain/auth/model/MemberAuth.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/auth/model/MemberAuth.kt
@@ -26,7 +26,8 @@ open class MemberAuth(
     @Column(name = "member_id", unique = true, nullable = false)
     val memberId: Long = memberId
 
-    @Column(name = "email", unique = true, nullable = false)
+    // 활성 계정 간 email 유일성은 partial unique index(uk_member_auth_email_active, Liquibase 017)로 관리
+    @Column(name = "email", nullable = false)
     val email: String = email
 
     @Column(name = "password", nullable = true)

--- a/src/main/kotlin/com/bandage/bandmanager/domain/band/model/Band.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/band/model/Band.kt
@@ -24,7 +24,8 @@ open class Band(
     lateinit var id: UUID
         protected set
 
-    @Column(name = "name", unique = true, nullable = false)
+    // 활성 밴드 간 name 유일성은 partial unique index(uk_band_name_active, Liquibase 017)로 관리
+    @Column(name = "name", nullable = false)
     var name: String = name
         protected set
 

--- a/src/main/kotlin/com/bandage/bandmanager/domain/member/model/Member.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/member/model/Member.kt
@@ -22,7 +22,8 @@ open class Member(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L
 
-    @Column(name = "email", unique = true, nullable = false)
+    // 활성 회원 간 email 유일성은 partial unique index(uk_member_email_active, Liquibase 017)로 관리
+    @Column(name = "email", nullable = false)
     var email: String = email
         protected set
 

--- a/src/main/resources/db/changelog/changes/017-soft-delete-partial-unique.sql
+++ b/src/main/resources/db/changelog/changes/017-soft-delete-partial-unique.sql
@@ -1,0 +1,22 @@
+-- BD-14: soft delete 리소스의 plain UNIQUE → partial unique index 전환
+--        활성(deleted_at IS NULL) 행만 유일성 보장 → soft delete 후 동일 email/name 재등록 허용.
+--        plain UNIQUE는 삭제 행까지 점유하여 재가입을 막고, existsByEmail(@SQLRestriction, 활성만 조회)과
+--        DB 제약이 어긋나 재가입 시 raw DataIntegrityViolationException(500)이 새던 문제도 함께 해소.
+--
+--        주의: 이후 changeset/코드에서 ON CONFLICT (email)/(name) 을 쓰려면 반드시
+--              'WHERE deleted_at IS NULL' predicate 를 함께 명시해야 partial index 가 arbiter 로 선택됨.
+
+-- 1) p_member.email
+ALTER TABLE public.p_member DROP CONSTRAINT p_member_email_key;
+CREATE UNIQUE INDEX uk_member_email_active
+    ON public.p_member (email) WHERE deleted_at IS NULL;
+
+-- 2) p_member_auth.email
+ALTER TABLE public.p_member_auth DROP CONSTRAINT p_member_auth_email_key;
+CREATE UNIQUE INDEX uk_member_auth_email_active
+    ON public.p_member_auth (email) WHERE deleted_at IS NULL;
+
+-- 3) p_band.name
+ALTER TABLE public.p_band DROP CONSTRAINT p_band_name_key;
+CREATE UNIQUE INDEX uk_band_name_active
+    ON public.p_band (name) WHERE deleted_at IS NULL;

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -200,3 +200,17 @@ databaseChangeLog:
             splitStatements: true
             stripComments: true
             endDelimiter: ";"
+  - changeSet:
+      id: 017-soft-delete-partial-unique
+      author: bandage
+      comment: |
+        BD-14: soft delete 리소스 plain UNIQUE → partial unique index 전환
+        - p_member.email / p_member_auth.email / p_band.name
+        - 활성(deleted_at IS NULL) 행만 유일성 보장, soft delete 후 동일 값 재등록 허용
+      changes:
+        - sqlFile:
+            path: changes/017-soft-delete-partial-unique.sql
+            relativeToChangelogFile: true
+            splitStatements: true
+            stripComments: true
+            endDelimiter: ";"


### PR DESCRIPTION
## 🛠️ Issue Number
### closes BD-14

📌 **작업 내용 및 특이사항**

soft delete 리소스의 **plain UNIQUE 제약**이 삭제된 행까지 점유하여, 회원/밴드를 soft delete한 뒤 **동일 email/name으로 재등록이 불가능**한 문제를 수정했습니다.

- `p_member.email`, `p_member_auth.email`, `p_band.name`: plain UNIQUE → **partial unique index** (`WHERE deleted_at IS NULL`) 전환
  - 활성(`deleted_at IS NULL`) 행만 유일성 보장 → soft delete된 값은 재등록 허용, 삭제 행 N개 공존 허용
- 부수 효과로, `existsByEmail`(`@SQLRestriction`으로 활성만 조회)과 DB plain 제약의 **불일치 해소**
  - 기존: 앱은 "재사용 가능"으로 판단해 INSERT → DB가 거부 → raw `DataIntegrityViolationException`(500) 누수
  - 변경 후: 앱·DB 모두 "활성만" 기준으로 일치
- 엔티티 `@Column(unique = true)` 제거 (오해 방지) — 실제 유일성은 Liquibase `017` partial index가 관리
- Liquibase changeset `017-soft-delete-partial-unique` 추가

**선례:** `014`의 `uk_performance_invitation_pending`이 동일한 partial unique index 패턴을 이미 사용 중이라, 신규 구조가 아닌 기존 패턴으로의 정합화입니다.

📚 **참고사항**

- 적용 범위는 **자연키 3종**으로 한정. 복합 UK(`uk_performance_manager`, `uk_setlist_*`, `uk_track_selection_*` 등)도 같은 plain 패턴이나, "삭제 후 동일 키 재생성"이 실제 시나리오일 때만 영향 → 별도 이슈로 검토.
- **side effect 검증 완료**: 해당 unique를 참조하는 FK 없음 / `ON CONFLICT ON CONSTRAINT` 미사용 / `restore()`는 현재 호출부 0건(死코드). `ON CONFLICT (email)` 시드(`003`)는 마이그레이션 순서상 `017`보다 먼저 실행되어 영향 없음.
- ⚠️ **향후 주의**: `017` 이후 `ON CONFLICT (email)/(name)`을 쓰려면 `WHERE deleted_at IS NULL` predicate를 함께 명시해야 partial index가 arbiter로 선택됨 (SQL 파일 주석에 명시).
- `restore()` 복구 기능을 실제 구현할 때는 복구 전 활성 유일성 사전 체크 + 예외 매핑 필요 (별도 작업).

✅ **체크리스트**
- [ ] API(Controller/DTO)를 변경한 경우 `docs/openapi.json`을 갱신했습니다 (코드-스펙 동일 PR 규약) — **해당 없음**(DB 마이그레이션/엔티티 어노테이션만 변경, API 표면 변화 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)