### PR TITLE
[BD-173] refactor: 참여자 memberId 정리 및 셋리스트 트랙 조회 회원 정보 보강

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3768,16 +3768,11 @@
                     "member": {
                         "$ref": "#/components/schemas/MemberSummary",
                         "description": "\ucc38\uc5ec\uc790 \ud68c\uc6d0 \uc815\ubcf4 (\ud0c8\ud1f4 \ud68c\uc6d0\uc774\uba74 null)"
-                    },
-                    "memberId": {
-                        "format": "int64",
-                        "type": "integer"
                     }
                 },
                 "required": [
                     "bandIds",
-                    "isManager",
-                    "memberId"
+                    "isManager"
                 ],
                 "type": "object"
             },
@@ -5209,9 +5204,9 @@
                         "type": "integer"
                     },
                     "participants": {
+                        "description": "\ubc30\uc815\ub41c \ucc38\uc5ec\uc790 \ubaa9\ub85d",
                         "items": {
-                            "format": "int64",
-                            "type": "integer"
+                            "$ref": "#/components/schemas/MemberSummary"
                         },
                         "type": "array"
                     },

--- a/src/main/kotlin/com/bandage/bandmanager/domain/selection/dto/res/TrackSelectionDetailResponse.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/selection/dto/res/TrackSelectionDetailResponse.kt
@@ -44,7 +44,6 @@ data class TrackSelectionDetailResponse(
 
 @Schema(description = "선곡 참여자 응답")
 data class ParticipantResponse(
-    val memberId: Long,
     @Schema(description = "참여자 회원 정보 (탈퇴 회원이면 null)")
     val member: MemberSummary?,
     val bandIds: List<UUID>,
@@ -58,7 +57,6 @@ data class ParticipantResponse(
             managerId: Long,
         ): ParticipantResponse =
             ParticipantResponse(
-                memberId = member.memberId,
                 member = memberInfo,
                 bandIds = member.bandIds.toList(),
                 isManager = member.memberId == managerId,

--- a/src/main/kotlin/com/bandage/bandmanager/domain/setlist/dto/res/SetlistTrackResponse.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/setlist/dto/res/SetlistTrackResponse.kt
@@ -1,5 +1,6 @@
 package com.bandage.bandmanager.domain.setlist.dto.res
 
+import com.bandage.bandmanager.domain.member.dto.res.MemberSummary
 import com.bandage.bandmanager.domain.setlist.model.SetlistTrack
 import com.bandage.bandmanager.domain.setlist.model.SetlistTrackParticipant
 import com.bandage.bandmanager.global.common.domain.SessionDef
@@ -27,13 +28,14 @@ data class SetlistTrackResponse(
         fun of(
             track: SetlistTrack,
             participants: List<SetlistTrackParticipant>,
+            memberInfos: Map<Long, MemberSummary>,
         ): SetlistTrackResponse {
             val participantsBySession = participants.groupBy { it.sessionId }
             val sessions =
                 track.sessions.map { def ->
                     SetlistTrackSessionResponse.of(
                         def = def,
-                        participants = participantsBySession[def.sessionId]?.map { it.memberId } ?: emptyList(),
+                        participants = participantsBySession[def.sessionId]?.mapNotNull { memberInfos[it.memberId] } ?: emptyList(),
                     )
                 }
             return SetlistTrackResponse(
@@ -60,12 +62,13 @@ data class SetlistTrackSessionResponse(
     val short: String,
     val need: Int,
     val custom: Boolean,
-    val participants: List<Long>,
+    @Schema(description = "배정된 참여자 목록")
+    val participants: List<MemberSummary>,
 ) {
     companion object {
         fun of(
             def: SessionDef,
-            participants: List<Long>,
+            participants: List<MemberSummary>,
         ): SetlistTrackSessionResponse =
             SetlistTrackSessionResponse(
                 sessionId = def.sessionId,

--- a/src/main/kotlin/com/bandage/bandmanager/domain/setlist/service/SetlistService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/setlist/service/SetlistService.kt
@@ -2,6 +2,7 @@ package com.bandage.bandmanager.domain.setlist.service
 
 import com.bandage.bandmanager.domain.band.model.BandMember
 import com.bandage.bandmanager.domain.band.repository.BandMemberRepository
+import com.bandage.bandmanager.domain.member.service.MemberService
 import com.bandage.bandmanager.domain.setlist.dto.req.SetlistPagingQuery
 import com.bandage.bandmanager.domain.setlist.dto.req.SetlistTrackPagingQuery
 import com.bandage.bandmanager.domain.setlist.dto.req.SetlistTrackUpdateRequest
@@ -36,6 +37,7 @@ class SetlistService(
     private val setlistTrackRepository: SetlistTrackRepository,
     private val setlistTrackParticipantRepository: SetlistTrackParticipantRepository,
     private val bandMemberRepository: BandMemberRepository,
+    private val memberService: MemberService,
 ) : MemberAuthorityCleanupHandler {
     override val authorityType: ResourceAuthorityType = ResourceAuthorityType.SETLIST_MANAGEMENT
 
@@ -88,13 +90,16 @@ class SetlistService(
         if (result.content.isEmpty()) {
             return CursorResponse(content = emptyList(), nextCursor = null, hasNext = false)
         }
-        val participantsByTrack =
-            setlistTrackParticipantRepository.findAllByTrackIn(result.content).groupBy { it.track.id }
+        val allParticipants = setlistTrackParticipantRepository.findAllByTrackIn(result.content)
+        val participantsByTrack = allParticipants.groupBy { it.track.id }
+        // 페이지 전체 참여자 회원 정보를 1회 bulk 조회(목록 단위 N+1 방지)
+        val memberInfos = memberService.getMemberSummaries(allParticipants.map { it.memberId })
         val content =
             result.content.map { track ->
                 SetlistTrackResponse.of(
                     track = track,
                     participants = participantsByTrack[track.id] ?: emptyList(),
+                    memberInfos = memberInfos,
                 )
             }
         return CursorResponse(content = content, nextCursor = result.nextCursor, hasNext = result.hasNext)
@@ -108,10 +113,7 @@ class SetlistService(
         val setlist = getSetlistOrThrow(setlistId)
         validateAccess(setlist, memberId)
         val track = getTrackOrThrow(setlist, trackId)
-        return SetlistTrackResponse.of(
-            track = track,
-            participants = setlistTrackParticipantRepository.findAllByTrack(track),
-        )
+        return toTrackResponse(track)
     }
 
     @Transactional
@@ -135,10 +137,7 @@ class SetlistService(
                 .forEach { setlistTrackParticipantRepository.delete(it) }
             track.replaceSessions(newDefs)
         }
-        return SetlistTrackResponse.of(
-            track = track,
-            participants = setlistTrackParticipantRepository.findAllByTrack(track),
-        )
+        return toTrackResponse(track)
     }
 
     @Transactional
@@ -152,6 +151,13 @@ class SetlistService(
         val track = getTrackOrThrow(setlist, trackId)
         setlistTrackParticipantRepository.findAllByTrack(track).forEach { it.markAsDeleted(memberId) }
         track.markAsDeleted(memberId)
+    }
+
+    /** 단건 트랙 응답 구성. 참여자 회원 정보를 1회 bulk 조회(N+1 방지). */
+    private fun toTrackResponse(track: SetlistTrack): SetlistTrackResponse {
+        val participants = setlistTrackParticipantRepository.findAllByTrack(track)
+        val memberInfos = memberService.getMemberSummaries(participants.map { it.memberId })
+        return SetlistTrackResponse.of(track, participants, memberInfos)
     }
 
     private fun getSetlistOrThrow(setlistId: UUID): Setlist =

--- a/src/test/kotlin/com/bandage/bandmanager/domain/selection/dto/res/ParticipantResponseTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/selection/dto/res/ParticipantResponseTest.kt
@@ -20,7 +20,7 @@ class ParticipantResponseTest {
         val res = ParticipantResponse.of(member(1L), MemberSummary(1L, "홍길동", null), managerId = 1L)
 
         assertThat(res.isManager).isTrue()
-        assertThat(res.memberId).isEqualTo(1L)
+        assertThat(res.member?.memberId).isEqualTo(1L)
         assertThat(res.member?.name).isEqualTo("홍길동")
     }
 
@@ -32,11 +32,10 @@ class ParticipantResponseTest {
     }
 
     @Test
-    fun `of - 회원 정보가 없으면(탈퇴) member는 null이지만 memberId와 isManager는 유지`() {
+    fun `of - 회원 정보가 없으면(탈퇴) member는 null이지만 isManager는 유지`() {
         val res = ParticipantResponse.of(member(1L), null, managerId = 1L)
 
         assertThat(res.member).isNull()
-        assertThat(res.memberId).isEqualTo(1L)
         assertThat(res.isManager).isTrue()
     }
 }

--- a/src/test/kotlin/com/bandage/bandmanager/domain/setlist/dto/res/SetlistTrackResponseTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/setlist/dto/res/SetlistTrackResponseTest.kt
@@ -1,0 +1,60 @@
+package com.bandage.bandmanager.domain.setlist.dto.res
+
+import com.bandage.bandmanager.domain.member.dto.res.MemberSummary
+import com.bandage.bandmanager.domain.setlist.model.Setlist
+import com.bandage.bandmanager.domain.setlist.model.SetlistTrack
+import com.bandage.bandmanager.domain.setlist.model.SetlistTrackParticipant
+import com.bandage.bandmanager.global.common.domain.SessionDef
+import com.bandage.bandmanager.global.common.domain.TrackInfo
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.util.UUID
+
+class SetlistTrackResponseTest {
+    private fun track(sessionIds: List<String>): SetlistTrack {
+        val setlist = mock(Setlist::class.java)
+        `when`(setlist.id).thenReturn(UUID.randomUUID())
+        val t = mock(SetlistTrack::class.java)
+        `when`(t.id).thenReturn(UUID.randomUUID())
+        `when`(t.setlist).thenReturn(setlist)
+        `when`(t.trackInfo).thenReturn(TrackInfo(title = "곡", artist = "아티스트"))
+        `when`(t.note).thenReturn(null)
+        `when`(t.sessions).thenReturn(sessionIds.map { SessionDef(it, it, it, 1, false) })
+        return t
+    }
+
+    private fun participant(
+        sessionId: String,
+        memberId: Long,
+    ): SetlistTrackParticipant {
+        val p = mock(SetlistTrackParticipant::class.java)
+        `when`(p.sessionId).thenReturn(sessionId)
+        `when`(p.memberId).thenReturn(memberId)
+        return p
+    }
+
+    @Test
+    fun `of - 세션별 참여자에 회원 정보를 채운다`() {
+        val track = track(listOf("G"))
+        val members = mapOf(2L to MemberSummary(2L, "참여자", "https://cdn/2.jpg"))
+
+        val res = SetlistTrackResponse.of(track, listOf(participant("G", 2L)), members)
+
+        val guitar = res.sessions.first { it.sessionId == "G" }
+        assertThat(guitar.participants).hasSize(1)
+        assertThat(guitar.participants.first().name).isEqualTo("참여자")
+    }
+
+    @Test
+    fun `of - 맵에 없는 회원(탈퇴)은 세션 목록에서 제외`() {
+        val track = track(listOf("G"))
+        val members = mapOf(2L to MemberSummary(2L, "참여자", null)) // 99L 누락
+
+        val res = SetlistTrackResponse.of(track, listOf(participant("G", 2L), participant("G", 99L)), members)
+
+        val guitar = res.sessions.first { it.sessionId == "G" }
+        assertThat(guitar.participants.map { it.memberId }).containsExactly(2L)
+    }
+}

--- a/src/test/kotlin/com/bandage/bandmanager/domain/setlist/service/SetlistServiceCleanupTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/setlist/service/SetlistServiceCleanupTest.kt
@@ -4,6 +4,7 @@ import com.bandage.bandmanager.domain.band.model.Band
 import com.bandage.bandmanager.domain.band.model.BandMember
 import com.bandage.bandmanager.domain.band.model.enums.BandRole
 import com.bandage.bandmanager.domain.band.repository.BandMemberRepository
+import com.bandage.bandmanager.domain.member.service.MemberService
 import com.bandage.bandmanager.domain.setlist.model.Setlist
 import com.bandage.bandmanager.domain.setlist.model.SetlistBand
 import com.bandage.bandmanager.domain.setlist.model.SetlistTrack
@@ -26,6 +27,7 @@ class SetlistServiceCleanupTest {
     private val setlistTrackRepository = mock(SetlistTrackRepository::class.java)
     private val setlistTrackParticipantRepository = mock(SetlistTrackParticipantRepository::class.java)
     private val bandMemberRepository = mock(BandMemberRepository::class.java)
+    private val memberService = mock(MemberService::class.java)
 
     private val sut =
         SetlistService(
@@ -34,6 +36,7 @@ class SetlistServiceCleanupTest {
             setlistTrackRepository,
             setlistTrackParticipantRepository,
             bandMemberRepository,
+            memberService,
         )
 
     private val setlistId: UUID = UUID.fromString("00000000-0000-0000-0000-0000000000a1")


### PR DESCRIPTION
## 🛠️ Issue Number
### closes # BD-173

📌 **작업 내용 및 특이사항**

#124(조회 API 회원 정보 보강)의 후속 정리 PR입니다. 두 가지를 처리합니다.

**1. 선곡 참여자 응답에서 중복 `memberId` 제거**
- `GET /api/v1/track-selections/{selectionId}` 의 `ParticipantResponse`에서 `memberId` 필드 제거
- `member.memberId`에 동일 값이 있어 중복이었고, 다른 보강 응답(`JamParticipantResponse` 등)은 이미 `member` 객체만 두는 방식으로 통일돼 있어 일관성을 맞춤
- `isManager` 판별은 내부적으로 엔티티 memberId를 사용하므로 영향 없음

**2. 셋리스트 트랙 조회 응답 회원 정보 보강 (#124에서 누락된 동종 API)**
- `GET /api/v1/setlists/{setlistId}/tracks` (목록)
- `GET /api/v1/setlists/{setlistId}/tracks/{trackId}` (단건)
- `SetlistTrackSessionResponse.participants`: `List<Long>` → `List<MemberSummary>`
- `getTracks` 목록은 페이지 전체 참여자를 1회 bulk 조회, 단건은 `toTrackResponse` 헬퍼로 통일(N+1 방지)
- 탈퇴 회원은 세션 목록에서 `mapNotNull`로 제외

⚠️ **Breaking change**
- `ParticipantResponse.memberId`(number) 삭제 → `member.memberId`로 접근
- `SetlistTrackSessionResponse.participants`: `number[]` → `MemberSummary[]`

FE 측 수정이 필요합니다.

📚 **참고사항**

- 변경을 3개 커밋(참여자 memberId 제거 / 셋리스트 트랙 보강 / 스펙)으로 분리
- 신규/수정 단위 테스트 포함, 전체 `./gradlew build` 통과(스펙 동기화 테스트 포함)

✅ **체크리스트**
- [x] API(Controller/DTO)를 변경한 경우 `docs/openapi.json`을 갱신했습니다 (코드-스펙 동일 PR 규약)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Ros5k8vRCUn4iBvpvdWyt
