### PR TITLE
[BD-151] refactor: 멤버 가용성 슬롯 조회 + 범위 한정 쓰기로 개편

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -859,6 +859,40 @@
                 ],
                 "type": "object"
             },
+            "ApiResponseListScheduleSlotResponse": {
+                "properties": {
+                    "code": {
+                        "type": "string"
+                    },
+                    "data": {
+                        "items": {
+                            "$ref": "#/components/schemas/ScheduleSlotResponse"
+                        },
+                        "type": "array"
+                    },
+                    "fieldErrors": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "type": "object"
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "success": {
+                        "type": "boolean"
+                    },
+                    "timestamp": {
+                        "format": "date-time",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "success",
+                    "timestamp"
+                ],
+                "type": "object"
+            },
             "ApiResponseListSetlistResponse": {
                 "properties": {
                     "code": {
@@ -3008,6 +3042,18 @@
             },
             "MemberAvailabilityRequest": {
                 "properties": {
+                    "effectiveFrom": {
+                        "description": "\uad50\uccb4 \ub300\uc0c1 \uad6c\uac04 \uc2dc\uc791\uc77c",
+                        "example": "2026-06-13",
+                        "format": "date",
+                        "type": "string"
+                    },
+                    "effectiveTo": {
+                        "description": "\uad50\uccb4 \ub300\uc0c1 \uad6c\uac04 \uc885\ub8cc\uc77c(\ud3ec\ud568)",
+                        "example": "2026-07-01",
+                        "format": "date",
+                        "type": "string"
+                    },
                     "exceptions": {
                         "items": {
                             "$ref": "#/components/schemas/AvailabilityExceptionRequest"
@@ -3027,6 +3073,8 @@
                     }
                 },
                 "required": [
+                    "effectiveFrom",
+                    "effectiveTo",
                     "exceptions",
                     "weeklyRules"
                 ],
@@ -4650,6 +4698,52 @@
                 ],
                 "type": "object"
             },
+            "ScheduleSlotResponse": {
+                "description": "\uc77c\uc815 \uc2ac\ub86f (30\ubd84 48\uc2ac\ub86f, [startSlot, endSlot) \ubc18\uc5f4\ub9b0 \uad6c\uac04)",
+                "properties": {
+                    "date": {
+                        "description": "\ub0a0\uc9dc",
+                        "example": "2026-06-13",
+                        "format": "date",
+                        "type": "string"
+                    },
+                    "endSlot": {
+                        "description": "\uc885\ub8cc \uc2ac\ub86f (1~48, \ubbf8\ud3ec\ud568)",
+                        "example": 44,
+                        "format": "int32",
+                        "type": "integer"
+                    },
+                    "refId": {
+                        "description": "\uc5f0\uacb0 \ub9ac\uc18c\uc2a4 ID(\ud569\uc8fc/\uacf5\uc5f0 \ub4f1). \uac00\uc6a9\uc131 \uc2ac\ub86f\uc740 null",
+                        "type": "string"
+                    },
+                    "startSlot": {
+                        "description": "\uc2dc\uc791 \uc2ac\ub86f (0~47)",
+                        "example": 20,
+                        "format": "int32",
+                        "type": "integer"
+                    },
+                    "title": {
+                        "description": "\ud45c\uc2dc\uc6a9 \uc81c\ubaa9. \uac00\uc6a9\uc131 \uc2ac\ub86f\uc740 null",
+                        "type": "string"
+                    },
+                    "type": {
+                        "description": "\uc2ac\ub86f \uc885\ub958",
+                        "enum": [
+                            "AVAILABLE"
+                        ],
+                        "example": "AVAILABLE",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "date",
+                    "endSlot",
+                    "startSlot",
+                    "type"
+                ],
+                "type": "object"
+            },
             "ScheduleUnconfirmResponse": {
                 "properties": {
                     "unconfirmedAt": {
@@ -5637,14 +5731,6 @@
                         ],
                         "type": "string"
                     },
-                    "effectiveFrom": {
-                        "format": "date",
-                        "type": "string"
-                    },
-                    "effectiveTo": {
-                        "format": "date",
-                        "type": "string"
-                    },
                     "endSlot": {
                         "format": "int32",
                         "type": "integer"
@@ -5656,7 +5742,6 @@
                 },
                 "required": [
                     "dayOfWeek",
-                    "effectiveFrom",
                     "endSlot",
                     "startSlot"
                 ],
@@ -7123,7 +7208,7 @@
                 ]
             },
             "put": {
-                "description": "\ubcf8\uc778\ub9cc \uc218\uc815 \uac00\ub2a5. weeklyRules/exceptions \uc804\uccb4 \uad50\uccb4.",
+                "description": "\ubcf8\uc778\ub9cc \uc218\uc815 \uac00\ub2a5. effectiveFrom~effectiveTo \uad6c\uac04\ub9cc \uad50\uccb4\ud558\uace0 \uad6c\uac04 \ubc16(\uacfc\uac70 \ud3ec\ud568)\uc740 \ubcf4\uc874\ud55c\ub2e4.",
                 "operationId": "updateMyAvailability",
                 "requestBody": {
                     "content": {
@@ -7148,6 +7233,48 @@
                     }
                 },
                 "summary": "\ub0b4 \uac00\uc6a9\uc131 \ub4f1\ub85d/\uc218\uc815",
+                "tags": [
+                    "member-availability"
+                ]
+            }
+        },
+        "/api/v1/me/availability/slots": {
+            "get": {
+                "description": "\uc870\ud68c \uae30\uac04(from~to, \ucd5c\ub300 366\uc77c)\uc5d0 \uc18d\ud55c \uac00\uc6a9 \uc2ac\ub86f\uc744 \ub0a0\uc9dc\ubcc4\ub85c \uc804\uac1c\ud574 \ubc18\ud658. \ud074\ub77c\uc774\uc5b8\ud2b8 \ucd94\uac00 \uacc4\uc0b0 \ubd88\ud544\uc694.",
+                "operationId": "getMyAvailabilitySlots",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "from",
+                        "required": true,
+                        "schema": {
+                            "format": "date",
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "to",
+                        "required": true,
+                        "schema": {
+                            "format": "date",
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiResponseListScheduleSlotResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    }
+                },
+                "summary": "\ub0b4 \uac00\uc6a9\uc131 \uc2ac\ub86f \uc870\ud68c",
                 "tags": [
                     "member-availability"
                 ]
@@ -10180,7 +10307,7 @@
     "servers": [
         {
             "description": "Generated server url",
-            "url": "http://bandage-band-manager:8080"
+            "url": "http://localhost:8080"
         }
     ],
     "tags": [

--- a/src/main/kotlin/com/bandage/bandmanager/domain/availability/controller/MemberAvailabilityController.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/availability/controller/MemberAvailabilityController.kt
@@ -5,15 +5,19 @@ import com.bandage.bandmanager.domain.availability.dto.res.MemberAvailabilityRes
 import com.bandage.bandmanager.domain.availability.service.MemberAvailabilityService
 import com.bandage.bandmanager.global.common.constants.PathPrefix.PREFIX
 import com.bandage.bandmanager.global.common.response.ApiResponse
+import com.bandage.bandmanager.global.common.response.ScheduleSlotResponse
 import com.bandage.bandmanager.global.security.annotation.CurrentMemberId
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
 
 @Tag(name = "member-availability", description = "멤버 글로벌 가용성 API")
 @RestController
@@ -26,6 +30,18 @@ class MemberAvailabilityController(
     fun getMyAvailability(
         @CurrentMemberId memberId: Long,
     ): ApiResponse<MemberAvailabilityResponse> = ApiResponse.success(memberAvailabilityService.getMyAvailability(memberId))
+
+    @GetMapping("/slots")
+    @Operation(
+        operationId = "getMyAvailabilitySlots",
+        summary = "내 가용성 슬롯 조회",
+        description = "조회 기간(from~to, 최대 366일)에 속한 가용 슬롯을 날짜별로 전개해 반환. 클라이언트 추가 계산 불필요.",
+    )
+    fun getMyAvailabilitySlots(
+        @CurrentMemberId memberId: Long,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
+    ): ApiResponse<List<ScheduleSlotResponse>> = ApiResponse.success(memberAvailabilityService.getMySlots(memberId, from, to))
 
     @PutMapping
     @Operation(operationId = "updateMyAvailability", summary = "내 가용성 등록/수정", description = "본인만 수정 가능. weeklyRules/exceptions 전체 교체.")

--- a/src/main/kotlin/com/bandage/bandmanager/domain/availability/controller/MemberAvailabilityController.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/availability/controller/MemberAvailabilityController.kt
@@ -44,7 +44,11 @@ class MemberAvailabilityController(
     ): ApiResponse<List<ScheduleSlotResponse>> = ApiResponse.success(memberAvailabilityService.getMySlots(memberId, from, to))
 
     @PutMapping
-    @Operation(operationId = "updateMyAvailability", summary = "내 가용성 등록/수정", description = "본인만 수정 가능. weeklyRules/exceptions 전체 교체.")
+    @Operation(
+        operationId = "updateMyAvailability",
+        summary = "내 가용성 등록/수정",
+        description = "본인만 수정 가능. effectiveFrom~effectiveTo 구간만 교체하고 구간 밖(과거 포함)은 보존한다.",
+    )
     fun updateMyAvailability(
         @CurrentMemberId memberId: Long,
         @Valid @RequestBody request: MemberAvailabilityRequest,

--- a/src/main/kotlin/com/bandage/bandmanager/domain/availability/dto/req/MemberAvailabilityRequest.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/availability/dto/req/MemberAvailabilityRequest.kt
@@ -3,16 +3,23 @@ package com.bandage.bandmanager.domain.availability.dto.req
 import com.bandage.bandmanager.domain.availability.model.AvailabilityException
 import com.bandage.bandmanager.domain.availability.model.AvailabilityKind
 import com.bandage.bandmanager.domain.availability.model.WeeklyRule
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
 import jakarta.validation.constraints.Size
 import java.time.DayOfWeek
 import java.time.LocalDate
 
 /**
- * 멤버 글로벌 가용성 등록/수정(upsert) 요청.
- * weeklyRules/exceptions 는 전체 교체(replace) 방식으로 적용된다.
+ * 멤버 글로벌 가용성 등록/수정 요청 (범위 한정).
+ *
+ * [effectiveFrom, effectiveTo] 구간만 교체한다. 이 구간 밖의 가용성(과거 포함)은 보존된다.
+ * weeklyRules 는 이 구간 동안 반복 적용되며, exceptions 의 날짜는 반드시 이 구간 안이어야 한다.
  */
 data class MemberAvailabilityRequest(
+    @Schema(description = "교체 대상 구간 시작일", example = "2026-06-13")
+    val effectiveFrom: LocalDate,
+    @Schema(description = "교체 대상 구간 종료일(포함)", example = "2026-07-01")
+    val effectiveTo: LocalDate,
     @field:Valid
     val weeklyRules: List<WeeklyRuleRequest> = emptyList(),
     @field:Valid
@@ -20,14 +27,15 @@ data class MemberAvailabilityRequest(
     @field:Size(max = 500, message = "note 는 최대 500자까지 입력할 수 있습니다.")
     val note: String? = null,
 ) {
+    /** 각 주간 규칙은 요청 구간 [effectiveFrom, effectiveTo] 동안 유효하다. */
     fun toWeeklyRules(): List<WeeklyRule> =
         weeklyRules.map {
             WeeklyRule(
                 dayOfWeek = it.dayOfWeek,
                 startSlot = it.startSlot,
                 endSlot = it.endSlot,
-                effectiveFrom = it.effectiveFrom,
-                effectiveTo = it.effectiveTo,
+                effectiveFrom = effectiveFrom,
+                effectiveTo = effectiveTo,
             )
         }
 
@@ -45,8 +53,6 @@ data class MemberAvailabilityRequest(
         val dayOfWeek: DayOfWeek,
         val startSlot: Int,
         val endSlot: Int,
-        val effectiveFrom: LocalDate,
-        val effectiveTo: LocalDate? = null,
     )
 
     data class AvailabilityExceptionRequest(

--- a/src/main/kotlin/com/bandage/bandmanager/domain/availability/model/AvailabilityException.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/availability/model/AvailabilityException.kt
@@ -50,4 +50,26 @@ open class AvailabilityException(
 
     /** 전일 적용 예외인지 여부. */
     val isAllDay: Boolean get() = startSlot == null && endSlot == null
+
+    /** 요청 구간 [reqStart, reqEnd) 와 이 예외가 겹치는지(전일 예외는 항상 겹침). */
+    fun overlaps(
+        reqStart: Int,
+        reqEnd: Int,
+    ): Boolean {
+        if (isAllDay) return true
+        val s = startSlot ?: return true
+        val e = endSlot ?: return true
+        return s < reqEnd && e > reqStart
+    }
+
+    /** 이 예외가 요청 구간 [reqStart, reqEnd) 를 완전히 포함하는지(전일 예외는 항상 포함). */
+    fun covers(
+        reqStart: Int,
+        reqEnd: Int,
+    ): Boolean {
+        if (isAllDay) return true
+        val s = startSlot ?: return true
+        val e = endSlot ?: return true
+        return s <= reqStart && reqEnd <= e
+    }
 }

--- a/src/main/kotlin/com/bandage/bandmanager/domain/availability/model/MemberAvailability.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/availability/model/MemberAvailability.kt
@@ -10,6 +10,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.Table
 import org.hibernate.annotations.SQLRestriction
+import java.time.LocalDate
 
 /**
  * 멤버의 글로벌 가용성. 특정 회의/공연에 종속되지 않는 멤버 본인의 상시 가용 정보다.
@@ -71,5 +72,21 @@ open class MemberAvailability(
 
     fun updateNote(note: String?) {
         this.note = note
+    }
+
+    /**
+     * 특정 날짜의 요청 구간 [reqStart, reqEnd) 가 가용한지 판정한다.
+     * 우선순위: BLOCKED 예외(겹치면 불가) > AVAILABLE 예외(포함하면 가용) > 주간 규칙(완전히 덮으면 가용).
+     * 가용성/충돌 계산(AvailabilityCalculator)과 슬롯 전개 양쪽이 공유하는 단일 판정 로직이다.
+     */
+    fun isAvailableAt(
+        date: LocalDate,
+        reqStart: Int,
+        reqEnd: Int,
+    ): Boolean {
+        val dayExceptions = _exceptions.filter { it.date == date }
+        if (dayExceptions.any { it.kind == AvailabilityKind.BLOCKED && it.overlaps(reqStart, reqEnd) }) return false
+        if (dayExceptions.any { it.kind == AvailabilityKind.AVAILABLE && it.covers(reqStart, reqEnd) }) return true
+        return _weeklyRules.any { it.isEffectiveOn(date) && it.startSlot <= reqStart && reqEnd <= it.endSlot }
     }
 }

--- a/src/main/kotlin/com/bandage/bandmanager/domain/availability/service/MemberAvailabilityService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/availability/service/MemberAvailabilityService.kt
@@ -5,11 +5,16 @@ import com.bandage.bandmanager.domain.availability.dto.res.MemberAvailabilityRes
 import com.bandage.bandmanager.domain.availability.model.AvailabilityException
 import com.bandage.bandmanager.domain.availability.model.MemberAvailability
 import com.bandage.bandmanager.domain.availability.model.WeeklyRule
+import com.bandage.bandmanager.domain.availability.model.WeeklyRule.Companion.SLOTS_PER_DAY
 import com.bandage.bandmanager.domain.availability.repository.MemberAvailabilityRepository
+import com.bandage.bandmanager.global.common.response.ScheduleSlotResponse
+import com.bandage.bandmanager.global.common.response.ScheduleSlotType
 import com.bandage.bandmanager.global.error.errorcode.ErrorCode
 import com.bandage.bandmanager.global.error.exception.BusinessException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
 
 @Service
 @Transactional(readOnly = true)
@@ -22,6 +27,52 @@ class MemberAvailabilityService(
             .findByMemberId(memberId)
             ?.let { MemberAvailabilityResponse.from(it) }
             ?: MemberAvailabilityResponse.empty(memberId)
+
+    /**
+     * 조회 기간 [from, to] 에 속한 가용 슬롯을 날짜별로 전개해 반환한다.
+     * 규칙/예외를 서버에서 구체 슬롯으로 풀어주므로 클라이언트는 추가 계산 없이 그대로 렌더할 수 있다.
+     * 미등록 멤버는 빈 리스트. 최대 366일까지 조회 가능.
+     */
+    fun getMySlots(
+        memberId: Long,
+        from: LocalDate,
+        to: LocalDate,
+    ): List<ScheduleSlotResponse> {
+        if (from.isAfter(to) || ChronoUnit.DAYS.between(from, to) > MAX_RANGE_DAYS) {
+            throw BusinessException(ErrorCode.AVAILABILITY_RANGE_INVALID)
+        }
+        val availability = memberAvailabilityRepository.findByMemberId(memberId) ?: return emptyList()
+
+        val slots = mutableListOf<ScheduleSlotResponse>()
+        var date = from
+        while (!date.isAfter(to)) {
+            // 하루 48슬롯을 가용 판정에 통과시켜 연속 구간(run-length)으로 묶는다.
+            var start = -1
+            for (slot in 0 until SLOTS_PER_DAY) {
+                val available = availability.isAvailableAt(date, slot, slot + 1)
+                if (available && start < 0) start = slot
+                if (!available && start >= 0) {
+                    slots += slotOf(date, start, slot)
+                    start = -1
+                }
+            }
+            if (start >= 0) slots += slotOf(date, start, SLOTS_PER_DAY)
+            date = date.plusDays(1)
+        }
+        return slots
+    }
+
+    private fun slotOf(
+        date: LocalDate,
+        startSlot: Int,
+        endSlot: Int,
+    ): ScheduleSlotResponse =
+        ScheduleSlotResponse(
+            date = date,
+            startSlot = startSlot,
+            endSlot = endSlot,
+            type = ScheduleSlotType.AVAILABLE,
+        )
 
     /** 내 가용성 등록/수정(upsert). weeklyRules/exceptions 는 전체 교체. */
     @Transactional
@@ -58,4 +109,8 @@ class MemberAvailabilityService(
         } catch (e: IllegalArgumentException) {
             throw BusinessException(ErrorCode.AVAILABILITY_INVALID)
         }
+
+    companion object {
+        const val MAX_RANGE_DAYS: Long = 366
+    }
 }

--- a/src/main/kotlin/com/bandage/bandmanager/domain/availability/service/MemberAvailabilityService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/availability/service/MemberAvailabilityService.kt
@@ -74,25 +74,65 @@ class MemberAvailabilityService(
             type = ScheduleSlotType.AVAILABLE,
         )
 
-    /** 내 가용성 등록/수정(upsert). weeklyRules/exceptions 는 전체 교체. */
+    /**
+     * 내 가용성 등록/수정(범위 한정 교체). [effectiveFrom, effectiveTo] 구간만 교체하고 구간 밖은 보존한다.
+     * - 구간에 걸치는 기존 주간 규칙은 경계에서 잘라낸다(머리/꼬리, 완전 포함이면 제거).
+     * - 구간 안의 기존 예외는 제거하고 제출분으로 대체한다.
+     */
     @Transactional
     fun updateMyAvailability(
         memberId: Long,
         request: MemberAvailabilityRequest,
     ): MemberAvailabilityResponse {
-        val rules = parseWeeklyRules(request)
-        val exceptions = parseExceptions(request)
+        val from = request.effectiveFrom
+        val to = request.effectiveTo
+        if (from.isAfter(to)) throw BusinessException(ErrorCode.AVAILABILITY_INVALID)
+
+        val newRules = parseWeeklyRules(request)
+        val newExceptions = parseExceptions(request)
+        if (newExceptions.any { it.date.isBefore(from) || it.date.isAfter(to) }) {
+            throw BusinessException(ErrorCode.AVAILABILITY_INVALID)
+        }
 
         val availability =
             memberAvailabilityRepository.findByMemberId(memberId)
                 ?: MemberAvailability.create(memberId = memberId)
 
-        availability.updateWeeklyRules(rules)
-        availability.updateExceptions(exceptions)
+        val keptRules = availability.weeklyRules.flatMap { clip(it, from, to) }
+        val keptExceptions = availability.exceptions.filter { it.date.isBefore(from) || it.date.isAfter(to) }
+
+        availability.updateWeeklyRules(keptRules + newRules)
+        availability.updateExceptions(keptExceptions + newExceptions)
         availability.updateNote(request.note)
 
         val saved = memberAvailabilityRepository.save(availability)
         return MemberAvailabilityResponse.from(saved)
+    }
+
+    /**
+     * 주간 규칙에서 [from, to] 구간을 도려낸다. 반환은 0~2개:
+     * - 안 겹침 → 원본 그대로(1개)
+     * - 머리/꼬리만 걸침 → 잘린 1개
+     * - 구간이 규칙 가운데를 관통 → 머리+꼬리 2개(split)
+     * - 규칙이 구간에 완전히 포함 → 0개(제출분으로 대체)
+     */
+    private fun clip(
+        rule: WeeklyRule,
+        from: LocalDate,
+        to: LocalDate,
+    ): List<WeeklyRule> {
+        val ruleTo = rule.effectiveTo ?: LocalDate.MAX
+        if (ruleTo.isBefore(from) || rule.effectiveFrom.isAfter(to)) return listOf(rule)
+
+        val result = mutableListOf<WeeklyRule>()
+        if (rule.effectiveFrom.isBefore(from)) {
+            result += WeeklyRule(rule.dayOfWeek, rule.startSlot, rule.endSlot, rule.effectiveFrom, from.minusDays(1))
+        }
+        if (ruleTo.isAfter(to)) {
+            // 원래 무기한(effectiveTo == null)이면 꼬리도 무기한 유지
+            result += WeeklyRule(rule.dayOfWeek, rule.startSlot, rule.endSlot, to.plusDays(1), rule.effectiveTo)
+        }
+        return result
     }
 
     // 슬롯/기간 검증은 Embeddable init 에서 수행되므로, 생성 실패 시 BusinessException 으로 변환한다.

--- a/src/main/kotlin/com/bandage/bandmanager/domain/schedule/placement/AvailabilityCalculator.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/schedule/placement/AvailabilityCalculator.kt
@@ -1,7 +1,5 @@
 package com.bandage.bandmanager.domain.schedule.placement
 
-import com.bandage.bandmanager.domain.availability.model.AvailabilityException
-import com.bandage.bandmanager.domain.availability.model.AvailabilityKind
 import com.bandage.bandmanager.domain.availability.model.MemberAvailability
 import com.bandage.bandmanager.domain.availability.repository.MemberAvailabilityRepository
 import com.bandage.bandmanager.domain.jam.model.JamReservation
@@ -77,7 +75,7 @@ class AvailabilityCalculator(
     ): ConflictReason? {
         // 1. 글로벌 가용성
         val availability = context.availabilityByMember[memberId]
-        if (availability != null && !isAvailable(availability, date, startSlot, endSlot)) {
+        if (availability != null && !availability.isAvailableAt(date, startSlot, endSlot)) {
             return ConflictReason.UNAVAILABLE
         }
         // 2. 확정 Jam 예약 충돌
@@ -90,49 +88,6 @@ class AvailabilityCalculator(
             return ConflictReason.PENDING_BLOCK
         }
         return null
-    }
-
-    private fun isAvailable(
-        availability: MemberAvailability,
-        date: LocalDate,
-        reqStart: Int,
-        reqEnd: Int,
-    ): Boolean {
-        val dayExceptions = availability.exceptions.filter { it.date == date }
-        // BLOCKED 예외가 요청 구간과 겹치면 불가
-        if (dayExceptions.any { it.kind == AvailabilityKind.BLOCKED && exceptionOverlaps(it, reqStart, reqEnd) }) {
-            return false
-        }
-        // AVAILABLE 예외가 요청 구간을 포함하면 가용(주간규칙 무관)
-        if (dayExceptions.any { it.kind == AvailabilityKind.AVAILABLE && exceptionCovers(it, reqStart, reqEnd) }) {
-            return true
-        }
-        // 주간 반복 규칙으로 요청 구간이 완전히 덮이면 가용
-        return availability.weeklyRules.any {
-            it.isEffectiveOn(date) && it.startSlot <= reqStart && reqEnd <= it.endSlot
-        }
-    }
-
-    private fun exceptionOverlaps(
-        exception: AvailabilityException,
-        reqStart: Int,
-        reqEnd: Int,
-    ): Boolean {
-        if (exception.isAllDay) return true
-        val s = exception.startSlot ?: return true
-        val e = exception.endSlot ?: return true
-        return s < reqEnd && e > reqStart
-    }
-
-    private fun exceptionCovers(
-        exception: AvailabilityException,
-        reqStart: Int,
-        reqEnd: Int,
-    ): Boolean {
-        if (exception.isAllDay) return true
-        val s = exception.startSlot ?: return true
-        val e = exception.endSlot ?: return true
-        return s <= reqStart && reqEnd <= e
     }
 
     private fun overlapsReservation(

--- a/src/main/kotlin/com/bandage/bandmanager/global/common/response/ScheduleSlotResponse.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/global/common/response/ScheduleSlotResponse.kt
@@ -1,0 +1,30 @@
+package com.bandage.bandmanager.global.common.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+
+/**
+ * 일정 슬롯. 30분 48슬롯 체계이며 가용 구간은 [startSlot, endSlot) 반열린 구간으로 표현한다.
+ * 가용성(MemberAvailability) 조회의 응답 단위이자, 향후 합주/공연 등 멤버 전체 일정을
+ * 동일 포맷으로 투영하기 위한 공유 응답 모양이다.
+ */
+@Schema(description = "일정 슬롯 (30분 48슬롯, [startSlot, endSlot) 반열린 구간)")
+data class ScheduleSlotResponse(
+    @Schema(description = "날짜", example = "2026-06-13")
+    val date: LocalDate,
+    @Schema(description = "시작 슬롯 (0~47)", example = "20")
+    val startSlot: Int,
+    @Schema(description = "종료 슬롯 (1~48, 미포함)", example = "44")
+    val endSlot: Int,
+    @Schema(description = "슬롯 종류", example = "AVAILABLE")
+    val type: ScheduleSlotType,
+    @Schema(description = "연결 리소스 ID(합주/공연 등). 가용성 슬롯은 null", nullable = true)
+    val refId: String? = null,
+    @Schema(description = "표시용 제목. 가용성 슬롯은 null", nullable = true)
+    val title: String? = null,
+)
+
+// ponytail: 현재 AVAILABLE 단일 값. 통합 일정 피드(JAM/PERFORMANCE 등) 도입 시 여기에 추가.
+enum class ScheduleSlotType {
+    AVAILABLE,
+}

--- a/src/main/kotlin/com/bandage/bandmanager/global/error/errorcode/ErrorCode.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/global/error/errorcode/ErrorCode.kt
@@ -101,6 +101,7 @@ enum class ErrorCode(
 
     // availability
     AVAILABILITY_INVALID(HttpStatus.BAD_REQUEST, "가용성 정보가 올바르지 않습니다."),
+    AVAILABILITY_RANGE_INVALID(HttpStatus.BAD_REQUEST, "조회 기간이 올바르지 않습니다. (from <= to, 최대 366일)"),
 
     // schedule (performance scope)
     SCHEDULE_PERFORMANCE_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 공연 일정에 접근할 권한이 없습니다."),

--- a/src/test/kotlin/com/bandage/bandmanager/domain/availability/service/MemberAvailabilitySlotsTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/availability/service/MemberAvailabilitySlotsTest.kt
@@ -1,0 +1,79 @@
+package com.bandage.bandmanager.domain.availability.service
+
+import com.bandage.bandmanager.domain.availability.model.AvailabilityException
+import com.bandage.bandmanager.domain.availability.model.AvailabilityKind
+import com.bandage.bandmanager.domain.availability.model.MemberAvailability
+import com.bandage.bandmanager.domain.availability.model.WeeklyRule
+import com.bandage.bandmanager.domain.availability.repository.MemberAvailabilityRepository
+import com.bandage.bandmanager.global.error.exception.BusinessException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.assertj.core.api.Assertions.tuple
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.time.LocalDate
+
+class MemberAvailabilitySlotsTest {
+    private val repository = mock(MemberAvailabilityRepository::class.java)
+    private val sut = MemberAvailabilityService(repository)
+
+    private val mon = LocalDate.of(2026, 6, 1)
+
+    private fun availability(
+        rules: List<WeeklyRule> = emptyList(),
+        exceptions: List<AvailabilityException> = emptyList(),
+    ): MemberAvailability =
+        MemberAvailability.create(1L).apply {
+            updateWeeklyRules(rules)
+            updateExceptions(exceptions)
+        }
+
+    @Test
+    fun `주간 규칙을 날짜별 가용 슬롯으로 전개한다`() {
+        // mon 요일, 10:00~22:00(slot 20~44)
+        val rule = WeeklyRule(mon.dayOfWeek, startSlot = 20, endSlot = 44, effectiveFrom = mon)
+        `when`(repository.findByMemberId(1L)).thenReturn(availability(rules = listOf(rule)))
+
+        val slots = sut.getMySlots(1L, mon, mon.plusDays(7))
+
+        // mon 과 mon+7 두 번만 해당 요일 → 슬롯 2개
+        assertThat(slots.map { it.date }).containsExactly(mon, mon.plusDays(7))
+        assertThat(slots).allSatisfy {
+            assertThat(it.startSlot).isEqualTo(20)
+            assertThat(it.endSlot).isEqualTo(44)
+        }
+    }
+
+    @Test
+    fun `BLOCKED 예외 구간은 가용 슬롯에서 도려내져 두 구간으로 쪼개진다`() {
+        val rule = WeeklyRule(mon.dayOfWeek, 20, 44, effectiveFrom = mon)
+        val blocked = AvailabilityException(mon, AvailabilityKind.BLOCKED, startSlot = 30, endSlot = 34)
+        `when`(repository.findByMemberId(1L)).thenReturn(availability(rules = listOf(rule), exceptions = listOf(blocked)))
+
+        val slots = sut.getMySlots(1L, mon, mon)
+
+        assertThat(slots)
+            .extracting("startSlot", "endSlot")
+            .containsExactly(tuple(20, 30), tuple(34, 44))
+    }
+
+    @Test
+    fun `미등록 멤버는 빈 리스트`() {
+        `when`(repository.findByMemberId(1L)).thenReturn(null)
+
+        assertThat(sut.getMySlots(1L, mon, mon.plusDays(7))).isEmpty()
+    }
+
+    @Test
+    fun `from 이 to 보다 늦으면 예외`() {
+        assertThatThrownBy { sut.getMySlots(1L, mon, mon.minusDays(1)) }
+            .isInstanceOf(BusinessException::class.java)
+    }
+
+    @Test
+    fun `366일을 초과하면 예외`() {
+        assertThatThrownBy { sut.getMySlots(1L, mon, mon.plusDays(400)) }
+            .isInstanceOf(BusinessException::class.java)
+    }
+}

--- a/src/test/kotlin/com/bandage/bandmanager/domain/availability/service/MemberAvailabilityWriteTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/availability/service/MemberAvailabilityWriteTest.kt
@@ -1,0 +1,154 @@
+package com.bandage.bandmanager.domain.availability.service
+
+import com.bandage.bandmanager.domain.availability.dto.req.MemberAvailabilityRequest
+import com.bandage.bandmanager.domain.availability.dto.req.MemberAvailabilityRequest.AvailabilityExceptionRequest
+import com.bandage.bandmanager.domain.availability.dto.req.MemberAvailabilityRequest.WeeklyRuleRequest
+import com.bandage.bandmanager.domain.availability.model.AvailabilityException
+import com.bandage.bandmanager.domain.availability.model.AvailabilityKind
+import com.bandage.bandmanager.domain.availability.model.MemberAvailability
+import com.bandage.bandmanager.domain.availability.model.WeeklyRule
+import com.bandage.bandmanager.domain.availability.repository.MemberAvailabilityRepository
+import com.bandage.bandmanager.global.error.exception.BusinessException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.assertj.core.api.Assertions.tuple
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.time.DayOfWeek
+import java.time.LocalDate
+
+class MemberAvailabilityWriteTest {
+    private val repository = mock(MemberAvailabilityRepository::class.java)
+    private val sut = MemberAvailabilityService(repository)
+
+    private val day = DayOfWeek.MONDAY
+    private val from = LocalDate.of(2026, 6, 13)
+    private val to = LocalDate.of(2026, 7, 1)
+
+    private fun rule(
+        f: LocalDate,
+        t: LocalDate?,
+    ) = WeeklyRule(day, startSlot = 20, endSlot = 44, effectiveFrom = f, effectiveTo = t)
+
+    private fun seed(
+        rules: List<WeeklyRule> = emptyList(),
+        exceptions: List<AvailabilityException> = emptyList(),
+    ): MemberAvailability {
+        val av =
+            MemberAvailability.create(1L).apply {
+                updateWeeklyRules(rules)
+                updateExceptions(exceptions)
+            }
+        `when`(repository.findByMemberId(1L)).thenReturn(av)
+        `when`(repository.save(av)).thenReturn(av)
+        return av
+    }
+
+    private fun request(exceptions: List<AvailabilityExceptionRequest> = emptyList()) =
+        MemberAvailabilityRequest(
+            effectiveFrom = from,
+            effectiveTo = to,
+            weeklyRules = listOf(WeeklyRuleRequest(day, 20, 44)),
+            exceptions = exceptions,
+        )
+
+    private fun ranges(av: MemberAvailability) = av.weeklyRules.map { tuple(it.effectiveFrom, it.effectiveTo) }
+
+    @Test
+    fun `구간에 머리만 걸친 규칙은 잘리고 새 규칙이 들어간다 - 6_1~6_15 후 6_13~7_1`() {
+        val av = seed(rules = listOf(rule(LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 15))))
+
+        sut.updateMyAvailability(1L, request())
+
+        // 6/1~6/12 보존(머리), 6/13~7/1 신규. 겹침/손실 없음
+        assertThat(ranges(av)).containsExactlyInAnyOrder(
+            tuple(LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 12)),
+            tuple(from, to),
+        )
+    }
+
+    @Test
+    fun `구간이 규칙 가운데를 관통하면 머리+꼬리로 split 된다`() {
+        val av = seed(rules = listOf(rule(LocalDate.of(2026, 6, 1), LocalDate.of(2026, 7, 31))))
+
+        sut.updateMyAvailability(1L, request())
+
+        assertThat(ranges(av)).containsExactlyInAnyOrder(
+            tuple(LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 12)),
+            tuple(LocalDate.of(2026, 7, 2), LocalDate.of(2026, 7, 31)),
+            tuple(from, to),
+        )
+    }
+
+    @Test
+    fun `구간에 완전히 포함된 규칙은 제거되고 새 규칙으로 대체된다`() {
+        val av = seed(rules = listOf(rule(LocalDate.of(2026, 6, 14), LocalDate.of(2026, 6, 20))))
+
+        sut.updateMyAvailability(1L, request())
+
+        assertThat(ranges(av)).containsExactly(tuple(from, to))
+    }
+
+    @Test
+    fun `구간과 겹치지 않는 규칙은 그대로 보존된다`() {
+        val av = seed(rules = listOf(rule(LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 31))))
+
+        sut.updateMyAvailability(1L, request())
+
+        assertThat(ranges(av)).containsExactlyInAnyOrder(
+            tuple(LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 31)),
+            tuple(from, to),
+        )
+    }
+
+    @Test
+    fun `무기한 규칙은 꼬리가 무기한으로 유지된다`() {
+        val av = seed(rules = listOf(rule(LocalDate.of(2026, 6, 1), null)))
+
+        sut.updateMyAvailability(1L, request())
+
+        assertThat(ranges(av)).containsExactlyInAnyOrder(
+            tuple(LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 12)),
+            tuple(LocalDate.of(2026, 7, 2), null),
+            tuple(from, to),
+        )
+    }
+
+    @Test
+    fun `구간 안 예외는 교체되고 구간 밖 예외는 보존된다`() {
+        val outside = AvailabilityException(LocalDate.of(2026, 6, 1), AvailabilityKind.BLOCKED)
+        val inside = AvailabilityException(LocalDate.of(2026, 6, 20), AvailabilityKind.BLOCKED)
+        val av = seed(exceptions = listOf(outside, inside))
+
+        sut.updateMyAvailability(
+            1L,
+            request(exceptions = listOf(AvailabilityExceptionRequest(LocalDate.of(2026, 6, 14), AvailabilityKind.BLOCKED))),
+        )
+
+        assertThat(av.exceptions.map { it.date })
+            .containsExactlyInAnyOrder(LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 14))
+    }
+
+    @Test
+    fun `구간 밖 날짜의 예외를 제출하면 AVAILABILITY_INVALID`() {
+        seed()
+
+        assertThatThrownBy {
+            sut.updateMyAvailability(
+                1L,
+                request(exceptions = listOf(AvailabilityExceptionRequest(LocalDate.of(2026, 8, 1), AvailabilityKind.BLOCKED))),
+            )
+        }.isInstanceOf(BusinessException::class.java)
+    }
+
+    @Test
+    fun `effectiveFrom 이 effectiveTo 보다 늦으면 AVAILABILITY_INVALID`() {
+        assertThatThrownBy {
+            sut.updateMyAvailability(
+                1L,
+                MemberAvailabilityRequest(effectiveFrom = to, effectiveTo = from),
+            )
+        }.isInstanceOf(BusinessException::class.java)
+    }
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #
> Jira: BD-151

📌 **작업 내용 및 특이사항**

멤버 글로벌 가용성 도메인의 **조회 응답·쓰기 시맨틱**을 개편했습니다. 입력은 기존처럼 effective from-to + 예외(벌크)를 유지하되, 다음 3가지 문제를 해결합니다.

| 문제 | 해결 |
|---|---|
| ① 전체 교체(full-replace)로 과거/무관 날짜 가용성이 함께 소실 | **범위 한정 쓰기**: `effectiveFrom~effectiveTo` 구간만 교체, 구간 밖은 보존 |
| ② 겹치는 일정의 순수 상태(net)를 알 수 없음 | **조회 시 서버 전개**: 우선순위 적용 후 확정 슬롯으로 반환 |
| ③ 클라이언트가 규칙→날짜 전개를 직접 계산 | **슬롯 응답**: 날짜별 가용 슬롯 그대로 렌더 가능 |

**변경 요약**
- `GET /me/availability/slots?from=&to=` 신설 — 규칙/예외를 날짜별 가용 슬롯으로 on-read 전개해 반환(최대 366일). 별도 슬롯 저장 테이블·마이그레이션 없음.
- `PUT /me/availability` — 범위 한정 교체로 변경. 구간에 걸친 기존 주간 규칙을 경계에서 clip(머리/꼬리/관통 시 split, 완전 포함 시 제거), 무기한 규칙은 꼬리 무기한 유지. 구간 내 예외만 교체.
- 가용 판정 로직을 `MemberAvailability.isAvailableAt`로 이동(+`AvailabilityException.overlaps/covers`), `AvailabilityCalculator`는 위임 — **거동 불변**(기존 테스트 그대로 통과).
- 공유 `ScheduleSlotResponse`/`ScheduleSlotType` DTO 신설 — 향후 합주/공연 등 멤버 전체 일정을 동일 포맷으로 투영하기 위한 기반(통합 엔드포인트 자체는 보류).
- `MemberAvailabilityRequest`: top-level `effectiveFrom/effectiveTo`(window) 추가, `WeeklyRuleRequest`의 per-rule 날짜 제거(window 상속). ⚠️ **요청 스키마 breaking change**.

**설계 메모(ponytail)**: 슬롯 영속화 테이블/월 단위 커서 페이징/통합 집계 엔드포인트는 의도적으로 제외. 조회 범위(`from~to`)가 곧 페이지, 규칙은 그대로 진실의 원천으로 유지.

📚 **참고사항**
- 신규 단위테스트: `MemberAvailabilitySlotsTest`(전개·BLOCKED 도려내기·범위 검증), `MemberAvailabilityWriteTest`(머리/꼬리/split/완전포함/보존/무기한/예외 교체/검증).
- 저장 스키마(`p_member_availability*`) 변경 없음 → DB 마이그레이션 불필요.

✅ **체크리스트**
- [x] API(Controller/DTO)를 변경한 경우 `docs/openapi.json`을 갱신했습니다 (코드-스펙 동일 PR 규약)

🤖 Generated with [Claude Code](https://claude.com/claude-code)