### PR TITLE
[BD-155] fix: 합주 변경/삭제를 합주 참여자만 가능하도록 검증 추가

### DIFF
--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/controller/JamController.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/controller/JamController.kt
@@ -98,7 +98,7 @@ class JamController(
         @CurrentMemberId memberId: Long,
     ): ApiResponse<JamDetailResponse> =
         ApiResponse.success(
-            jamService.updateSessions(jamId, request),
+            jamService.updateSessions(jamId, request, memberId),
         )
 
     @PostMapping("/{jamId}/participants")
@@ -109,7 +109,7 @@ class JamController(
         @CurrentMemberId memberId: Long,
     ): ApiResponse<JamParticipantResponse> =
         ApiResponse.success(
-            jamService.addParticipant(jamId, request),
+            jamService.addParticipant(jamId, request, memberId),
         )
 
     @PatchMapping("/{jamId}/participants/{participantId}/session")
@@ -125,7 +125,7 @@ class JamController(
         @CurrentMemberId memberId: Long,
     ): ApiResponse<JamParticipantResponse> =
         ApiResponse.success(
-            jamService.updateParticipantSession(jamId, participantId, request),
+            jamService.updateParticipantSession(jamId, participantId, request, memberId),
         )
 
     @DeleteMapping("/{jamId}/participants/{participantId}")
@@ -146,7 +146,7 @@ class JamController(
         @Valid @RequestBody request: JamTimeInfoUpdateRequest,
         @CurrentMemberId memberId: Long,
     ): ApiResponse<Unit> {
-        jamService.updateTimeInfo(jamId, request)
+        jamService.updateTimeInfo(jamId, request, memberId)
         return ApiResponse.success()
     }
 
@@ -157,7 +157,7 @@ class JamController(
         @Valid @RequestBody request: JamVenueUpdateRequest,
         @CurrentMemberId memberId: Long,
     ): ApiResponse<Unit> {
-        jamService.updateVenue(jamId, request)
+        jamService.updateVenue(jamId, request, memberId)
         return ApiResponse.success()
     }
 

--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/repository/JamParticipantRepository.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/repository/JamParticipantRepository.kt
@@ -24,6 +24,11 @@ interface JamParticipantRepository : JpaRepository<JamParticipant, UUID> {
         member: Long,
     ): Boolean
 
