### PR TITLE
[BD-173] refactor: 조회 API 응답에 회원 정보(MemberSummary) 보강

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2823,11 +2823,9 @@
             "JamParticipantResponse": {
                 "description": "\ud569\uc8fc \ucc38\uc5ec\uc790 \uc751\ub2f5",
                 "properties": {
-                    "memberId": {
-                        "description": "\ud68c\uc6d0 \uace0\uc720 \uc2dd\ubcc4\uc790 (Long)",
-                        "example": 1,
-                        "format": "int64",
-                        "type": "integer"
+                    "member": {
+                        "$ref": "#/components/schemas/MemberSummary",
+                        "description": "\ucc38\uc5ec\uc790 \ud68c\uc6d0 \uc815\ubcf4 (\ud0c8\ud1f4 \ud68c\uc6d0\uc774\uba74 null)"
                     },
                     "participantId": {
                         "description": "\ucc38\uc5ec\uc790 \uace0\uc720 \uc2dd\ubcc4\uc790 (UUID)",
@@ -2842,7 +2840,6 @@
                     }
                 },
                 "required": [
-                    "memberId",
                     "participantId"
                 ],
                 "type": "object"
@@ -2933,10 +2930,9 @@
                         "type": "integer"
                     },
                     "participants": {
-                        "description": "\ubc30\uc815\ub41c \ucc38\uc5ec\uc790 \ud68c\uc6d0 ID \ubaa9\ub85d",
+                        "description": "\ubc30\uc815\ub41c \ucc38\uc5ec\uc790 \ubaa9\ub85d",
                         "items": {
-                            "format": "int64",
-                            "type": "integer"
+                            "$ref": "#/components/schemas/MemberSummary"
                         },
                         "type": "array"
                     },
@@ -3447,6 +3443,32 @@
                 ],
                 "type": "object"
             },
