### PR TITLE
hotfix & fix: CI 스펙 동기화 + 무효 CORS Origin 제거

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5810,6 +5810,13 @@
                 ],
                 "type": "object"
             }
+        },
+        "securitySchemes": {
+            "bearerAuth": {
+                "bearerFormat": "JWT",
+                "scheme": "bearer",
+                "type": "http"
+            }
         }
     },
     "info": {
@@ -10350,6 +10357,11 @@
             }
         }
     },
+    "security": [
+        {
+            "bearerAuth": []
+        }
+    ],
     "servers": [
         {
             "description": "Generated server url",

--- a/src/main/kotlin/com/bandage/bandmanager/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/global/security/SecurityConfig.kt
@@ -60,7 +60,6 @@ class SecurityConfig(
                         "http://localhost:*",
                         "http://127.0.0.1:*",
                         "https://bandage.team",
-                        "https://bandage.team/swagger-ui/index.html",
                     )
                 allowedMethods =
                     listOf(


### PR DESCRIPTION


## 🛠️ Issue Number

📌 **작업 내용 및 특이사항**
- docs/openapi.json 에 누락된 securitySchemes.bearerAuth·전역 security 반영 (OpenApiSpecGenerationTest 실패 수정)
- SecurityConfig CORS allowedOriginPatterns 에서 경로 포함 무효 항목("https://bandage.team/swagger-ui/index.html") 제거 — CORS Origin 은 scheme+host+port 만 매칭, 상위 "https://bandage.team" 로 이미 허용됨


📚 **참고사항**


✅ **체크리스트**
- [x] API(Controller/DTO)를 변경한 경우 `docs/openapi.json`을 갱신했습니다 (코드-스펙 동일 PR 규약)