+    fun existsByJamAndMember(
+        jam: Jam,
+        member: Long,
+    ): Boolean
+
     @Query(
         "SELECT COUNT(pp) FROM JamParticipant pp " +
             "WHERE pp.member = :memberId AND pp.jam.timeInfo.startAt > :now",

--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/service/JamService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/service/JamService.kt
@@ -116,8 +116,10 @@ class JamService(
     fun updateSessions(
         jamId: UUID,
         request: JamSessionsUpdateRequest,
+        memberId: Long,
     ): JamDetailResponse {
         val jam = getJam(jamId)
+        validateParticipant(jam, memberId)
         val newDefs = request.sessions.map { it.toEntity() }
         val newSessionIds = newDefs.map { it.sessionId }.toSet()
         jamParticipantRepository
@@ -133,8 +135,10 @@ class JamService(
     fun addParticipant(
         jamId: UUID,
         request: JamMemberAddRequest,
+        memberId: Long,
     ): JamParticipantResponse {
         val jam = getJam(jamId)
+        validateParticipant(jam, memberId)
         validateSessionExists(jam, request.sessionId)
         validateParticipantNotExists(jam, request.sessionId, request.memberId)
         val participant =
@@ -154,8 +158,10 @@ class JamService(
         jamId: UUID,
         participantId: UUID,
         request: JamParticipantSessionUpdateRequest,
+        memberId: Long,
     ): JamParticipantResponse {
         val jam = getJam(jamId)
+        validateParticipant(jam, memberId)
         val participant =
             jamParticipantRepository.findByIdAndJam(participantId, jam)
                 ?: throw BusinessException(ErrorCode.JAM_PARTICIPANT_NOT_FOUND)
@@ -175,6 +181,7 @@ class JamService(
         memberId: Long,
     ) {
         val jam = getJam(jamId)
+        validateParticipant(jam, memberId)
         val participant =
             jamParticipantRepository.findByIdAndJam(participantId, jam)
                 ?: throw BusinessException(ErrorCode.JAM_PARTICIPANT_NOT_FOUND)
@@ -186,8 +193,10 @@ class JamService(
     fun updateTimeInfo(
         jamId: UUID,
         request: JamTimeInfoUpdateRequest,
+        memberId: Long,
     ) {
         val jam = getJam(jamId)
+        validateParticipant(jam, memberId)
         jam.updateTimeInfo(request.startAt, request.durationMinutes)
         jamReservationSyncService.sync(jam)
     }
@@ -196,8 +205,10 @@ class JamService(
     fun updateVenue(
         jamId: UUID,
         request: JamVenueUpdateRequest,
+        memberId: Long,
     ) {
         val jam = getJam(jamId)
+        validateParticipant(jam, memberId)
         jam.updateVenue(request.venue)
     }
 
@@ -207,6 +218,7 @@ class JamService(
         memberId: Long,
     ) {
         val jam = getJam(jamId)
+        validateParticipant(jam, memberId)
         jam.markAsDeleted(memberId)
         jamReservationSyncService.sync(jam)
     }
@@ -215,6 +227,15 @@ class JamService(
     private fun getJam(jamId: UUID): Jam =
         jamRepository.findByIdOrNull(jamId)
             ?: throw BusinessException(ErrorCode.JAM_NOT_FOUND)
+
+    private fun validateParticipant(
+        jam: Jam,
+        memberId: Long,
+    ) {
+        if (!jamParticipantRepository.existsByJamAndMember(jam, memberId)) {
+            throw BusinessException(ErrorCode.JAM_FORBIDDEN_NOT_PARTICIPANT)
+        }
+    }
 
     private fun validateSessionExists(
         jam: Jam,

--- a/src/main/kotlin/com/bandage/bandmanager/global/error/errorcode/ErrorCode.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/global/error/errorcode/ErrorCode.kt
@@ -49,6 +49,7 @@ enum class ErrorCode(
     JAM_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 합주 세션 정보를 찾을 수 없습니다."),
     JAM_PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "합주 참여자 정보를 찾을 수 없습니다."),
     JAM_PARTICIPANT_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 합주에 참여 중인 멤버입니다."),
+    JAM_FORBIDDEN_NOT_PARTICIPANT(HttpStatus.FORBIDDEN, "합주 참여자만 변경할 수 있습니다."),
 
     // performance
     PERFORMANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 공연 정보를 찾을 수 없습니다."),

--- a/src/test/kotlin/com/bandage/bandmanager/domain/jam/service/JamServiceTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/jam/service/JamServiceTest.kt
@@ -1,0 +1,64 @@
+package com.bandage.bandmanager.domain.jam.service
+
+import com.bandage.bandmanager.domain.band.repository.BandMemberRepository
+import com.bandage.bandmanager.domain.jam.dto.req.JamVenueUpdateRequest
+import com.bandage.bandmanager.domain.jam.model.Jam
+import com.bandage.bandmanager.domain.jam.repository.JamParticipantRepository
+import com.bandage.bandmanager.domain.jam.repository.JamRepository
+import com.bandage.bandmanager.global.common.domain.TrackInfo
+import com.bandage.bandmanager.global.error.errorcode.ErrorCode
+import com.bandage.bandmanager.global.error.exception.BusinessException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.time.LocalDateTime
+import java.util.Optional
+import java.util.UUID
+
+class JamServiceTest {
+    private val jamRepository = mock(JamRepository::class.java)
+    private val jamParticipantRepository = mock(JamParticipantRepository::class.java)
+    private val bandMemberRepository = mock(BandMemberRepository::class.java)
+    private val jamReservationSyncService = mock(JamReservationSyncService::class.java)
+    private val sut =
+        JamService(
+            jamRepository,
+            jamParticipantRepository,
+            bandMemberRepository,
+            jamReservationSyncService,
+        )
+
+    private val jamId = UUID.randomUUID()
+
+    private fun jam(): Jam =
+        Jam.create(
+            title = "합주",
+            trackInfo = TrackInfo(title = "곡", artist = "아티스트"),
+            startAt = LocalDateTime.of(2026, 6, 10, 19, 0),
+            durationMinutes = 120,
+            venue = null,
+        )
+
+    @Test
+    fun `합주 참여자가 아니면 합주를 수정할 수 없다`() {
+        `when`(jamRepository.findById(jamId)).thenReturn(Optional.of(jam()))
+        // existsByJamAndMember 미스텁 → 기본 false (비참여자)
+
+        assertThatThrownBy { sut.updateVenue(jamId, JamVenueUpdateRequest("홍대 스튜디오"), 99L) }
+            .isInstanceOf(BusinessException::class.java)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.JAM_FORBIDDEN_NOT_PARTICIPANT)
+    }
+
+    @Test
+    fun `합주 참여자면 합주를 수정할 수 있다`() {
+        val jam = jam()
+        `when`(jamRepository.findById(jamId)).thenReturn(Optional.of(jam))
+        `when`(jamParticipantRepository.existsByJamAndMember(jam, 1L)).thenReturn(true)
+
+        sut.updateVenue(jamId, JamVenueUpdateRequest("홍대 스튜디오"), 1L)
+
+        assertThat(jam.timeInfo.venue).isEqualTo("홍대 스튜디오")
+    }
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #BD-155

📌 **작업 내용 및 특이사항**

**문제**: 합주의 장소·시간 등 변경 및 삭제를 **합주 참여자가 아닌 사용자도 수행**할 수 있었음(권한 검증 누락).

**해결**: `JamService`의 write 메서드 7종에 "요청자가 해당 합주의 참여자인지" 검증(`validateParticipant`)을 추가.

| 적용 대상(7) | 제외 |
|---|---|
| `updateTimeInfo`·`updateVenue`·`updateSessions`·`addParticipant`·`updateParticipantSession`·`deleteParticipant`·`deleteJam` | `createJam`(생성자가 곧 참여자로 자동 등록), 조회 API 전체 |

- `ErrorCode.JAM_FORBIDDEN_NOT_PARTICIPANT`(403) 추가
- `JamParticipantRepository.existsByJamAndMember(jam, member)` 추가 (세션 배정 여부와 무관하게 소속 참여자면 통과)
- 컨트롤러는 기존부터 `@CurrentMemberId`를 수신 중 → 일부 메서드가 이를 서비스로 전달하도록 연결
- 검증 가드 단위테스트(`JamServiceTest`) 추가: 비참여자 차단 / 참여자 통과

📚 **참고사항**

- **OpenAPI 계약 변화 없음**: `@CurrentMemberId`는 인증 토큰 기반이라 스펙에 노출되지 않으며, 요청/응답 DTO·엔드포인트 변경이 없음. (재생성 diff는 로컬 server URL artifact뿐이라 반영하지 않음)
- 검증: 컴파일/`spotlessApply`/jam 전체 테스트/신규 테스트 통과, 로컬 부팅 `ddl-auto: validate` 통과

✅ **체크리스트**
- [x] API(Controller/DTO) 변경에 따른 외부 계약(`docs/openapi.json`) 변화 없음을 재생성으로 확인함

🤖 Generated with [Claude Code](https://claude.com/claude-code)