+            "MemberSummary": {
+                "description": "\ud68c\uc6d0 \uc694\uc57d \uc815\ubcf4 (\uc784\ubca0\ub4dc\uc6a9)",
+                "properties": {
+                    "memberId": {
+                        "description": "\ud68c\uc6d0 \uace0\uc720 \uc2dd\ubcc4\uc790 (Long)",
+                        "example": 1,
+                        "format": "int64",
+                        "type": "integer"
+                    },
+                    "name": {
+                        "description": "\ud68c\uc6d0 \uc774\ub984",
+                        "example": "\ud64d\uae38\ub3d9",
+                        "type": "string"
+                    },
+                    "profileImg": {
+                        "description": "\ud504\ub85c\ud544 \uc774\ubbf8\uc9c0 URL (nullable)",
+                        "example": "https://cdn.example.com/profile/member/1/uuid.jpg",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "memberId",
+                    "name"
+                ],
+                "type": "object"
+            },
             "MyBandApplicationInfoResponse": {
                 "description": "\ub0b4 \ubc34\ub4dc \uac00\uc785 \uc2e0\uccad \ud56d\ubaa9 (\uc2e0\uccad \uc815\ubcf4 + \ub300\uc0c1 \ubc34\ub4dc \uc815\ubcf4)",
                 "properties": {
@@ -3739,6 +3761,14 @@
                         },
                         "type": "array"
                     },
+                    "isManager": {
+                        "description": "\uc774 \ucc38\uc5ec\uc790\uac00 \uc120\uace1 \ud68c\uc758\uc758 \ub9e4\ub2c8\uc800\uc778\uc9c0 \uc5ec\ubd80",
+                        "type": "boolean"
+                    },
+                    "member": {
+                        "$ref": "#/components/schemas/MemberSummary",
+                        "description": "\ucc38\uc5ec\uc790 \ud68c\uc6d0 \uc815\ubcf4 (\ud0c8\ud1f4 \ud68c\uc6d0\uc774\uba74 null)"
+                    },
                     "memberId": {
                         "format": "int64",
                         "type": "integer"
@@ -3746,6 +3776,7 @@
                 },
                 "required": [
                     "bandIds",
+                    "isManager",
                     "memberId"
                 ],
                 "type": "object"
@@ -4802,16 +4833,16 @@
             "SessionDefResponse": {
                 "properties": {
                     "applicants": {
+                        "description": "\uc9c0\uc6d0\uc790 \ud68c\uc6d0 \ubaa9\ub85d",
                         "items": {
-                            "format": "int64",
-                            "type": "integer"
+                            "$ref": "#/components/schemas/MemberSummary"
                         },
                         "type": "array"
                     },
                     "confirmed": {
+                        "description": "\ud655\uc815\uc790 \ud68c\uc6d0 \ubaa9\ub85d",
                         "items": {
-                            "format": "int64",
-                            "type": "integer"
+                            "$ref": "#/components/schemas/MemberSummary"
                         },
                         "type": "array"
                     },
@@ -4865,9 +4896,9 @@
                         "format": "date-time",
                         "type": "string"
                     },
-                    "memberId": {
-                        "format": "int64",
-                        "type": "integer"
+                    "member": {
+                        "$ref": "#/components/schemas/MemberSummary",
+                        "description": "\uc791\uc131\uc790 \ud68c\uc6d0 \uc815\ubcf4 (\ud0c8\ud1f4 \ud68c\uc6d0\uc774\uba74 null)"
                     },
                     "message": {
                         "type": "string"
@@ -4882,7 +4913,6 @@
                     }
                 },
                 "required": [
-                    "memberId",
                     "message",
                     "messageId",
                     "trackSelectionItemId"
@@ -5508,9 +5538,9 @@
                     "note": {
                         "type": "string"
                     },
-                    "proposerId": {
-                        "format": "int64",
-                        "type": "integer"
+                    "proposer": {
+                        "$ref": "#/components/schemas/MemberSummary",
+                        "description": "\uace1 \uc81c\uc548\uc790 \ud68c\uc6d0 \uc815\ubcf4 (\ud0c8\ud1f4 \ud68c\uc6d0\uc774\uba74 null)"
                     },
                     "reference": {
                         "description": "\ucc38\uace0 \ub9c1\ud06c(\uc608: YouTube)",
@@ -5541,7 +5571,6 @@
                 "required": [
                     "artist",
                     "isSelected",
-                    "proposerId",
                     "selectionId",
                     "sessions",
                     "title",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7493,6 +7493,28 @@
                 ]
             }
         },
+        "/api/v1/members/{memberId}": {
+            "get": {
+                "description": "\ud68c\uc6d0 ID\ub85c \ud2b9\uc815 \ud68c\uc6d0\uc758 \uc815\ubcf4\ub97c \uc870\ud68c\ud569\ub2c8\ub2e4.",
+                "operationId": "getMemberInfoById",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiResponseMemberInfoResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    }
+                },
+                "summary": "\ud68c\uc6d0 \uc815\ubcf4 \uc870\ud68c API(\ud68c\uc6d0 ID)",
+                "tags": [
+                    "members"
+                ]
+            }
+        },
         "/api/v1/notifications": {
             "get": {
                 "description": "\ub85c\uadf8\uc778\ud55c \ud68c\uc6d0\uc758 \uc804\uccb4 \uc54c\ub9bc\uc744 \ucee4\uc11c \uae30\ubc18 \ucd5c\uc2e0\uc21c\uc73c\ub85c \uc870\ud68c\ud569\ub2c8\ub2e4. \uce74\ud14c\uace0\ub9ac \ud544\ud130\ub9c1\uc740 \ud504\ub860\ud2b8\uac00 \ucc98\ub9ac\ud569\ub2c8\ub2e4.",
@@ -10307,7 +10329,7 @@
     "servers": [
         {
             "description": "Generated server url",
-            "url": "http://bandage-band-manager:8080"
+            "url": "http://localhost:8080"
         }
     ],
     "tags": [

--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/dto/res/JamDetailResponse.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/dto/res/JamDetailResponse.kt
@@ -2,6 +2,7 @@ package com.bandage.bandmanager.domain.jam.dto.res
 
 import com.bandage.bandmanager.domain.jam.model.Jam
 import com.bandage.bandmanager.domain.jam.model.JamParticipant
+import com.bandage.bandmanager.domain.member.dto.res.MemberSummary
 import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
@@ -46,7 +47,10 @@ data class JamDetailResponse(
     )
 
     companion object {
-        fun of(jam: Jam): JamDetailResponse {
+        fun of(
+            jam: Jam,
+            members: Map<Long, MemberSummary>,
+        ): JamDetailResponse {
             // 세션 미배정(소속) 참여자는 sessionId=null 그룹으로 묶이며, 아래 세션별 매핑에서 자연히 제외된다.
             val participantsBySession: Map<String?, List<JamParticipant>> = jam.participants.groupBy { it.sessionId }
             return JamDetailResponse(
@@ -69,10 +73,10 @@ data class JamDetailResponse(
                     jam.sessions.map { def ->
                         JamSessionResponse.of(
                             def = def,
-                            participants = participantsBySession[def.sessionId]?.map { it.member } ?: emptyList(),
+                            participants = participantsBySession[def.sessionId]?.mapNotNull { members[it.member] } ?: emptyList(),
                         )
                     },
-                participants = jam.participants.map { JamParticipantResponse.of(it) },
+                participants = jam.participants.map { JamParticipantResponse.of(it, members[it.member]) },
             )
         }
     }

--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/dto/res/JamParticipantResponse.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/dto/res/JamParticipantResponse.kt
@@ -1,6 +1,7 @@
 package com.bandage.bandmanager.domain.jam.dto.res
 
 import com.bandage.bandmanager.domain.jam.model.JamParticipant
+import com.bandage.bandmanager.domain.member.dto.res.MemberSummary
 import io.swagger.v3.oas.annotations.media.Schema
 import java.util.UUID
 
@@ -10,15 +11,18 @@ data class JamParticipantResponse(
     val participantId: UUID,
     @Schema(description = "세션 토큰(SessionDef.sessionId). 세션 미배정 소속 참여자는 null", example = "G")
     val sessionId: String?,
-    @Schema(description = "회원 고유 식별자 (Long)", example = "1")
-    val memberId: Long,
+    @Schema(description = "참여자 회원 정보 (탈퇴 회원이면 null)")
+    val member: MemberSummary?,
 ) {
     companion object {
-        fun of(participant: JamParticipant): JamParticipantResponse =
+        fun of(
+            participant: JamParticipant,
+            member: MemberSummary?,
+        ): JamParticipantResponse =
             JamParticipantResponse(
                 participantId = participant.id,
                 sessionId = participant.sessionId,
-                memberId = participant.member,
+                member = member,
             )
     }
 }

--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/dto/res/JamSessionResponse.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/dto/res/JamSessionResponse.kt
@@ -1,5 +1,6 @@
 package com.bandage.bandmanager.domain.jam.dto.res
 
+import com.bandage.bandmanager.domain.member.dto.res.MemberSummary
 import com.bandage.bandmanager.global.common.domain.SessionDef
 import io.swagger.v3.oas.annotations.media.Schema
 
@@ -15,13 +16,13 @@ data class JamSessionResponse(
     val need: Int,
     @Schema(description = "커스텀 세션 여부", example = "false")
     val custom: Boolean,
-    @Schema(description = "배정된 참여자 회원 ID 목록")
-    val participants: List<Long>,
+    @Schema(description = "배정된 참여자 목록")
+    val participants: List<MemberSummary>,
 ) {
     companion object {
         fun of(
             def: SessionDef,
-            participants: List<Long>,
+            participants: List<MemberSummary>,
         ): JamSessionResponse =
             JamSessionResponse(
                 sessionId = def.sessionId,

--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/service/JamService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/service/JamService.kt
@@ -17,6 +17,8 @@ import com.bandage.bandmanager.domain.jam.model.Jam
 import com.bandage.bandmanager.domain.jam.model.JamParticipant
 import com.bandage.bandmanager.domain.jam.repository.JamParticipantRepository
 import com.bandage.bandmanager.domain.jam.repository.JamRepository
+import com.bandage.bandmanager.domain.member.dto.res.MemberSummary
+import com.bandage.bandmanager.domain.member.service.MemberService
 import com.bandage.bandmanager.global.common.response.CursorResponse
 import com.bandage.bandmanager.global.error.errorcode.ErrorCode
 import com.bandage.bandmanager.global.error.exception.BusinessException
@@ -32,6 +34,7 @@ class JamService(
     private val jamParticipantRepository: JamParticipantRepository,
     private val bandMemberRepository: BandMemberRepository,
     private val jamReservationSyncService: JamReservationSyncService,
+    private val memberService: MemberService,
 ) {
     @Transactional
     fun createJam(
@@ -59,7 +62,7 @@ class JamService(
         return JamResponse.of(jam)
     }
 
-    fun getJamDetail(jamId: UUID): JamDetailResponse = JamDetailResponse.of(getJam(jamId))
+    fun getJamDetail(jamId: UUID): JamDetailResponse = toDetailResponse(getJam(jamId))
 
     fun getJamsByCursor(
         bandId: UUID?,
@@ -128,7 +131,7 @@ class JamService(
             .forEach { jamParticipantRepository.delete(it) }
         jam.replaceSessions(newDefs)
         jamReservationSyncService.sync(jam)
-        return JamDetailResponse.of(jam)
+        return toDetailResponse(jam)
     }
 
     @Transactional
@@ -150,7 +153,7 @@ class JamService(
                 ),
             )
         jamReservationSyncService.sync(jam)
-        return JamParticipantResponse.of(participant)
+        return JamParticipantResponse.of(participant, summaryOf(participant.member))
     }
 
     @Transactional
@@ -166,12 +169,12 @@ class JamService(
             jamParticipantRepository.findByIdAndJam(participantId, jam)
                 ?: throw BusinessException(ErrorCode.JAM_PARTICIPANT_NOT_FOUND)
         if (participant.sessionId == request.sessionId) {
-            return JamParticipantResponse.of(participant)
+            return JamParticipantResponse.of(participant, summaryOf(participant.member))
         }
         validateSessionExists(jam, request.sessionId)
         validateParticipantNotExists(jam, request.sessionId, participant.member)
         participant.changeSession(request.sessionId)
-        return JamParticipantResponse.of(participant)
+        return JamParticipantResponse.of(participant, summaryOf(participant.member))
     }
 
     @Transactional
@@ -227,6 +230,14 @@ class JamService(
     private fun getJam(jamId: UUID): Jam =
         jamRepository.findByIdOrNull(jamId)
             ?: throw BusinessException(ErrorCode.JAM_NOT_FOUND)
+
+    /** 합주 참여자 전원의 회원 정보를 한 번에 조회해 상세 응답을 구성한다(N+1 방지). */
+    private fun toDetailResponse(jam: Jam): JamDetailResponse {
+        val members = memberService.getMemberSummaries(jam.participants.map { it.member })
+        return JamDetailResponse.of(jam, members)
+    }
+
+    private fun summaryOf(memberId: Long): MemberSummary? = memberService.getMemberSummaries(listOf(memberId))[memberId]
 
     private fun validateParticipant(
         jam: Jam,

--- a/src/main/kotlin/com/bandage/bandmanager/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/member/controller/MemberController.kt
@@ -24,6 +24,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -52,6 +53,15 @@ class MemberController(
     @Operation(operationId = "getMemberInfo", summary = "회원 정보 조회 API", description = "회원 본인의 정보를 조회합니다.")
     fun getMemberInfo(
         @CurrentMemberId memberId: Long,
+    ): ApiResponse<MemberInfoResponse> =
+        ApiResponse.success(
+            memberService.getMemberInfo(memberId),
+        )
+
+    @GetMapping("/{memberId}")
+    @Operation(operationId = "getMemberInfoById", summary = "회원 정보 조회 API(회원 ID)", description = "회원 ID로 특정 회원의 정보를 조회합니다.")
+    fun getMemberInfoById(
+        @PathVariable @CurrentMemberId memberId: Long,
     ): ApiResponse<MemberInfoResponse> =
         ApiResponse.success(
             memberService.getMemberInfo(memberId),

--- a/src/main/kotlin/com/bandage/bandmanager/domain/member/dto/res/MemberSummary.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/member/dto/res/MemberSummary.kt
@@ -1,0 +1,30 @@
+package com.bandage.bandmanager.domain.member.dto.res
+
+import com.bandage.bandmanager.domain.member.model.Member
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * 다른 도메인 응답에 회원 정보를 임베드할 때 쓰는 경량 DTO.
+ * email 등 개인정보는 제외하고 식별·표시에 필요한 최소 정보만 노출한다.
+ */
+@Schema(description = "회원 요약 정보 (임베드용)")
+data class MemberSummary(
+    @Schema(description = "회원 고유 식별자 (Long)", example = "1")
+    val memberId: Long,
+    @Schema(description = "회원 이름", example = "홍길동")
+    val name: String,
+    @Schema(description = "프로필 이미지 URL (nullable)", example = "https://cdn.example.com/profile/member/1/uuid.jpg")
+    val profileImg: String? = null,
+) {
+    companion object {
+        fun of(
+            member: Member,
+            profileImgUrl: String?,
+        ): MemberSummary =
+            MemberSummary(
+                memberId = member.id,
+                name = member.name,
+                profileImg = profileImgUrl,
+            )
+    }
+}

--- a/src/main/kotlin/com/bandage/bandmanager/domain/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/member/repository/MemberRepository.kt
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Repository
 interface MemberRepository : JpaRepository<Member, Long> {
     fun existsByEmail(email: String): Boolean
 
+    fun findAllByIdIn(ids: Collection<Long>): List<Member>
+
     fun findTop20ByNameContainingIgnoreCaseOrEmailContainingIgnoreCase(
         name: String,
         email: String,

--- a/src/main/kotlin/com/bandage/bandmanager/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/member/service/MemberService.kt
@@ -6,6 +6,7 @@ import com.bandage.bandmanager.domain.member.dto.req.MemberCreateRequest
 import com.bandage.bandmanager.domain.member.dto.req.MemberInfoUpdateRequest
 import com.bandage.bandmanager.domain.member.dto.res.MemberInfoResponse
 import com.bandage.bandmanager.domain.member.dto.res.MemberSearchItemResponse
+import com.bandage.bandmanager.domain.member.dto.res.MemberSummary
 import com.bandage.bandmanager.domain.member.model.Member
 import com.bandage.bandmanager.domain.member.repository.MemberRepository
 import com.bandage.bandmanager.global.error.errorcode.ErrorCode
@@ -41,6 +42,14 @@ class MemberService(
     fun getMemberInfo(memberId: Long): MemberInfoResponse {
         val member = getMember(memberId)
         return MemberInfoResponse.of(member, profileImageUrl(member.profileImg))
+    }
+
+    /** 다른 도메인 응답에 회원 정보를 임베드할 때 사용. memberId → MemberSummary 맵을 한 번의 조회로 반환(N+1 방지). */
+    fun getMemberSummaries(ids: Collection<Long>): Map<Long, MemberSummary> {
+        if (ids.isEmpty()) return emptyMap()
+        return memberRepository
+            .findAllByIdIn(ids.toSet())
+            .associateBy({ it.id }, { MemberSummary.of(it, profileImageUrl(it.profileImg)) })
     }
 
     @Transactional

--- a/src/main/kotlin/com/bandage/bandmanager/domain/selection/dto/res/SessionDefResponse.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/selection/dto/res/SessionDefResponse.kt
@@ -1,6 +1,8 @@
 package com.bandage.bandmanager.domain.selection.dto.res
 
+import com.bandage.bandmanager.domain.member.dto.res.MemberSummary
 import com.bandage.bandmanager.global.common.domain.SessionDef
+import io.swagger.v3.oas.annotations.media.Schema
 
 data class SessionDefResponse(
     val sessionId: String,
@@ -8,14 +10,16 @@ data class SessionDefResponse(
     val short: String,
     val need: Int,
     val custom: Boolean,
-    val applicants: List<Long>,
-    val confirmed: List<Long>,
+    @Schema(description = "지원자 회원 목록")
+    val applicants: List<MemberSummary>,
+    @Schema(description = "확정자 회원 목록")
+    val confirmed: List<MemberSummary>,
 ) {
     companion object {
         fun of(
             def: SessionDef,
-            applicants: List<Long>,
-            confirmed: List<Long>,
+            applicants: List<MemberSummary>,
+            confirmed: List<MemberSummary>,
         ): SessionDefResponse =
             SessionDefResponse(
                 sessionId = def.sessionId,

--- a/src/main/kotlin/com/bandage/bandmanager/domain/selection/dto/res/SetlistChatMessageResponse.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/selection/dto/res/SetlistChatMessageResponse.kt
@@ -1,5 +1,6 @@
 package com.bandage.bandmanager.domain.selection.dto.res
 
+import com.bandage.bandmanager.domain.member.dto.res.MemberSummary
 import com.bandage.bandmanager.domain.selection.model.TrackSelectionItemChatMessage
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
@@ -9,16 +10,20 @@ import java.util.UUID
 data class SetlistChatMessageResponse(
     val messageId: UUID,
     val trackSelectionItemId: UUID,
-    val memberId: Long,
+    @Schema(description = "작성자 회원 정보 (탈퇴 회원이면 null)")
+    val member: MemberSummary?,
     val message: String,
     val createdAt: LocalDateTime?,
 ) {
     companion object {
-        fun of(c: TrackSelectionItemChatMessage): SetlistChatMessageResponse =
+        fun of(
+            c: TrackSelectionItemChatMessage,
+            member: MemberSummary?,
+        ): SetlistChatMessageResponse =
             SetlistChatMessageResponse(
                 messageId = c.id,
                 trackSelectionItemId = c.item.id,
-                memberId = c.memberId,
+                member = member,
                 message = c.message,
                 createdAt = c.createdAt,
             )

--- a/src/main/kotlin/com/bandage/bandmanager/domain/selection/dto/res/TrackSelectionDetailResponse.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/selection/dto/res/TrackSelectionDetailResponse.kt
@@ -1,5 +1,6 @@
 package com.bandage.bandmanager.domain.selection.dto.res
 
+import com.bandage.bandmanager.domain.member.dto.res.MemberSummary
 import com.bandage.bandmanager.domain.selection.dto.PracticeWindowDto
 import com.bandage.bandmanager.domain.selection.model.TrackSelection
 import com.bandage.bandmanager.domain.selection.model.TrackSelectionMember
@@ -25,13 +26,14 @@ data class TrackSelectionDetailResponse(
             m: TrackSelection,
             bandIds: List<UUID>,
             members: List<TrackSelectionMember>,
+            memberInfos: Map<Long, MemberSummary>,
         ): TrackSelectionDetailResponse =
             TrackSelectionDetailResponse(
                 selectionId = m.id,
                 bandIds = bandIds,
                 title = m.title,
                 managerId = m.managerId,
-                participants = members.map { ParticipantResponse.of(it) },
+                participants = members.map { ParticipantResponse.of(it, memberInfos[it.memberId], m.managerId) },
                 practiceWindow = PracticeWindowDto.of(m.practiceWindow),
                 lockedAt = m.lockedAt,
                 createdAt = m.createdAt,
@@ -43,13 +45,23 @@ data class TrackSelectionDetailResponse(
 @Schema(description = "선곡 참여자 응답")
 data class ParticipantResponse(
     val memberId: Long,
+    @Schema(description = "참여자 회원 정보 (탈퇴 회원이면 null)")
+    val member: MemberSummary?,
     val bandIds: List<UUID>,
+    @Schema(description = "이 참여자가 선곡 회의의 매니저인지 여부")
+    val isManager: Boolean,
 ) {
     companion object {
-        fun of(member: TrackSelectionMember): ParticipantResponse =
+        fun of(
+            member: TrackSelectionMember,
+            memberInfo: MemberSummary?,
+            managerId: Long,
+        ): ParticipantResponse =
             ParticipantResponse(
                 memberId = member.memberId,
+                member = memberInfo,
                 bandIds = member.bandIds.toList(),
+                isManager = member.memberId == managerId,
             )
     }
 }

--- a/src/main/kotlin/com/bandage/bandmanager/domain/selection/dto/res/TrackSelectionItemResponse.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/selection/dto/res/TrackSelectionItemResponse.kt
@@ -1,5 +1,6 @@
 package com.bandage.bandmanager.domain.selection.dto.res
 
+import com.bandage.bandmanager.domain.member.dto.res.MemberSummary
 import com.bandage.bandmanager.domain.selection.model.TrackSelectionItem
 import com.bandage.bandmanager.domain.selection.model.TrackSelectionItemApplicant
 import com.bandage.bandmanager.domain.selection.model.TrackSelectionItemConfirmation
@@ -18,7 +19,8 @@ data class TrackSelectionItemResponse(
     val duration: Int?,
     @Schema(description = "참고 링크(예: YouTube)")
     val reference: String?,
-    val proposerId: Long,
+    @Schema(description = "곡 제안자 회원 정보 (탈퇴 회원이면 null)")
+    val proposer: MemberSummary?,
     val note: String?,
     val isSelected: Boolean,
     val sessions: List<SessionDefResponse>,
@@ -30,6 +32,7 @@ data class TrackSelectionItemResponse(
             item: TrackSelectionItem,
             applicants: List<TrackSelectionItemApplicant>,
             confirmations: List<TrackSelectionItemConfirmation>,
+            memberInfos: Map<Long, MemberSummary>,
         ): TrackSelectionItemResponse {
             val applicantsBySession = applicants.groupBy { it.sessionId }
             val confirmedBySession = confirmations.groupBy { it.sessionId }
@@ -37,8 +40,8 @@ data class TrackSelectionItemResponse(
                 item.sessions.map { def ->
                     SessionDefResponse.of(
                         def = def,
-                        applicants = applicantsBySession[def.sessionId]?.map { it.memberId } ?: emptyList(),
-                        confirmed = confirmedBySession[def.sessionId]?.map { it.memberId } ?: emptyList(),
+                        applicants = applicantsBySession[def.sessionId]?.mapNotNull { memberInfos[it.memberId] } ?: emptyList(),
+                        confirmed = confirmedBySession[def.sessionId]?.mapNotNull { memberInfos[it.memberId] } ?: emptyList(),
                     )
                 }
             return TrackSelectionItemResponse(
@@ -49,7 +52,7 @@ data class TrackSelectionItemResponse(
                 album = item.trackInfo.album,
                 duration = item.trackInfo.duration,
                 reference = item.trackInfo.reference,
-                proposerId = item.proposerId,
+                proposer = memberInfos[item.proposerId],
                 note = item.note,
                 isSelected = item.isSelected,
                 sessions = sessionResponses,

--- a/src/main/kotlin/com/bandage/bandmanager/domain/selection/service/TrackSelectionService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/selection/service/TrackSelectionService.kt
@@ -1,6 +1,8 @@
 package com.bandage.bandmanager.domain.selection.service
 
 import com.bandage.bandmanager.domain.band.repository.BandMemberRepository
+import com.bandage.bandmanager.domain.member.dto.res.MemberSummary
+import com.bandage.bandmanager.domain.member.service.MemberService
 import com.bandage.bandmanager.domain.selection.dto.req.SetlistChatMessageCreateRequest
 import com.bandage.bandmanager.domain.selection.dto.req.SetlistConfirmationUpdateRequest
 import com.bandage.bandmanager.domain.selection.dto.req.SetlistParticipantsUpdateRequest
@@ -53,6 +55,7 @@ class TrackSelectionService(
     private val confirmationRepository: TrackSelectionItemConfirmationRepository,
     private val chatMessageRepository: TrackSelectionItemChatMessageRepository,
     private val bandMemberRepository: BandMemberRepository,
+    private val memberService: MemberService,
 ) : MemberAuthorityCleanupHandler {
     override val authorityType: ResourceAuthorityType = ResourceAuthorityType.TRACK_SELECTION_MANAGEMENT
 
@@ -93,7 +96,7 @@ class TrackSelectionService(
         val members = selectionMemberRepository.findAllBySelection(selection)
         validateAccess(selection, members, memberId)
         val bandIds = selectionBandRepository.findAllBySelection(selection).map { it.bandId }
-        return TrackSelectionDetailResponse.of(selection, bandIds, members)
+        return TrackSelectionDetailResponse.of(selection, bandIds, members, memberInfosOf(members))
     }
 
     fun getMySelections(
@@ -191,7 +194,7 @@ class TrackSelectionService(
         }
 
         val members = selectionMemberRepository.findAllBySelection(selection)
-        return TrackSelectionDetailResponse.of(selection, loadBandIds(selection), members)
+        return TrackSelectionDetailResponse.of(selection, loadBandIds(selection), members, memberInfosOf(members))
     }
 
     // -------- items --------
@@ -491,6 +494,10 @@ class TrackSelectionService(
             ?: throw BusinessException(ErrorCode.SETLIST_MEETING_NOT_FOUND)
 
     private fun loadBandIds(selection: TrackSelection): List<UUID> = selectionBandRepository.findAllBySelection(selection).map { it.bandId }
+
+    /** 참여자 회원 정보를 1회 bulk 조회(N+1 방지). */
+    private fun memberInfosOf(members: List<TrackSelectionMember>): Map<Long, MemberSummary> =
+        memberService.getMemberSummaries(members.map { it.memberId })
 
     private fun getItemOrThrow(
         selection: TrackSelection,

--- a/src/main/kotlin/com/bandage/bandmanager/domain/selection/service/TrackSelectionService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/selection/service/TrackSelectionService.kt
@@ -451,8 +451,10 @@ class TrackSelectionService(
         validateAccess(selection, memberId)
         val item = getItemOrThrow(selection, itemId)
         val result = chatMessageRepository.findAllByItemAndPaging(item.id, lastId, pageSize)
+        // 페이지 내 작성자 회원 정보를 1회 bulk 조회(N+1 방지)
+        val memberInfos = memberService.getMemberSummaries(result.content.map { it.memberId })
         return CursorResponse(
-            content = result.content.map { SetlistChatMessageResponse.of(it) },
+            content = result.content.map { SetlistChatMessageResponse.of(it, memberInfos[it.memberId]) },
             nextCursor = result.nextCursor,
             hasNext = result.hasNext,
         )
@@ -472,7 +474,7 @@ class TrackSelectionService(
             chatMessageRepository.save(
                 TrackSelectionItemChatMessage.create(item = item, memberId = memberId, message = request.message),
             )
-        return SetlistChatMessageResponse.of(msg)
+        return SetlistChatMessageResponse.of(msg, memberService.getMemberSummaries(listOf(memberId))[memberId])
     }
 
     // -------- lock / unlock --------

--- a/src/main/kotlin/com/bandage/bandmanager/domain/selection/service/TrackSelectionService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/selection/service/TrackSelectionService.kt
@@ -225,7 +225,7 @@ class TrackSelectionService(
                     sessions = request.sessions.map { it.toEntity() },
                 ),
             )
-        return TrackSelectionItemResponse.of(item, emptyList(), emptyList())
+        return toItemResponse(item, emptyList(), emptyList())
     }
 
     fun getItems(
@@ -239,14 +239,26 @@ class TrackSelectionService(
         if (result.content.isEmpty()) {
             return CursorResponse(content = emptyList(), nextCursor = null, hasNext = false)
         }
-        val applicants = applicantRepository.findAllByItemIn(result.content).groupBy { it.item.id }
-        val confirmations = confirmationRepository.findAllByItemIn(result.content).groupBy { it.item.id }
+        val allApplicants = applicantRepository.findAllByItemIn(result.content)
+        val allConfirmations = confirmationRepository.findAllByItemIn(result.content)
+        val applicants = allApplicants.groupBy { it.item.id }
+        val confirmations = allConfirmations.groupBy { it.item.id }
+        // 페이지 전체의 회원 정보를 1회 bulk 조회(목록 단위 N+1 방지)
+        val memberInfos =
+            memberService.getMemberSummaries(
+                buildSet {
+                    result.content.forEach { add(it.proposerId) }
+                    allApplicants.forEach { add(it.memberId) }
+                    allConfirmations.forEach { add(it.memberId) }
+                },
+            )
         val content =
             result.content.map { item ->
                 TrackSelectionItemResponse.of(
                     item = item,
                     applicants = applicants[item.id] ?: emptyList(),
                     confirmations = confirmations[item.id] ?: emptyList(),
+                    memberInfos = memberInfos,
                 )
             }
         return CursorResponse(content = content, nextCursor = result.nextCursor, hasNext = result.hasNext)
@@ -260,7 +272,7 @@ class TrackSelectionService(
         val selection = getSelectionOrThrow(selectionId)
         validateAccess(selection, memberId)
         val item = getItemOrThrow(selection, itemId)
-        return TrackSelectionItemResponse.of(
+        return toItemResponse(
             item = item,
             applicants = applicantRepository.findAllByItem(item),
             confirmations = confirmationRepository.findAllByItem(item),
@@ -291,7 +303,7 @@ class TrackSelectionService(
             confirmations.filter { it.sessionId !in newSessionIds }.forEach { confirmationRepository.delete(it) }
             item.replaceSessions(newDefs)
         }
-        return TrackSelectionItemResponse.of(
+        return toItemResponse(
             item = item,
             applicants = applicantRepository.findAllByItem(item),
             confirmations = confirmationRepository.findAllByItem(item),
@@ -332,7 +344,7 @@ class TrackSelectionService(
         } else {
             item.deselect()
         }
-        return TrackSelectionItemResponse.of(
+        return toItemResponse(
             item = item,
             applicants = applicantRepository.findAllByItem(item),
             confirmations = confirmationRepository.findAllByItem(item),
@@ -420,7 +432,7 @@ class TrackSelectionService(
                 TrackSelectionItemConfirmation.create(item = item, sessionId = sessionId, memberId = uid, confirmedBy = memberId),
             )
         }
-        return TrackSelectionItemResponse.of(
+        return toItemResponse(
             item = item,
             applicants = applicantRepository.findAllByItem(item),
             confirmations = confirmationRepository.findAllByItem(item),
@@ -498,6 +510,27 @@ class TrackSelectionService(
     /** 참여자 회원 정보를 1회 bulk 조회(N+1 방지). */
     private fun memberInfosOf(members: List<TrackSelectionMember>): Map<Long, MemberSummary> =
         memberService.getMemberSummaries(members.map { it.memberId })
+
+    /** 선곡 항목 응답에 필요한 회원(제안자/지원자/확정자) 정보를 1회 bulk 조회(N+1 방지). */
+    private fun itemMemberInfos(
+        item: TrackSelectionItem,
+        applicants: List<TrackSelectionItemApplicant>,
+        confirmations: List<TrackSelectionItemConfirmation>,
+    ): Map<Long, MemberSummary> =
+        memberService.getMemberSummaries(
+            buildSet {
+                add(item.proposerId)
+                applicants.forEach { add(it.memberId) }
+                confirmations.forEach { add(it.memberId) }
+            },
+        )
+
+    private fun toItemResponse(
+        item: TrackSelectionItem,
+        applicants: List<TrackSelectionItemApplicant>,
+        confirmations: List<TrackSelectionItemConfirmation>,
+    ): TrackSelectionItemResponse =
+        TrackSelectionItemResponse.of(item, applicants, confirmations, itemMemberInfos(item, applicants, confirmations))
 
     private fun getItemOrThrow(
         selection: TrackSelection,

--- a/src/test/kotlin/com/bandage/bandmanager/domain/jam/dto/res/JamDetailResponseTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/jam/dto/res/JamDetailResponseTest.kt
@@ -1,0 +1,75 @@
+package com.bandage.bandmanager.domain.jam.dto.res
+
+import com.bandage.bandmanager.domain.jam.model.Jam
+import com.bandage.bandmanager.domain.jam.model.JamParticipant
+import com.bandage.bandmanager.domain.member.dto.res.MemberSummary
+import com.bandage.bandmanager.global.common.domain.SessionDef
+import com.bandage.bandmanager.global.common.domain.TimeInfoUnit
+import com.bandage.bandmanager.global.common.domain.TrackInfo
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.time.LocalDateTime
+import java.util.UUID
+
+class JamDetailResponseTest {
+    // id 가 @GeneratedValue(lateinit, protected set) 라 직접 주입 불가 → mock 으로 엔티티를 구성한다.
+    private fun participant(
+        sessionId: String,
+        member: Long,
+    ): JamParticipant {
+        val p = mock(JamParticipant::class.java)
+        `when`(p.id).thenReturn(UUID.randomUUID())
+        `when`(p.sessionId).thenReturn(sessionId)
+        `when`(p.member).thenReturn(member)
+        return p
+    }
+
+    private fun jamWith(participants: List<JamParticipant>): Jam {
+        val sessionIds = participants.map { it.sessionId!! }.distinct()
+        val jam = mock(Jam::class.java)
+        `when`(jam.id).thenReturn(UUID.randomUUID())
+        `when`(jam.title).thenReturn("합주")
+        `when`(jam.setlistId).thenReturn(null)
+        `when`(jam.note).thenReturn(null)
+        `when`(jam.timeInfo).thenReturn(TimeInfoUnit(LocalDateTime.of(2026, 6, 10, 19, 0), 120, null))
+        `when`(jam.trackInfo).thenReturn(TrackInfo(title = "곡", artist = "아티스트"))
+        `when`(jam.sessions).thenReturn(sessionIds.map { SessionDef(it, it, it, 1, false) })
+        `when`(jam.participants).thenReturn(participants)
+        return jam
+    }
+
+    @Test
+    fun `of - 참여자와 세션에 회원 요약 정보를 채운다`() {
+        val jam = jamWith(listOf(participant("G", 1L), participant("B", 2L)))
+        val members =
+            mapOf(
+                1L to MemberSummary(1L, "홍길동", "https://cdn/1.jpg"),
+                2L to MemberSummary(2L, "김철수", null),
+            )
+
+        val res = JamDetailResponse.of(jam, members)
+
+        assertThat(res.participants).hasSize(2)
+        assertThat(res.participants.map { it.member?.name }).containsExactlyInAnyOrder("홍길동", "김철수")
+        val guitar = res.sessions.first { it.sessionId == "G" }
+        assertThat(guitar.participants).hasSize(1)
+        assertThat(guitar.participants.first().name).isEqualTo("홍길동")
+    }
+
+    @Test
+    fun `of - 맵에 없는 회원(탈퇴)은 participant member가 null, 세션 목록에서는 제외된다`() {
+        val jam = jamWith(listOf(participant("G", 1L), participant("G", 99L)))
+        val members = mapOf(1L to MemberSummary(1L, "홍길동", null)) // 99L 누락
+
+        val res = JamDetailResponse.of(jam, members)
+
+        // participants 목록에는 탈퇴 회원도 행으로 남되 member=null
+        assertThat(res.participants).hasSize(2)
+        assertThat(res.participants.count { it.member == null }).isEqualTo(1)
+        // 세션 배정 목록에서는 mapNotNull 로 누락 회원 제외
+        val guitar = res.sessions.first { it.sessionId == "G" }
+        assertThat(guitar.participants.map { it.memberId }).containsExactly(1L)
+    }
+}

--- a/src/test/kotlin/com/bandage/bandmanager/domain/jam/service/JamServiceTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/jam/service/JamServiceTest.kt
@@ -5,6 +5,7 @@ import com.bandage.bandmanager.domain.jam.dto.req.JamVenueUpdateRequest
 import com.bandage.bandmanager.domain.jam.model.Jam
 import com.bandage.bandmanager.domain.jam.repository.JamParticipantRepository
 import com.bandage.bandmanager.domain.jam.repository.JamRepository
+import com.bandage.bandmanager.domain.member.service.MemberService
 import com.bandage.bandmanager.global.common.domain.TrackInfo
 import com.bandage.bandmanager.global.error.errorcode.ErrorCode
 import com.bandage.bandmanager.global.error.exception.BusinessException
@@ -22,12 +23,14 @@ class JamServiceTest {
     private val jamParticipantRepository = mock(JamParticipantRepository::class.java)
     private val bandMemberRepository = mock(BandMemberRepository::class.java)
     private val jamReservationSyncService = mock(JamReservationSyncService::class.java)
+    private val memberService = mock(MemberService::class.java)
     private val sut =
         JamService(
             jamRepository,
             jamParticipantRepository,
             bandMemberRepository,
             jamReservationSyncService,
+            memberService,
         )
 
     private val jamId = UUID.randomUUID()

--- a/src/test/kotlin/com/bandage/bandmanager/domain/member/service/MemberServiceSummaryTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/member/service/MemberServiceSummaryTest.kt
@@ -1,0 +1,81 @@
+package com.bandage.bandmanager.domain.member.service
+
+import com.bandage.bandmanager.domain.band.repository.BandMemberRepository
+import com.bandage.bandmanager.domain.jam.repository.JamParticipantRepository
+import com.bandage.bandmanager.domain.member.model.Member
+import com.bandage.bandmanager.domain.member.repository.MemberRepository
+import com.bandage.bandmanager.global.infra.s3.CloudFrontUrlResolver
+import com.bandage.bandmanager.global.infra.s3.ImagePresignSupport
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.Mockito.`when`
+
+class MemberServiceSummaryTest {
+    private val memberRepository = mock(MemberRepository::class.java)
+    private val bandMemberRepository = mock(BandMemberRepository::class.java)
+    private val jamParticipantRepository = mock(JamParticipantRepository::class.java)
+    private val cloudFrontUrlResolver = mock(CloudFrontUrlResolver::class.java)
+    private val imagePresignSupport = mock(ImagePresignSupport::class.java)
+
+    private val sut =
+        MemberService(
+            memberRepository,
+            bandMemberRepository,
+            jamParticipantRepository,
+            cloudFrontUrlResolver,
+            imagePresignSupport,
+        )
+
+    private fun member(
+        id: Long,
+        name: String,
+        profileImg: String?,
+    ): Member {
+        // id는 @GeneratedValue라 직접 설정 불가 → mock으로 id만 stub
+        val m = mock(Member::class.java)
+        `when`(m.id).thenReturn(id)
+        `when`(m.name).thenReturn(name)
+        `when`(m.profileImg).thenReturn(profileImg)
+        return m
+    }
+
+    @Test
+    fun `getMemberSummaries - memberId 맵으로 변환하고 프로필 URL을 resolve한다`() {
+        val m1 = member(1L, "홍길동", "profile/member/1/a.jpg")
+        val m2 = member(2L, "김철수", null)
+        `when`(memberRepository.findAllByIdIn(setOf(1L, 2L))).thenReturn(listOf(m1, m2))
+        `when`(cloudFrontUrlResolver.resolveOrNull("profile/member/1/a.jpg")).thenReturn("https://cdn/a.jpg")
+        `when`(cloudFrontUrlResolver.resolveOrNull(null)).thenReturn(null)
+
+        val result = sut.getMemberSummaries(listOf(1L, 2L))
+
+        assertThat(result).hasSize(2)
+        assertThat(result[1L]?.name).isEqualTo("홍길동")
+        assertThat(result[1L]?.profileImg).isEqualTo("https://cdn/a.jpg")
+        assertThat(result[2L]?.name).isEqualTo("김철수")
+        assertThat(result[2L]?.profileImg).isNull()
+    }
+
+    @Test
+    fun `getMemberSummaries - 빈 입력이면 조회 없이 빈 맵을 반환한다`() {
+        val result = sut.getMemberSummaries(emptyList())
+
+        assertThat(result).isEmpty()
+        verifyNoInteractions(memberRepository)
+    }
+
+    @Test
+    fun `getMemberSummaries - 중복 id는 한 번만 조회한다`() {
+        val m1 = member(1L, "홍길동", null)
+        `when`(memberRepository.findAllByIdIn(setOf(1L))).thenReturn(listOf(m1))
+        `when`(cloudFrontUrlResolver.resolveOrNull(null)).thenReturn(null)
+
+        val result = sut.getMemberSummaries(listOf(1L, 1L, 1L))
+
+        assertThat(result).hasSize(1)
+        verify(memberRepository).findAllByIdIn(setOf(1L))
+    }
+}

--- a/src/test/kotlin/com/bandage/bandmanager/domain/selection/dto/res/ParticipantResponseTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/selection/dto/res/ParticipantResponseTest.kt
@@ -1,0 +1,42 @@
+package com.bandage.bandmanager.domain.selection.dto.res
+
+import com.bandage.bandmanager.domain.member.dto.res.MemberSummary
+import com.bandage.bandmanager.domain.selection.model.TrackSelectionMember
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+class ParticipantResponseTest {
+    private fun member(memberId: Long): TrackSelectionMember {
+        val m = mock(TrackSelectionMember::class.java)
+        `when`(m.memberId).thenReturn(memberId)
+        `when`(m.bandIds).thenReturn(emptySet())
+        return m
+    }
+
+    @Test
+    fun `of - managerId와 같으면 isManager=true, 회원 정보를 채운다`() {
+        val res = ParticipantResponse.of(member(1L), MemberSummary(1L, "홍길동", null), managerId = 1L)
+
+        assertThat(res.isManager).isTrue()
+        assertThat(res.memberId).isEqualTo(1L)
+        assertThat(res.member?.name).isEqualTo("홍길동")
+    }
+
+    @Test
+    fun `of - managerId와 다르면 isManager=false`() {
+        val res = ParticipantResponse.of(member(2L), MemberSummary(2L, "김철수", null), managerId = 1L)
+
+        assertThat(res.isManager).isFalse()
+    }
+
+    @Test
+    fun `of - 회원 정보가 없으면(탈퇴) member는 null이지만 memberId와 isManager는 유지`() {
+        val res = ParticipantResponse.of(member(1L), null, managerId = 1L)
+
+        assertThat(res.member).isNull()
+        assertThat(res.memberId).isEqualTo(1L)
+        assertThat(res.isManager).isTrue()
+    }
+}

--- a/src/test/kotlin/com/bandage/bandmanager/domain/selection/dto/res/SetlistChatMessageResponseTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/selection/dto/res/SetlistChatMessageResponseTest.kt
@@ -1,0 +1,39 @@
+package com.bandage.bandmanager.domain.selection.dto.res
+
+import com.bandage.bandmanager.domain.member.dto.res.MemberSummary
+import com.bandage.bandmanager.domain.selection.model.TrackSelectionItem
+import com.bandage.bandmanager.domain.selection.model.TrackSelectionItemChatMessage
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.util.UUID
+
+class SetlistChatMessageResponseTest {
+    private fun chatMessage(): TrackSelectionItemChatMessage {
+        val item = mock(TrackSelectionItem::class.java)
+        `when`(item.id).thenReturn(UUID.randomUUID())
+        val c = mock(TrackSelectionItemChatMessage::class.java)
+        `when`(c.id).thenReturn(UUID.randomUUID())
+        `when`(c.item).thenReturn(item)
+        `when`(c.message).thenReturn("안녕하세요")
+        return c
+    }
+
+    @Test
+    fun `of - 작성자 회원 정보를 채운다`() {
+        val res = SetlistChatMessageResponse.of(chatMessage(), MemberSummary(1L, "작성자", "https://cdn/1.jpg"))
+
+        assertThat(res.member?.memberId).isEqualTo(1L)
+        assertThat(res.member?.name).isEqualTo("작성자")
+        assertThat(res.message).isEqualTo("안녕하세요")
+    }
+
+    @Test
+    fun `of - 탈퇴 회원이면 member는 null`() {
+        val res = SetlistChatMessageResponse.of(chatMessage(), null)
+
+        assertThat(res.member).isNull()
+        assertThat(res.message).isEqualTo("안녕하세요")
+    }
+}

--- a/src/test/kotlin/com/bandage/bandmanager/domain/selection/dto/res/TrackSelectionItemResponseTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/selection/dto/res/TrackSelectionItemResponseTest.kt
@@ -1,0 +1,96 @@
+package com.bandage.bandmanager.domain.selection.dto.res
+
+import com.bandage.bandmanager.domain.member.dto.res.MemberSummary
+import com.bandage.bandmanager.domain.selection.model.TrackSelection
+import com.bandage.bandmanager.domain.selection.model.TrackSelectionItem
+import com.bandage.bandmanager.domain.selection.model.TrackSelectionItemApplicant
+import com.bandage.bandmanager.domain.selection.model.TrackSelectionItemConfirmation
+import com.bandage.bandmanager.global.common.domain.SessionDef
+import com.bandage.bandmanager.global.common.domain.TrackInfo
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.util.UUID
+
+class TrackSelectionItemResponseTest {
+    private fun item(
+        proposerId: Long,
+        sessionIds: List<String>,
+    ): TrackSelectionItem {
+        val selection = mock(TrackSelection::class.java)
+        `when`(selection.id).thenReturn(UUID.randomUUID())
+        val item = mock(TrackSelectionItem::class.java)
+        `when`(item.id).thenReturn(UUID.randomUUID())
+        `when`(item.selection).thenReturn(selection)
+        `when`(item.trackInfo).thenReturn(TrackInfo(title = "곡", artist = "아티스트"))
+        `when`(item.proposerId).thenReturn(proposerId)
+        `when`(item.note).thenReturn(null)
+        `when`(item.isSelected).thenReturn(false)
+        `when`(item.sessions).thenReturn(sessionIds.map { SessionDef(it, it, it, 1, false) })
+        return item
+    }
+
+    private fun applicant(
+        sessionId: String,
+        memberId: Long,
+    ): TrackSelectionItemApplicant {
+        val a = mock(TrackSelectionItemApplicant::class.java)
+        `when`(a.sessionId).thenReturn(sessionId)
+        `when`(a.memberId).thenReturn(memberId)
+        return a
+    }
+
+    private fun confirmation(
+        sessionId: String,
+        memberId: Long,
+    ): TrackSelectionItemConfirmation {
+        val c = mock(TrackSelectionItemConfirmation::class.java)
+        `when`(c.sessionId).thenReturn(sessionId)
+        `when`(c.memberId).thenReturn(memberId)
+        return c
+    }
+
+    @Test
+    fun `of - proposer, 세션별 지원자, 확정자에 회원 정보를 채운다`() {
+        val item = item(proposerId = 1L, sessionIds = listOf("G"))
+        val members =
+            mapOf(
+                1L to MemberSummary(1L, "제안자", null),
+                2L to MemberSummary(2L, "지원자", null),
+                3L to MemberSummary(3L, "확정자", null),
+            )
+
+        val res =
+            TrackSelectionItemResponse.of(
+                item = item,
+                applicants = listOf(applicant("G", 2L)),
+                confirmations = listOf(confirmation("G", 3L)),
+                memberInfos = members,
+            )
+
+        assertThat(res.proposer?.name).isEqualTo("제안자")
+        val guitar = res.sessions.first { it.sessionId == "G" }
+        assertThat(guitar.applicants.map { it.name }).containsExactly("지원자")
+        assertThat(guitar.confirmed.map { it.name }).containsExactly("확정자")
+    }
+
+    @Test
+    fun `of - 맵에 없는 회원(탈퇴)은 proposer null, 세션 목록에서 제외`() {
+        val item = item(proposerId = 99L, sessionIds = listOf("G"))
+        val members = mapOf(2L to MemberSummary(2L, "지원자", null)) // 99L(제안자), 3L(확정자) 누락
+
+        val res =
+            TrackSelectionItemResponse.of(
+                item = item,
+                applicants = listOf(applicant("G", 2L)),
+                confirmations = listOf(confirmation("G", 3L)),
+                memberInfos = members,
+            )
+
+        assertThat(res.proposer).isNull()
+        val guitar = res.sessions.first { it.sessionId == "G" }
+        assertThat(guitar.applicants.map { it.memberId }).containsExactly(2L)
+        assertThat(guitar.confirmed).isEmpty() // 3L 누락 → mapNotNull 로 제외
+    }
+}

--- a/src/test/kotlin/com/bandage/bandmanager/domain/selection/service/TrackSelectionServiceCleanupTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/selection/service/TrackSelectionServiceCleanupTest.kt
@@ -4,6 +4,7 @@ import com.bandage.bandmanager.domain.band.model.Band
 import com.bandage.bandmanager.domain.band.model.BandMember
 import com.bandage.bandmanager.domain.band.model.enums.BandRole
 import com.bandage.bandmanager.domain.band.repository.BandMemberRepository
+import com.bandage.bandmanager.domain.member.service.MemberService
 import com.bandage.bandmanager.domain.selection.model.PracticeWindow
 import com.bandage.bandmanager.domain.selection.model.TrackSelection
 import com.bandage.bandmanager.domain.selection.model.TrackSelectionBand
@@ -35,6 +36,7 @@ class TrackSelectionServiceCleanupTest {
     private val confirmationRepository = mock(TrackSelectionItemConfirmationRepository::class.java)
     private val chatMessageRepository = mock(TrackSelectionItemChatMessageRepository::class.java)
     private val bandMemberRepository = mock(BandMemberRepository::class.java)
+    private val memberService = mock(MemberService::class.java)
 
     private val sut =
         TrackSelectionService(
@@ -46,6 +48,7 @@ class TrackSelectionServiceCleanupTest {
             confirmationRepository,
             chatMessageRepository,
             bandMemberRepository,
+            memberService,
         )
 
     private val selectionId: UUID = UUID.fromString("00000000-0000-0000-0000-0000000000a1")


### PR DESCRIPTION
## 🛠️ Issue Number
### closes # BD-173

📌 **작업 내용 및 특이사항**

4개 조회 API 응답에서 회원 정보를 `memberId`(Long)만 노출하던 것을 `MemberSummary`(memberId + name + profileImg) 객체로 보강합니다. 직전 BD-173에서 추가한 회원 조회 기능을 도메인 간 재사용합니다.

**대상 API**
- `GET /api/v1/jams/{jamId}` — 합주 조회
- `GET /api/v1/track-selections/{selectionId}` — 선곡 단건 조회
- `GET /api/v1/track-selections/{selectionId}/items/{itemId}` — 선곡 항목 단건 조회
- `GET /api/v1/track-selections/{selectionId}/items/{itemId}/chat` — 선곡 항목 채팅 조회

**주요 변경**
- 공용: `MemberSummary` DTO 신설(email 등 개인정보 제외), `MemberService.getMemberSummaries(ids)` bulk 조회 추가
- 합주: `JamParticipantResponse.memberId → member`, `JamSessionResponse.participants: List<Long> → List<MemberSummary>`
- 선곡 단건: `ParticipantResponse`에 `member`, **`isManager`** 추가(`memberId`는 유지). `isManager = (참여자 memberId == selection.managerId)`
- 선곡 항목: `proposerId → proposer`, 세션 `applicants`/`confirmed`: `List<Long> → List<MemberSummary>`
- 채팅: `SetlistChatMessageResponse.memberId → member`

**설계 결정**
- **N+1 방지**: 응답마다 등장 memberId를 모아 1회 bulk 조회. 목록 API(`getItems`, 채팅 커서)는 페이지 전체를 한 번에 조회
- **탈퇴 회원**: `member`는 nullable — soft-delete된 회원도 응답이 깨지지 않으며, 세션 배정 목록에서는 `mapNotNull`로 제외
- **nickname 미포함**: Member 엔티티에 nickname 필드가 없어 보강 대상에서 제외
- **manager 표시**: Selection/Setlist에만 manager 개념이 있어 `isManager`는 선곡 참여자 목록(`ParticipantResponse`)에만 추가. Jam은 해당 없음

⚠️ **Breaking change**: `memberId`(number) → `member`(object), `List<Long>` → `List<MemberSummary>`, `proposerId` → `proposer` 등 필드 타입/형태가 변경됩니다. 일관성을 위해 단건을 반환하는 write API(`addParticipant`, `updateParticipantSession`, 항목 생성/수정 등)도 함께 변경했습니다. FE 측 수정이 필요합니다.

📚 **참고사항**

- 단계별 6개 커밋(공용 인프라 → 합주 → 선곡 단건 → 선곡 항목 → 채팅 → 스펙)으로 분리
- 신규 단위 테스트 5종 추가, 전체 `./gradlew build` 통과(스펙 동기화 테스트 포함)

✅ **체크리스트**
- [x] API(Controller/DTO)를 변경한 경우 `docs/openapi.json`을 갱신했습니다 (코드-스펙 동일 PR 규약)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Ros5k8vRCUn4iBvpvdWyt
