### PR TITLE
[BD-151] refactor: 가용성 주간 규칙 coalesce(파편화 방지)

### DIFF
--- a/src/main/kotlin/com/bandage/bandmanager/domain/availability/service/MemberAvailabilityService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/availability/service/MemberAvailabilityService.kt
@@ -13,6 +13,7 @@ import com.bandage.bandmanager.global.error.errorcode.ErrorCode
 import com.bandage.bandmanager.global.error.exception.BusinessException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 
@@ -78,6 +79,7 @@ class MemberAvailabilityService(
      * 내 가용성 등록/수정(범위 한정 교체). [effectiveFrom, effectiveTo] 구간만 교체하고 구간 밖은 보존한다.
      * - 구간에 걸치는 기존 주간 규칙은 경계에서 잘라낸다(머리/꼬리, 완전 포함이면 제거).
      * - 구간 안의 기존 예외는 제거하고 제출분으로 대체한다.
+     * - 잘린 조각/신규 규칙 중 같은 패턴이 맞닿으면 다시 병합(coalesce)해 파편화를 막는다.
      */
     @Transactional
     fun updateMyAvailability(
@@ -101,7 +103,7 @@ class MemberAvailabilityService(
         val keptRules = availability.weeklyRules.flatMap { clip(it, from, to) }
         val keptExceptions = availability.exceptions.filter { it.date.isBefore(from) || it.date.isAfter(to) }
 
-        availability.updateWeeklyRules(keptRules + newRules)
+        availability.updateWeeklyRules(coalesce(keptRules + newRules))
         availability.updateExceptions(keptExceptions + newExceptions)
         availability.updateNote(request.note)
 
@@ -134,6 +136,47 @@ class MemberAvailabilityService(
         }
         return result
     }
+
+    /**
+     * 같은 패턴(dayOfWeek, startSlot, endSlot)의 규칙들 중 날짜 구간이 맞닿거나 겹치는 것을 하나로 병합한다.
+     * 동일 패턴을 부분 구간에 다시 칠하거나 clip 으로 쪼개진 조각이 그대로 쌓이는 파편화를 막아,
+     * 저장 레벨에서도 멱등이 되게 한다. (무기한 effectiveTo == null 꼬리 포함)
+     */
+    private fun coalesce(rules: List<WeeklyRule>): List<WeeklyRule> =
+        rules
+            .groupBy { Triple(it.dayOfWeek, it.startSlot, it.endSlot) }
+            .flatMap { (pattern, group) -> mergeContiguous(pattern, group) }
+
+    private fun mergeContiguous(
+        pattern: Triple<DayOfWeek, Int, Int>,
+        group: List<WeeklyRule>,
+    ): List<WeeklyRule> {
+        val sorted = group.sortedWith(compareBy({ it.effectiveFrom }, { it.effectiveTo ?: LocalDate.MAX }))
+        val merged = mutableListOf<WeeklyRule>()
+        var from = sorted.first().effectiveFrom
+        var to: LocalDate? = sorted.first().effectiveTo
+        for (rule in sorted.drop(1)) {
+            val curTo = to
+            val ruleTo = rule.effectiveTo
+            // 무기한 꼬리(curTo == null)는 이후 전부 흡수. 그 외엔 맞닿음(curTo+1)/겹침이면 병합.
+            val contiguous = curTo == null || !rule.effectiveFrom.isAfter(curTo.plusDays(1))
+            if (contiguous) {
+                to = if (curTo == null || ruleTo == null) null else maxOf(curTo, ruleTo)
+            } else {
+                merged += ruleOf(pattern, from, curTo)
+                from = rule.effectiveFrom
+                to = ruleTo
+            }
+        }
+        merged += ruleOf(pattern, from, to)
+        return merged
+    }
+
+    private fun ruleOf(
+        pattern: Triple<DayOfWeek, Int, Int>,
+        from: LocalDate,
+        to: LocalDate?,
+    ): WeeklyRule = WeeklyRule(pattern.first, pattern.second, pattern.third, from, to)
 
     // 슬롯/기간 검증은 Embeddable init 에서 수행되므로, 생성 실패 시 BusinessException 으로 변환한다.
     private fun parseWeeklyRules(request: MemberAvailabilityRequest): List<WeeklyRule> =

--- a/src/test/kotlin/com/bandage/bandmanager/domain/availability/service/MemberAvailabilityWriteTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/availability/service/MemberAvailabilityWriteTest.kt
@@ -26,10 +26,11 @@ class MemberAvailabilityWriteTest {
     private val from = LocalDate.of(2026, 6, 13)
     private val to = LocalDate.of(2026, 7, 1)
 
-    private fun rule(
+    /** 기존(seeded) 패턴: 월 18~22h (slot 36~44). */
+    private fun seeded(
         f: LocalDate,
         t: LocalDate?,
-    ) = WeeklyRule(day, startSlot = 20, endSlot = 44, effectiveFrom = f, effectiveTo = t)
+    ) = WeeklyRule(day, startSlot = 36, endSlot = 44, effectiveFrom = f, effectiveTo = t)
 
     private fun seed(
         rules: List<WeeklyRule> = emptyList(),
@@ -45,75 +46,117 @@ class MemberAvailabilityWriteTest {
         return av
     }
 
-    private fun request(exceptions: List<AvailabilityExceptionRequest> = emptyList()) =
-        MemberAvailabilityRequest(
-            effectiveFrom = from,
-            effectiveTo = to,
-            weeklyRules = listOf(WeeklyRuleRequest(day, 20, 44)),
-            exceptions = exceptions,
-        )
+    /** 기본 신규 규칙은 기존과 다른 슬롯(20~24)이라 clip 조각과 병합되지 않아 조각이 관찰된다. */
+    private fun request(
+        startSlot: Int = 20,
+        endSlot: Int = 24,
+        exceptions: List<AvailabilityExceptionRequest> = emptyList(),
+    ) = MemberAvailabilityRequest(
+        effectiveFrom = from,
+        effectiveTo = to,
+        weeklyRules = listOf(WeeklyRuleRequest(day, startSlot, endSlot)),
+        exceptions = exceptions,
+    )
 
-    private fun ranges(av: MemberAvailability) = av.weeklyRules.map { tuple(it.effectiveFrom, it.effectiveTo) }
+    /** (startSlot, effectiveFrom, effectiveTo) — startSlot 36/20 으로 패턴 구분. */
+    private fun rows(av: MemberAvailability) = av.weeklyRules.map { tuple(it.startSlot, it.effectiveFrom, it.effectiveTo) }
+
+    // ---------- clip: 다른 패턴 신규 → 잘린 조각이 그대로 남는다 ----------
 
     @Test
-    fun `구간에 머리만 걸친 규칙은 잘리고 새 규칙이 들어간다 - 6_1~6_15 후 6_13~7_1`() {
-        val av = seed(rules = listOf(rule(LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 15))))
+    fun `구간에 머리만 걸친 규칙은 잘리고 새 규칙이 들어간다`() {
+        val av = seed(rules = listOf(seeded(LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 15))))
 
         sut.updateMyAvailability(1L, request())
 
-        // 6/1~6/12 보존(머리), 6/13~7/1 신규. 겹침/손실 없음
-        assertThat(ranges(av)).containsExactlyInAnyOrder(
-            tuple(LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 12)),
-            tuple(from, to),
+        assertThat(rows(av)).containsExactlyInAnyOrder(
+            tuple(36, LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 12)),
+            tuple(20, from, to),
         )
     }
 
     @Test
     fun `구간이 규칙 가운데를 관통하면 머리+꼬리로 split 된다`() {
-        val av = seed(rules = listOf(rule(LocalDate.of(2026, 6, 1), LocalDate.of(2026, 7, 31))))
+        val av = seed(rules = listOf(seeded(LocalDate.of(2026, 6, 1), LocalDate.of(2026, 7, 31))))
 
         sut.updateMyAvailability(1L, request())
 
-        assertThat(ranges(av)).containsExactlyInAnyOrder(
-            tuple(LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 12)),
-            tuple(LocalDate.of(2026, 7, 2), LocalDate.of(2026, 7, 31)),
-            tuple(from, to),
+        assertThat(rows(av)).containsExactlyInAnyOrder(
+            tuple(36, LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 12)),
+            tuple(36, LocalDate.of(2026, 7, 2), LocalDate.of(2026, 7, 31)),
+            tuple(20, from, to),
         )
     }
 
     @Test
     fun `구간에 완전히 포함된 규칙은 제거되고 새 규칙으로 대체된다`() {
-        val av = seed(rules = listOf(rule(LocalDate.of(2026, 6, 14), LocalDate.of(2026, 6, 20))))
+        val av = seed(rules = listOf(seeded(LocalDate.of(2026, 6, 14), LocalDate.of(2026, 6, 20))))
 
         sut.updateMyAvailability(1L, request())
 
-        assertThat(ranges(av)).containsExactly(tuple(from, to))
+        assertThat(rows(av)).containsExactly(tuple(20, from, to))
     }
 
     @Test
     fun `구간과 겹치지 않는 규칙은 그대로 보존된다`() {
-        val av = seed(rules = listOf(rule(LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 31))))
+        val av = seed(rules = listOf(seeded(LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 31))))
 
         sut.updateMyAvailability(1L, request())
 
