### PR TITLE
[BD-156] refactor: 내 공연 목록 조회에 직접 참여 경로 합집합

### DIFF
--- a/src/main/kotlin/com/bandage/bandmanager/domain/performance/repository/PerformanceRepositoryCustom.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/performance/repository/PerformanceRepositoryCustom.kt
@@ -16,7 +16,8 @@ interface PerformanceRepositoryCustom {
         pageSize: Int,
     ): CursorResponse<Performance, UUID>
 
-    fun findAllByBandIdsAndPaging(
+    fun findMyPerformancesByCursor(
+        memberId: Long,
         bandIds: List<UUID>,
         lastId: UUID?,
         pageSize: Int,

--- a/src/main/kotlin/com/bandage/bandmanager/domain/performance/repository/PerformanceRepositoryImpl.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/performance/repository/PerformanceRepositoryImpl.kt
@@ -2,10 +2,12 @@ package com.bandage.bandmanager.domain.performance.repository
 
 import com.bandage.bandmanager.domain.performance.model.Performance
 import com.bandage.bandmanager.domain.performance.model.QPerformance
+import com.bandage.bandmanager.domain.performance.model.QPerformanceManager
 import com.bandage.bandmanager.domain.performance.model.QPerformanceSetlist
 import com.bandage.bandmanager.domain.setlist.model.QSetlistBand
 import com.bandage.bandmanager.global.common.response.CursorResponse
 import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.JPAExpressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import java.util.UUID
 
@@ -55,7 +57,8 @@ class PerformanceRepositoryImpl(
         return buildCursorResponse(contents, pageSize)
     }
 
-    override fun findAllByBandIdsAndPaging(
+    override fun findMyPerformancesByCursor(
+        memberId: Long,
         bandIds: List<UUID>,
         lastId: UUID?,
         pageSize: Int,
@@ -63,18 +66,34 @@ class PerformanceRepositoryImpl(
         val qPerformance = QPerformance.performance
         val qPerformanceSetlist = QPerformanceSetlist.performanceSetlist
         val qSetlistBand = QSetlistBand.setlistBand
+        val qPerformanceManager = QPerformanceManager.performanceManager
+
+        // 직접 참여 경로: 공연 멤버(생성자 OWNER · 초대 수락 MANAGER)는 밴드 매핑과 무관하게 항상 포함
+        val viaManager =
+            JPAExpressions
+                .select(qPerformanceManager.performance.id)
+                .from(qPerformanceManager)
+                .where(qPerformanceManager.member.eq(memberId))
+        var condition: BooleanExpression = qPerformance.id.`in`(viaManager)
+
+        // 밴드 참여 경로: 내가 속한 밴드가 셋리스트로 참여하는 공연 — 소속 밴드가 있을 때만 합집합
+        if (bandIds.isNotEmpty()) {
+            val viaBand =
+                JPAExpressions
+                    .select(qPerformanceSetlist.performance.id)
+                    .from(qPerformanceSetlist)
+                    .join(qSetlistBand)
+                    .on(qSetlistBand.setlistId.eq(qPerformanceSetlist.setlistId))
+                    .where(qSetlistBand.bandId.`in`(bandIds))
+            condition = condition.or(qPerformance.id.`in`(viaBand))
+        }
 
         val contents =
             queryFactory
                 .selectFrom(qPerformance)
-                .join(qPerformanceSetlist)
-                .on(qPerformanceSetlist.performance.eq(qPerformance))
-                .join(qSetlistBand)
-                .on(qSetlistBand.setlistId.eq(qPerformanceSetlist.setlistId))
-                .where(qSetlistBand.bandId.`in`(bandIds))
+                .where(condition)
                 .where(ltPerformanceId(lastId))
                 .orderBy(qPerformance.id.desc())
-                .distinct()
                 .limit(pageSize.toLong() + 1)
                 .fetch()
 

--- a/src/main/kotlin/com/bandage/bandmanager/domain/performance/service/PerformanceService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/performance/service/PerformanceService.kt
@@ -110,10 +110,7 @@ class PerformanceService(
         query: PerformancePagingQuery,
     ): CursorResponse<PerformanceListResponse, UUID> {
         val bandIds = bandMemberRepository.findAllBandIdsByMember(memberId)
-        if (bandIds.isEmpty()) {
-            return CursorResponse(content = emptyList(), nextCursor = null, hasNext = false)
-        }
-        val result = performanceRepository.findAllByBandIdsAndPaging(bandIds, query.lastId, query.pageSize)
+        val result = performanceRepository.findMyPerformancesByCursor(memberId, bandIds, query.lastId, query.pageSize)
         val summaries = buildSetlistSummaries(result.content.flatMap { p -> p.setlists.map { it.setlistId } })
         return CursorResponse(
             content = result.content.map { PerformanceListResponse.of(it, summaries) },

--- a/src/main/resources/db/changelog/changes/020-performance-manager-member-index.sql
+++ b/src/main/resources/db/changelog/changes/020-performance-manager-member-index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_performance_manager_member
+    ON p_performance_manager (member_id);

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -240,3 +240,16 @@ databaseChangeLog:
             splitStatements: true
             stripComments: true
             endDelimiter: ";"
+  - changeSet:
+      id: 020-performance-manager-member-index
+      author: bandage
+      comment: |
+        BD-156: 내 공연 목록 직접 참여 경로 조회 인덱스
+        - p_performance_manager.member_id 단독 인덱스 (UK가 performance_id 선두라 member_id 단독 조회엔 미사용)
+      changes:
+        - sqlFile:
+            path: changes/020-performance-manager-member-index.sql
+            relativeToChangelogFile: true
+            splitStatements: true
+            stripComments: true
+            endDelimiter: ";"


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #156

📌 **작업 내용 및 특이사항**

- `내 공연 목록 조회`(`GET /performances/me`)가 밴드 멤버십 경로(셋리스트→밴드)로만 조회해, 밴드에 매이지 않은 **개인 공연 참여자**(초대 수락자 등)가 자기 공연을 보지 못하던 문제를 보강했습니다.
- `PerformanceManager`(공연 멤버 — 생성자 OWNER·초대 수락 MANAGER)를 **직접 참여 경로**로 합집합 조회에 추가했습니다. (`findMyPerformancesByCursor`)
- 소속 밴드가 없으면 빈 결과를 반환하던 early return을 제거했습니다.
- 직접 참여 경로 서브쿼리(`member_id`) 조회를 위해 `p_performance_manager(member_id)` 인덱스를 추가했습니다. (UK가 `performance_id` 선두라 단독 조회엔 미사용 / Liquibase changeset `020`)

📚 **참고사항**

- 엔드포인트·요청/응답 DTO 변경 없음(내부 쿼리만) → `docs/openapi.json` 갱신 불필요.
- **후속 과제(본 PR 범위 밖)**: ① 공연 참여 = 전체 활동 참여(선곡회의/합주 등)로의 전파, ② OWNER 탈퇴 시 밴드 기반 fallback이 개인-only 공연에서 비는 케이스.

✅ **체크리스트**
- [x] API(Controller/DTO)를 변경한 경우 `docs/openapi.json`을 갱신했습니다 (코드-스펙 동일 PR 규약) — 본 PR은 API 변경 없음