-        assertThat(ranges(av)).containsExactlyInAnyOrder(
-            tuple(LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 31)),
-            tuple(from, to),
+        assertThat(rows(av)).containsExactlyInAnyOrder(
+            tuple(36, LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 31)),
+            tuple(20, from, to),
         )
     }
 
     @Test
     fun `무기한 규칙은 꼬리가 무기한으로 유지된다`() {
-        val av = seed(rules = listOf(rule(LocalDate.of(2026, 6, 1), null)))
+        val av = seed(rules = listOf(seeded(LocalDate.of(2026, 6, 1), null)))
 
         sut.updateMyAvailability(1L, request())
 
-        assertThat(ranges(av)).containsExactlyInAnyOrder(
-            tuple(LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 12)),
-            tuple(LocalDate.of(2026, 7, 2), null),
-            tuple(from, to),
+        assertThat(rows(av)).containsExactlyInAnyOrder(
+            tuple(36, LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 12)),
+            tuple(36, LocalDate.of(2026, 7, 2), null),
+            tuple(20, from, to),
         )
     }
+
+    // ---------- coalesce: 같은 패턴 신규 → 맞닿은 조각이 다시 병합된다 ----------
+
+    @Test
+    fun `같은 패턴을 겹치는 구간에 다시 칠하면 하나로 병합된다`() {
+        val av = seed(rules = listOf(seeded(LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 15))))
+
+        sut.updateMyAvailability(1L, request(startSlot = 36, endSlot = 44))
+
+        // 머리(6/1~6/12) + 신규(6/13~7/1) 동일 패턴 → (6/1~7/1) 한 줄
+        assertThat(rows(av)).containsExactly(tuple(36, LocalDate.of(2026, 6, 1), to))
+    }
+
+    @Test
+    fun `같은 패턴이면 split 된 무기한 규칙이 다시 무기한 한 줄로 자가치유된다`() {
+        val av = seed(rules = listOf(seeded(LocalDate.of(2026, 6, 1), null)))
+
+        sut.updateMyAvailability(1L, request(startSlot = 36, endSlot = 44))
+
+        // 머리 + 신규 + 무기한 꼬리 모두 동일 패턴·연속 → (6/1~무기한) 한 줄로 복원(저장 멱등)
+        assertThat(rows(av)).containsExactly(tuple(36, LocalDate.of(2026, 6, 1), null))
+    }
+
+    @Test
+    fun `날짜가 맞닿아도 패턴이 다르면 병합하지 않는다`() {
+        val av = seed(rules = listOf(seeded(LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 12))))
+
+        sut.updateMyAvailability(1L, request(startSlot = 20, endSlot = 24))
+
+        assertThat(rows(av)).containsExactlyInAnyOrder(
+            tuple(36, LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 12)),
+            tuple(20, from, to),
+        )
+    }
+
+    // ---------- 예외 / 검증 ----------
 
     @Test
     fun `구간 안 예외는 교체되고 구간 밖 예외는 보존된다`() {


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #
> Jira: BD-151 (후속)

📌 **작업 내용 및 특이사항**

범위 한정 쓰기(#121)의 후속. 같은 패턴을 부분 구간에 다시 칠하거나, `clip`으로 쪼개진 조각이 그대로 누적되는 **주간 규칙 파편화**를 막습니다.

- `updateMyAvailability` 끝에서 같은 패턴(`dayOfWeek, startSlot, endSlot`)이면서 날짜 구간이 맞닿거나 겹치는 규칙을 하나로 **병합(coalesce)**.
- 효과: 동일 패턴 편집이 **저장 레벨에서도 멱등**이 됨.
  - 예) `월 18~22h 무기한` 규칙에 `[6/13~7/1]` 같은 패턴을 다시 PUT → 기존엔 머리/꼬리/신규 3조각으로 남던 것이 → `월 18~22h 무기한` 한 줄로 **자가치유**.
- 무기한(`effectiveTo == null`) 꼬리 병합 포함.
- 다른 패턴(슬롯/요일 다름)은 날짜가 맞닿아도 병합하지 않음.

**스코프 메모**: 내부 로직 변경만으로 API/DTO·DB 스키마 불변 → `docs/openapi.json` 변경 없음.

📚 **참고사항**
- `MemberAvailabilityWriteTest` 를 clip(다른 패턴→조각 유지) / coalesce(같은 패턴→치유) 두 그룹으로 재구성, 병합 케이스 3종 추가.

✅ **체크리스트**
- [x] API(Controller/DTO)를 변경한 경우 `docs/openapi.json`을 갱신했습니다 (코드-스펙 동일 PR 규약) — 해당 없음(내부 로직만)

🤖 Generated with [Claude Code](https://claude.com/claude-code)