### PR TITLE
[BD-165][BD-166] 합주 세션 개별 수정 API 추가 및 1세션=1인 고정

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2910,6 +2910,41 @@
                 ],
                 "type": "object"
             },
+            "JamSessionAddRequest": {
+                "description": "\ud569\uc8fc \uc138\uc158 \ucd94\uac00 \uc694\uccad",
+                "properties": {
+                    "custom": {
+                        "description": "\ucee4\uc2a4\ud140 \uc138\uc158 \uc5ec\ubd80",
+                        "example": false,
+                        "type": "boolean"
+                    },
+                    "label": {
+                        "description": "\uc138\uc158 \uc774\ub984",
+                        "example": "\uae30\ud0c0",
+                        "minLength": 1,
+                        "type": "string"
+                    },
+                    "sessionId": {
+                        "description": "\uc138\uc158 \ud1a0\ud070",
+                        "example": "G-2",
+                        "minLength": 1,
+                        "type": "string"
+                    },
+                    "short": {
+                        "description": "\ud45c\uc2dc\uc6a9 \uc57d\uc5b4",
+                        "example": "G",
+                        "minLength": 1,
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "custom",
+                    "label",
+                    "sessionId",
+                    "short"
+                ],
+                "type": "object"
+            },
             "JamSessionResponse": {
                 "description": "\ud569\uc8fc \uc138\uc158 \uc751\ub2f5",
                 "properties": {
@@ -2922,12 +2957,6 @@
                         "description": "\uc138\uc158 \uc774\ub984",
                         "example": "\uae30\ud0c0",
                         "type": "string"
-                    },
-                    "need": {
-                        "description": "\uc815\uc6d0",
-                        "example": 1,
-                        "format": "int32",
-                        "type": "integer"
                     },
                     "participants": {
                         "description": "\ubc30\uc815\ub41c \ucc38\uc5ec\uc790 \ubaa9\ub85d",
@@ -2950,9 +2979,30 @@
                 "required": [
                     "custom",
                     "label",
-                    "need",
                     "participants",
                     "sessionId",
+                    "short"
+                ],
+                "type": "object"
+            },
+            "JamSessionUpdateRequest": {
+                "description": "\ud569\uc8fc \uc138\uc158 \uac1c\ubcc4 \uc218\uc815 \uc694\uccad",
+                "properties": {
+                    "label": {
+                        "description": "\uc138\uc158 \uc774\ub984",
+                        "example": "\uae30\ud0c0",
+                        "minLength": 1,
+                        "type": "string"
+                    },
+                    "short": {
+                        "description": "\ud45c\uc2dc\uc6a9 \uc57d\uc5b4",
+                        "example": "G",
+                        "minLength": 1,
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "label",
                     "short"
                 ],
                 "type": "object"
@@ -4796,13 +4846,6 @@
                         "minLength": 1,
                         "type": "string"
                     },
-                    "need": {
-                        "description": "\uc815\uc6d0",
-                        "example": 1,
-                        "format": "int32",
-                        "minimum": 1,
-                        "type": "integer"
-                    },
                     "sessionId": {
                         "description": "\uc138\uc158 \ud1a0\ud070",
                         "example": "G",
@@ -4819,7 +4862,6 @@
                 "required": [
                     "custom",
                     "label",
-                    "need",
                     "sessionId",
                     "short"
                 ],
@@ -4847,10 +4889,6 @@
                     "label": {
                         "type": "string"
                     },
-                    "need": {
-                        "format": "int32",
-                        "type": "integer"
-                    },
                     "sessionId": {
                         "type": "string"
                     },
@@ -4863,7 +4901,6 @@
                     "confirmed",
                     "custom",
                     "label",
-                    "need",
                     "sessionId",
                     "short"
                 ],
@@ -5199,10 +5236,6 @@
                     "label": {
                         "type": "string"
                     },
-                    "need": {
-                        "format": "int32",
-                        "type": "integer"
-                    },
                     "participants": {
                         "description": "\ubc30\uc815\ub41c \ucc38\uc5ec\uc790 \ubaa9\ub85d",
                         "items": {
@@ -5220,7 +5253,6 @@
                 "required": [
                     "custom",
                     "label",
-                    "need",
                     "participants",
                     "sessionId",
                     "short"
@@ -7089,6 +7121,47 @@
             }
         },
         "/api/v1/jams/{jamId}/sessions": {
+            "post": {
+                "description": "\ud569\uc8fc\uc5d0 \uc138\uc158\uc744 \ud558\ub098 \ucd94\uac00\ud569\ub2c8\ub2e4.",
+                "operationId": "addSession",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "jamId",
+                        "required": true,
+                        "schema": {
+                            "format": "uuid",
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/JamSessionAddRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiResponseJamDetailResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    }
+                },
+                "summary": "\ud569\uc8fc \uc138\uc158 \ucd94\uac00 API",
+                "tags": [
+                    "jams"
+                ]
+            },
             "put": {
                 "description": "\ud569\uc8fc\uc758 \uc138\uc158 \uc815\uc758 \ubaa9\ub85d\uc744 \uc804\uccb4 \uad50\uccb4\ud569\ub2c8\ub2e4. \uc81c\uac70\ub41c \uc138\uc158\uc758 \ucc38\uc5ec\uc790 \ubc30\uc815\uc740 \ud568\uaed8 \uc0ad\uc81c\ub429\ub2c8\ub2e4.",
                 "operationId": "updateSessions",
@@ -7126,6 +7199,96 @@
                     }
                 },
                 "summary": "\ud569\uc8fc \uc138\uc158 \uc815\uc758 \uad50\uccb4 API",
+                "tags": [
+                    "jams"
+                ]
+            }
+        },
+        "/api/v1/jams/{jamId}/sessions/{sessionId}": {
+            "delete": {
+                "description": "\ud569\uc8fc \uc138\uc158 \ud558\ub098\ub97c \uc0ad\uc81c\ud569\ub2c8\ub2e4. \ubc30\uc815\ub41c \ucc38\uc5ec\uc790\ub3c4 \ud568\uaed8 \uc0ad\uc81c\ub429\ub2c8\ub2e4.",
+                "operationId": "removeSession",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "jamId",
+                        "required": true,
+                        "schema": {
+                            "format": "uuid",
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "sessionId",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiResponseJamDetailResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    }
+                },
+                "summary": "\ud569\uc8fc \uc138\uc158 \uc0ad\uc81c API",
+                "tags": [
+                    "jams"
+                ]
+            },
+            "patch": {
+                "description": "\ud569\uc8fc \uc138\uc158 \ud558\ub098\uc758 \uc774\ub984/\uc57d\uce6d\uc744 \uc218\uc815\ud569\ub2c8\ub2e4.",
+                "operationId": "updateSession",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "jamId",
+                        "required": true,
+                        "schema": {
+                            "format": "uuid",
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "sessionId",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/JamSessionUpdateRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiResponseJamDetailResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    }
+                },
+                "summary": "\ud569\uc8fc \uc138\uc158 \uac1c\ubcc4 \uc218\uc815 API",
                 "tags": [
                     "jams"
                 ]
@@ -10365,7 +10528,7 @@
     "servers": [
         {
             "description": "Generated server url",
-            "url": "http://bandage-band-manager:8080"
+            "url": "http://localhost:8080"
         }
     ],
     "tags": [

--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/controller/JamController.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/controller/JamController.kt
@@ -5,6 +5,8 @@ import com.bandage.bandmanager.domain.jam.dto.req.JamMemberAddRequest
 import com.bandage.bandmanager.domain.jam.dto.req.JamPagingQuery
 import com.bandage.bandmanager.domain.jam.dto.req.JamParticipantSessionUpdateRequest
 import com.bandage.bandmanager.domain.jam.dto.req.JamSearchQuery
+import com.bandage.bandmanager.domain.jam.dto.req.JamSessionAddRequest
+import com.bandage.bandmanager.domain.jam.dto.req.JamSessionUpdateRequest
 import com.bandage.bandmanager.domain.jam.dto.req.JamSessionsUpdateRequest
 import com.bandage.bandmanager.domain.jam.dto.req.JamTimeInfoUpdateRequest
 import com.bandage.bandmanager.domain.jam.dto.req.JamVenueUpdateRequest
@@ -99,6 +101,40 @@ class JamController(
     ): ApiResponse<JamDetailResponse> =
         ApiResponse.success(
             jamService.updateSessions(jamId, request, memberId),
+        )
+
+    @PostMapping("/{jamId}/sessions")
+    @Operation(operationId = "addSession", summary = "합주 세션 추가 API", description = "합주에 세션을 하나 추가합니다.")
+    fun addSession(
+        @PathVariable jamId: UUID,
+        @Valid @RequestBody request: JamSessionAddRequest,
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<JamDetailResponse> =
+        ApiResponse.success(
+            jamService.addSession(jamId, request, memberId),
+        )
+
+    @PatchMapping("/{jamId}/sessions/{sessionId}")
+    @Operation(operationId = "updateSession", summary = "합주 세션 개별 수정 API", description = "합주 세션 하나의 이름/약칭을 수정합니다.")
+    fun updateSession(
+        @PathVariable jamId: UUID,
+        @PathVariable sessionId: String,
+        @Valid @RequestBody request: JamSessionUpdateRequest,
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<JamDetailResponse> =
+        ApiResponse.success(
+            jamService.updateSession(jamId, sessionId, request, memberId),
+        )
+
+    @DeleteMapping("/{jamId}/sessions/{sessionId}")
+    @Operation(operationId = "removeSession", summary = "합주 세션 삭제 API", description = "합주 세션 하나를 삭제합니다. 배정된 참여자도 함께 삭제됩니다.")
+    fun removeSession(
+        @PathVariable jamId: UUID,
+        @PathVariable sessionId: String,
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<JamDetailResponse> =
+        ApiResponse.success(
+            jamService.removeSession(jamId, sessionId, memberId),
         )
 
     @PostMapping("/{jamId}/participants")

--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/dto/req/JamSessionAddRequest.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/dto/req/JamSessionAddRequest.kt
@@ -1,13 +1,12 @@
-package com.bandage.bandmanager.domain.selection.dto.req
+package com.bandage.bandmanager.domain.jam.dto.req
 
-import com.bandage.bandmanager.global.common.domain.SessionDef
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 
-@Schema(description = "세션 정의")
-data class SessionDefDto(
+@Schema(description = "합주 세션 추가 요청")
+data class JamSessionAddRequest(
     @field:NotBlank
-    @Schema(description = "세션 토큰", example = "G")
+    @Schema(description = "세션 토큰", example = "G-2")
     val sessionId: String,
     @field:NotBlank
     @Schema(description = "세션 이름", example = "기타")
@@ -17,6 +16,4 @@ data class SessionDefDto(
     val short: String,
     @Schema(description = "커스텀 세션 여부", example = "false")
     val custom: Boolean = false,
-) {
-    fun toEntity(): SessionDef = SessionDef(sessionId = sessionId, label = label, short = short, custom = custom)
-}
+)

--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/dto/req/JamSessionUpdateRequest.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/dto/req/JamSessionUpdateRequest.kt
@@ -1,0 +1,14 @@
+package com.bandage.bandmanager.domain.jam.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+
+@Schema(description = "합주 세션 개별 수정 요청")
+data class JamSessionUpdateRequest(
+    @field:NotBlank
+    @Schema(description = "세션 이름", example = "기타")
+    val label: String,
+    @field:NotBlank
+    @Schema(description = "표시용 약어", example = "G")
+    val short: String,
+)

--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/dto/res/JamSessionResponse.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/dto/res/JamSessionResponse.kt
@@ -12,8 +12,6 @@ data class JamSessionResponse(
     val label: String,
     @Schema(description = "표시용 약어", example = "G")
     val short: String,
-    @Schema(description = "정원", example = "1")
-    val need: Int,
     @Schema(description = "커스텀 세션 여부", example = "false")
     val custom: Boolean,
     @Schema(description = "배정된 참여자 목록")
@@ -28,7 +26,6 @@ data class JamSessionResponse(
                 sessionId = def.sessionId,
                 label = def.label,
                 short = def.short,
-                need = def.need,
                 custom = def.custom,
                 participants = participants,
             )

--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/model/Jam.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/model/Jam.kt
@@ -136,6 +136,26 @@ open class Jam(
         this._sessions.addAll(newSessions)
     }
 
+    fun addSession(def: SessionDef) {
+        require(_sessions.none { it.sessionId == def.sessionId }) { "이미 존재하는 세션입니다: ${def.sessionId}" }
+        _sessions.add(def)
+    }
+
+    fun updateSession(
+        sessionId: String,
+        label: String,
+        short: String,
+    ) {
+        val idx = _sessions.indexOfFirst { it.sessionId == sessionId }
+        require(idx >= 0) { "존재하지 않는 세션입니다: $sessionId" }
+        val custom = _sessions[idx].custom
+        _sessions[idx] = SessionDef(sessionId = sessionId, label = label, short = short, custom = custom)
+    }
+
+    fun removeSession(sessionId: String) {
+        _sessions.removeIf { it.sessionId == sessionId }
+    }
+
     fun addParticipant(
         sessionId: String,
         member: Long,

--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/repository/JamParticipantRepository.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/repository/JamParticipantRepository.kt
@@ -24,6 +24,11 @@ interface JamParticipantRepository : JpaRepository<JamParticipant, UUID> {
         member: Long,
     ): Boolean
 
+    fun existsByJamAndSessionId(
+        jam: Jam,
+        sessionId: String,
+    ): Boolean
+
     fun existsByJamAndMember(
         jam: Jam,
         member: Long,

--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/service/JamService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/service/JamService.kt
@@ -6,6 +6,8 @@ import com.bandage.bandmanager.domain.jam.dto.req.JamMemberAddRequest
 import com.bandage.bandmanager.domain.jam.dto.req.JamPagingQuery
 import com.bandage.bandmanager.domain.jam.dto.req.JamParticipantSessionUpdateRequest
 import com.bandage.bandmanager.domain.jam.dto.req.JamSearchQuery
+import com.bandage.bandmanager.domain.jam.dto.req.JamSessionAddRequest
+import com.bandage.bandmanager.domain.jam.dto.req.JamSessionUpdateRequest
 import com.bandage.bandmanager.domain.jam.dto.req.JamSessionsUpdateRequest
 import com.bandage.bandmanager.domain.jam.dto.req.JamTimeInfoUpdateRequest
 import com.bandage.bandmanager.domain.jam.dto.req.JamVenueUpdateRequest
@@ -19,6 +21,7 @@ import com.bandage.bandmanager.domain.jam.repository.JamParticipantRepository
 import com.bandage.bandmanager.domain.jam.repository.JamRepository
 import com.bandage.bandmanager.domain.member.dto.res.MemberSummary
 import com.bandage.bandmanager.domain.member.service.MemberService
+import com.bandage.bandmanager.global.common.domain.SessionDef
 import com.bandage.bandmanager.global.common.response.CursorResponse
 import com.bandage.bandmanager.global.error.errorcode.ErrorCode
 import com.bandage.bandmanager.global.error.exception.BusinessException
@@ -125,11 +128,57 @@ class JamService(
         validateParticipant(jam, memberId)
         val newDefs = request.sessions.map { it.toEntity() }
         val newSessionIds = newDefs.map { it.sessionId }.toSet()
-        jamParticipantRepository
-            .findAllByJam(jam)
-            .filter { it.sessionId !in newSessionIds }
-            .forEach { jamParticipantRepository.delete(it) }
+        deleteParticipantsNotIn(jam, newSessionIds)
         jam.replaceSessions(newDefs)
+        jamReservationSyncService.sync(jam)
+        return toDetailResponse(jam)
+    }
+
+    @Transactional
+    fun addSession(
+        jamId: UUID,
+        request: JamSessionAddRequest,
+        memberId: Long,
+    ): JamDetailResponse {
+        val jam = getJam(jamId)
+        validateParticipant(jam, memberId)
+        validateSessionNotExists(jam, request.sessionId)
+        jam.addSession(
+            SessionDef(
+                sessionId = request.sessionId,
+                label = request.label,
+                short = request.short,
+                custom = request.custom,
+            ),
+        )
+        return toDetailResponse(jam)
+    }
+
+    @Transactional
+    fun updateSession(
+        jamId: UUID,
+        sessionId: String,
+        request: JamSessionUpdateRequest,
+        memberId: Long,
+    ): JamDetailResponse {
+        val jam = getJam(jamId)
+        validateParticipant(jam, memberId)
+        validateSessionExists(jam, sessionId)
+        jam.updateSession(sessionId, request.label, request.short)
+        return toDetailResponse(jam)
+    }
+
+    @Transactional
+    fun removeSession(
+        jamId: UUID,
+        sessionId: String,
+        memberId: Long,
+    ): JamDetailResponse {
+        val jam = getJam(jamId)
+        validateParticipant(jam, memberId)
+        validateSessionExists(jam, sessionId)
+        deleteParticipantsNotIn(jam, jam.sessions.map { it.sessionId }.toSet() - sessionId)
+        jam.removeSession(sessionId)
         jamReservationSyncService.sync(jam)
         return toDetailResponse(jam)
     }
@@ -144,6 +193,7 @@ class JamService(
         validateParticipant(jam, memberId)
         validateSessionExists(jam, request.sessionId)
         validateParticipantNotExists(jam, request.sessionId, request.memberId)
+        validateSessionNotFull(jam, request.sessionId)
         val participant =
             jamParticipantRepository.save(
                 JamParticipant.create(
@@ -173,6 +223,7 @@ class JamService(
         }
         validateSessionExists(jam, request.sessionId)
         validateParticipantNotExists(jam, request.sessionId, participant.member)
+        validateSessionNotFull(jam, request.sessionId)
         participant.changeSession(request.sessionId)
         return JamParticipantResponse.of(participant, summaryOf(participant.member))
     }
@@ -254,6 +305,38 @@ class JamService(
     ) {
         if (jam.sessions.none { it.sessionId == sessionId }) {
             throw BusinessException(ErrorCode.JAM_SESSION_NOT_FOUND)
+        }
+    }
+
+    private fun validateSessionNotExists(
+        jam: Jam,
+        sessionId: String,
+    ) {
+        if (jam.sessions.any { it.sessionId == sessionId }) {
+            throw BusinessException(ErrorCode.JAM_SESSION_ALREADY_EXISTS)
+        }
+    }
+
+    /**
+     * 남길 세션(keepSessionIds)에 포함되지 않은 참여자 배정을 정리한다(세션 전체 교체/개별 삭제 공용).
+     * 세션 미배정 소속 참여자(sessionId=null, 생성자 등)는 세션 목록과 무관하므로 대상에서 제외한다.
+     */
+    private fun deleteParticipantsNotIn(
+        jam: Jam,
+        keepSessionIds: Set<String>,
+    ) {
+        jamParticipantRepository
+            .findAllByJam(jam)
+            .filter { it.sessionId != null && it.sessionId !in keepSessionIds }
+            .forEach { jamParticipantRepository.delete(it) }
+    }
+
+    private fun validateSessionNotFull(
+        jam: Jam,
+        sessionId: String,
+    ) {
+        if (jamParticipantRepository.existsByJamAndSessionId(jam, sessionId)) {
+            throw BusinessException(ErrorCode.JAM_SESSION_FULL)
         }
     }
 

--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/service/SetlistTrackToJamConverter.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/service/SetlistTrackToJamConverter.kt
@@ -62,7 +62,6 @@ class SetlistTrackToJamConverter(
                             sessionId = def.sessionId,
                             label = def.label,
                             short = def.short,
-                            need = def.need,
                             custom = def.custom,
                         )
                     },

--- a/src/main/kotlin/com/bandage/bandmanager/domain/selection/dto/res/SessionDefResponse.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/selection/dto/res/SessionDefResponse.kt
@@ -8,7 +8,6 @@ data class SessionDefResponse(
     val sessionId: String,
     val label: String,
     val short: String,
-    val need: Int,
     val custom: Boolean,
     @Schema(description = "지원자 회원 목록")
     val applicants: List<MemberSummary>,
@@ -25,7 +24,6 @@ data class SessionDefResponse(
                 sessionId = def.sessionId,
                 label = def.label,
                 short = def.short,
-                need = def.need,
                 custom = def.custom,
                 applicants = applicants,
                 confirmed = confirmed,

--- a/src/main/kotlin/com/bandage/bandmanager/domain/selection/repository/TrackSelectionItemConfirmationRepository.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/selection/repository/TrackSelectionItemConfirmationRepository.kt
@@ -18,10 +18,10 @@ interface TrackSelectionItemConfirmationRepository : JpaRepository<TrackSelectio
         memberId: Long,
     ): TrackSelectionItemConfirmation?
 
-    fun countByItemAndSessionId(
+    fun existsByItemAndSessionId(
         item: TrackSelectionItem,
         sessionId: String,
-    ): Long
+    ): Boolean
 
     fun deleteAllByItemInAndMemberId(
         items: List<TrackSelectionItem>,

--- a/src/main/kotlin/com/bandage/bandmanager/domain/selection/service/TrackSelectionService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/selection/service/TrackSelectionService.kt
@@ -353,8 +353,7 @@ class TrackSelectionService(
 
     private fun validateAllSessionsConfirmed(item: TrackSelectionItem) {
         item.sessions.forEach { sessionDef ->
-            val confirmedCount = confirmationRepository.countByItemAndSessionId(item, sessionDef.sessionId).toInt()
-            if (confirmedCount < sessionDef.need) {
+            if (!confirmationRepository.existsByItemAndSessionId(item, sessionDef.sessionId)) {
                 throw BusinessException(ErrorCode.SETLIST_SELECTION_INCOMPLETE_SESSION)
             }
         }
@@ -410,21 +409,18 @@ class TrackSelectionService(
         val selection = getSelectionOrThrow(selectionId)
         validateManager(selection, memberId)
         val item = getItemOrThrow(selection, itemId)
-        val sessionDef =
-            item.sessions.firstOrNull { it.sessionId == sessionId }
-                ?: throw BusinessException(ErrorCode.SETLIST_MEETING_ITEM_SESSION_NOT_FOUND)
+        validateSessionExists(item, sessionId)
 
         request.unconfirm.forEach { uid ->
             confirmationRepository.findByItemAndSessionIdAndMemberId(item, sessionId, uid)?.let {
                 confirmationRepository.delete(it)
             }
         }
-        val currentCount = confirmationRepository.countByItemAndSessionId(item, sessionId).toInt()
         val toAdd =
             request.confirm.filter { uid ->
                 confirmationRepository.findByItemAndSessionIdAndMemberId(item, sessionId, uid) == null
             }
-        if (currentCount + toAdd.size > sessionDef.need) {
+        if (toAdd.isNotEmpty() && confirmationRepository.existsByItemAndSessionId(item, sessionId)) {
             throw BusinessException(ErrorCode.SETLIST_MEETING_ITEM_SESSION_FULL)
         }
         toAdd.forEach { uid ->

--- a/src/main/kotlin/com/bandage/bandmanager/domain/setlist/dto/res/SetlistTrackResponse.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/setlist/dto/res/SetlistTrackResponse.kt
@@ -60,7 +60,6 @@ data class SetlistTrackSessionResponse(
     val sessionId: String,
     val label: String,
     val short: String,
-    val need: Int,
     val custom: Boolean,
     @Schema(description = "배정된 참여자 목록")
     val participants: List<MemberSummary>,
@@ -74,7 +73,6 @@ data class SetlistTrackSessionResponse(
                 sessionId = def.sessionId,
                 label = def.label,
                 short = def.short,
-                need = def.need,
                 custom = def.custom,
                 participants = participants,
             )

--- a/src/main/kotlin/com/bandage/bandmanager/global/common/domain/SessionDef.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/global/common/domain/SessionDef.kt
@@ -8,7 +8,6 @@ open class SessionDef(
     sessionId: String,
     label: String,
     short: String,
-    need: Int,
     custom: Boolean,
 ) {
     @Column(name = "session_id", nullable = false)
@@ -21,10 +20,6 @@ open class SessionDef(
 
     @Column(name = "session_short", nullable = false)
     var short: String = short
-        protected set
-
-    @Column(name = "session_need", nullable = false)
-    var need: Int = need
         protected set
 
     @Column(name = "session_custom", nullable = false)

--- a/src/main/kotlin/com/bandage/bandmanager/global/error/errorcode/ErrorCode.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/global/error/errorcode/ErrorCode.kt
@@ -50,6 +50,8 @@ enum class ErrorCode(
     JAM_PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "합주 참여자 정보를 찾을 수 없습니다."),
     JAM_PARTICIPANT_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 합주에 참여 중인 멤버입니다."),
     JAM_FORBIDDEN_NOT_PARTICIPANT(HttpStatus.FORBIDDEN, "합주 참여자만 변경할 수 있습니다."),
+    JAM_SESSION_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 세션입니다."),
+    JAM_SESSION_FULL(HttpStatus.CONFLICT, "이미 다른 멤버가 배정된 세션입니다."),
 
     // performance
     PERFORMANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 공연 정보를 찾을 수 없습니다."),

--- a/src/main/resources/db/changelog/changes/021-drop-session-need.sql
+++ b/src/main/resources/db/changelog/changes/021-drop-session-need.sql
@@ -1,0 +1,3 @@
+ALTER TABLE p_track_selection_item_session DROP COLUMN session_need;
+ALTER TABLE p_setlist_track_session DROP COLUMN session_need;
+ALTER TABLE p_jam_session DROP COLUMN session_need;

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -253,3 +253,17 @@ databaseChangeLog:
             splitStatements: true
             stripComments: true
             endDelimiter: ";"
+  - changeSet:
+      id: 021-drop-session-need
+      author: bandage
+      comment: |
+        세션 "1세션=1인" 고정: SessionDef.need(정원) 필드 제거
+        - p_track_selection_item_session / p_setlist_track_session / p_jam_session 의 session_need 컬럼 DROP
+        - 정원 N명 세션은 이제 클라이언트가 세션을 N개(예: G-1, G-2) 등록하는 것으로 표현
+      changes:
+        - sqlFile:
+            path: changes/021-drop-session-need.sql
+            relativeToChangelogFile: true
+            splitStatements: true
+            stripComments: true
+            endDelimiter: ";"

--- a/src/test/kotlin/com/bandage/bandmanager/domain/jam/dto/res/JamDetailResponseTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/jam/dto/res/JamDetailResponseTest.kt
@@ -35,7 +35,7 @@ class JamDetailResponseTest {
         `when`(jam.note).thenReturn(null)
         `when`(jam.timeInfo).thenReturn(TimeInfoUnit(LocalDateTime.of(2026, 6, 10, 19, 0), 120, null))
         `when`(jam.trackInfo).thenReturn(TrackInfo(title = "곡", artist = "아티스트"))
-        `when`(jam.sessions).thenReturn(sessionIds.map { SessionDef(it, it, it, 1, false) })
+        `when`(jam.sessions).thenReturn(sessionIds.map { SessionDef(it, it, it, false) })
         `when`(jam.participants).thenReturn(participants)
         return jam
     }

--- a/src/test/kotlin/com/bandage/bandmanager/domain/jam/service/JamServiceTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/jam/service/JamServiceTest.kt
@@ -1,11 +1,16 @@
 package com.bandage.bandmanager.domain.jam.service
 
 import com.bandage.bandmanager.domain.band.repository.BandMemberRepository
+import com.bandage.bandmanager.domain.jam.dto.req.JamMemberAddRequest
+import com.bandage.bandmanager.domain.jam.dto.req.JamSessionAddRequest
+import com.bandage.bandmanager.domain.jam.dto.req.JamSessionUpdateRequest
 import com.bandage.bandmanager.domain.jam.dto.req.JamVenueUpdateRequest
 import com.bandage.bandmanager.domain.jam.model.Jam
+import com.bandage.bandmanager.domain.jam.model.JamParticipant
 import com.bandage.bandmanager.domain.jam.repository.JamParticipantRepository
 import com.bandage.bandmanager.domain.jam.repository.JamRepository
 import com.bandage.bandmanager.domain.member.service.MemberService
+import com.bandage.bandmanager.global.common.domain.SessionDef
 import com.bandage.bandmanager.global.common.domain.TrackInfo
 import com.bandage.bandmanager.global.error.errorcode.ErrorCode
 import com.bandage.bandmanager.global.error.exception.BusinessException
@@ -13,6 +18,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import java.time.LocalDateTime
 import java.util.Optional
@@ -35,14 +41,21 @@ class JamServiceTest {
 
     private val jamId = UUID.randomUUID()
 
-    private fun jam(): Jam =
-        Jam.create(
-            title = "합주",
-            trackInfo = TrackInfo(title = "곡", artist = "아티스트"),
-            startAt = LocalDateTime.of(2026, 6, 10, 19, 0),
-            durationMinutes = 120,
-            venue = null,
-        )
+    private fun jam(sessions: List<SessionDef> = emptyList()): Jam {
+        val jam =
+            Jam.create(
+                title = "합주",
+                trackInfo = TrackInfo(title = "곡", artist = "아티스트"),
+                startAt = LocalDateTime.of(2026, 6, 10, 19, 0),
+                durationMinutes = 120,
+                venue = null,
+                sessions = sessions,
+            )
+        val field = Jam::class.java.getDeclaredField("id")
+        field.isAccessible = true
+        field.set(jam, jamId)
+        return jam
+    }
 
     @Test
     fun `합주 참여자가 아니면 합주를 수정할 수 없다`() {
@@ -63,5 +76,78 @@ class JamServiceTest {
         sut.updateVenue(jamId, JamVenueUpdateRequest("홍대 스튜디오"), 1L)
 
         assertThat(jam.timeInfo.venue).isEqualTo("홍대 스튜디오")
+    }
+
+    @Test
+    fun `세션을 추가할 수 있다`() {
+        val jam = jam()
+        `when`(jamRepository.findById(jamId)).thenReturn(Optional.of(jam))
+        `when`(jamParticipantRepository.existsByJamAndMember(jam, 1L)).thenReturn(true)
+
+        sut.addSession(jamId, JamSessionAddRequest("G-2", "기타", "G", false), 1L)
+
+        assertThat(jam.sessions.map { it.sessionId }).containsExactly("G-2")
+    }
+
+    @Test
+    fun `이미 존재하는 세션 토큰은 추가할 수 없다`() {
+        val jam = jam(listOf(SessionDef("G-1", "기타", "G", false)))
+        `when`(jamRepository.findById(jamId)).thenReturn(Optional.of(jam))
+        `when`(jamParticipantRepository.existsByJamAndMember(jam, 1L)).thenReturn(true)
+
+        assertThatThrownBy { sut.addSession(jamId, JamSessionAddRequest("G-1", "기타", "G", false), 1L) }
+            .isInstanceOf(BusinessException::class.java)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.JAM_SESSION_ALREADY_EXISTS)
+    }
+
+    @Test
+    fun `세션 이름과 약칭을 개별로 수정할 수 있다`() {
+        val jam = jam(listOf(SessionDef("G-1", "기타", "G", false)))
+        `when`(jamRepository.findById(jamId)).thenReturn(Optional.of(jam))
+        `when`(jamParticipantRepository.existsByJamAndMember(jam, 1L)).thenReturn(true)
+
+        sut.updateSession(jamId, "G-1", JamSessionUpdateRequest("메인 기타", "MG"), 1L)
+
+        val session = jam.sessions.first { it.sessionId == "G-1" }
+        assertThat(session.label).isEqualTo("메인 기타")
+        assertThat(session.short).isEqualTo("MG")
+    }
+
+    @Test
+    fun `존재하지 않는 세션은 수정할 수 없다`() {
+        val jam = jam()
+        `when`(jamRepository.findById(jamId)).thenReturn(Optional.of(jam))
+        `when`(jamParticipantRepository.existsByJamAndMember(jam, 1L)).thenReturn(true)
+
+        assertThatThrownBy { sut.updateSession(jamId, "G-1", JamSessionUpdateRequest("기타", "G"), 1L) }
+            .isInstanceOf(BusinessException::class.java)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.JAM_SESSION_NOT_FOUND)
+    }
+
+    @Test
+    fun `세션을 삭제하면 배정된 참여자도 함께 삭제된다`() {
+        val jam = jam(listOf(SessionDef("G-1", "기타", "G", false)))
+        val participant = mock(JamParticipant::class.java)
+        `when`(participant.sessionId).thenReturn("G-1")
+        `when`(jamRepository.findById(jamId)).thenReturn(Optional.of(jam))
+        `when`(jamParticipantRepository.existsByJamAndMember(jam, 1L)).thenReturn(true)
+        `when`(jamParticipantRepository.findAllByJam(jam)).thenReturn(listOf(participant))
+
+        sut.removeSession(jamId, "G-1", 1L)
+
+        assertThat(jam.sessions).isEmpty()
+        verify(jamParticipantRepository).delete(participant)
+    }
+
+    @Test
+    fun `이미 다른 멤버가 배정된 세션에는 추가로 배정할 수 없다`() {
+        val jam = jam(listOf(SessionDef("G-1", "기타", "G", false)))
+        `when`(jamRepository.findById(jamId)).thenReturn(Optional.of(jam))
+        `when`(jamParticipantRepository.existsByJamAndMember(jam, 1L)).thenReturn(true)
+        `when`(jamParticipantRepository.existsByJamAndSessionId(jam, "G-1")).thenReturn(true)
+
+        assertThatThrownBy { sut.addParticipant(jamId, JamMemberAddRequest("G-1", 2L), 1L) }
+            .isInstanceOf(BusinessException::class.java)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.JAM_SESSION_FULL)
     }
 }

--- a/src/test/kotlin/com/bandage/bandmanager/domain/selection/dto/res/TrackSelectionItemResponseTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/selection/dto/res/TrackSelectionItemResponseTest.kt
@@ -27,7 +27,7 @@ class TrackSelectionItemResponseTest {
         `when`(item.proposerId).thenReturn(proposerId)
         `when`(item.note).thenReturn(null)
         `when`(item.isSelected).thenReturn(false)
-        `when`(item.sessions).thenReturn(sessionIds.map { SessionDef(it, it, it, 1, false) })
+        `when`(item.sessions).thenReturn(sessionIds.map { SessionDef(it, it, it, false) })
         return item
     }
 

--- a/src/test/kotlin/com/bandage/bandmanager/domain/selection/service/TrackSelectionServiceConfirmationTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/selection/service/TrackSelectionServiceConfirmationTest.kt
@@ -1,0 +1,148 @@
+package com.bandage.bandmanager.domain.selection.service
+
+import com.bandage.bandmanager.domain.band.repository.BandMemberRepository
+import com.bandage.bandmanager.domain.member.service.MemberService
+import com.bandage.bandmanager.domain.selection.dto.req.SetlistConfirmationUpdateRequest
+import com.bandage.bandmanager.domain.selection.dto.req.TrackSelectionItemSelectionRequest
+import com.bandage.bandmanager.domain.selection.model.PracticeWindow
+import com.bandage.bandmanager.domain.selection.model.TrackSelection
+import com.bandage.bandmanager.domain.selection.model.TrackSelectionItem
+import com.bandage.bandmanager.domain.selection.repository.TrackSelectionBandRepository
+import com.bandage.bandmanager.domain.selection.repository.TrackSelectionItemApplicantRepository
+import com.bandage.bandmanager.domain.selection.repository.TrackSelectionItemChatMessageRepository
+import com.bandage.bandmanager.domain.selection.repository.TrackSelectionItemConfirmationRepository
+import com.bandage.bandmanager.domain.selection.repository.TrackSelectionItemRepository
+import com.bandage.bandmanager.domain.selection.repository.TrackSelectionMemberRepository
+import com.bandage.bandmanager.domain.selection.repository.TrackSelectionRepository
+import com.bandage.bandmanager.global.common.domain.SessionDef
+import com.bandage.bandmanager.global.common.domain.TrackInfo
+import com.bandage.bandmanager.global.error.errorcode.ErrorCode
+import com.bandage.bandmanager.global.error.exception.BusinessException
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.time.LocalDate
+import java.util.Optional
+import java.util.UUID
+
+/** 세션 슬롯화(1세션=1인) 이후 정원 검증(existsByItemAndSessionId 기반) 회귀 테스트. */
+class TrackSelectionServiceConfirmationTest {
+    private val selectionRepository = mock(TrackSelectionRepository::class.java)
+    private val selectionMemberRepository = mock(TrackSelectionMemberRepository::class.java)
+    private val selectionBandRepository = mock(TrackSelectionBandRepository::class.java)
+    private val itemRepository = mock(TrackSelectionItemRepository::class.java)
+    private val applicantRepository = mock(TrackSelectionItemApplicantRepository::class.java)
+    private val confirmationRepository = mock(TrackSelectionItemConfirmationRepository::class.java)
+    private val chatMessageRepository = mock(TrackSelectionItemChatMessageRepository::class.java)
+    private val bandMemberRepository = mock(BandMemberRepository::class.java)
+    private val memberService = mock(MemberService::class.java)
+
+    private val sut =
+        TrackSelectionService(
+            selectionRepository,
+            selectionMemberRepository,
+            selectionBandRepository,
+            itemRepository,
+            applicantRepository,
+            confirmationRepository,
+            chatMessageRepository,
+            bandMemberRepository,
+            memberService,
+        )
+
+    private val managerId = 1L
+    private val selectionId: UUID = UUID.randomUUID()
+    private val itemId: UUID = UUID.randomUUID()
+
+    private fun setEntityId(
+        target: Any,
+        id: UUID,
+    ) {
+        val field = target.javaClass.getDeclaredField("id")
+        field.isAccessible = true
+        field.set(target, id)
+    }
+
+    private fun selection(): TrackSelection {
+        val selection =
+            TrackSelection.create(
+                title = "회의",
+                managerId = managerId,
+                practiceWindow = PracticeWindow(from = LocalDate.of(2026, 1, 1), to = LocalDate.of(2026, 1, 31)),
+            )
+        setEntityId(selection, selectionId)
+        return selection
+    }
+
+    private fun item(selection: TrackSelection): TrackSelectionItem {
+        val item = mock(TrackSelectionItem::class.java)
+        `when`(item.id).thenReturn(itemId)
+        `when`(item.selection).thenReturn(selection)
+        `when`(item.proposerId).thenReturn(managerId)
+        `when`(item.trackInfo).thenReturn(TrackInfo(title = "곡", artist = "아티스트"))
+        `when`(item.note).thenReturn(null)
+        `when`(item.isSelected).thenReturn(false)
+        `when`(item.sessions).thenReturn(listOf(SessionDef("G-1", "기타", "G", false)))
+        return item
+    }
+
+    @Test
+    fun `이미 확정자가 있는 세션에 추가로 확정하려 하면 정원 초과 예외가 발생한다`() {
+        val selection = selection()
+        val item = item(selection)
+        `when`(selectionRepository.findById(selectionId)).thenReturn(Optional.of(selection))
+        `when`(itemRepository.findById(itemId)).thenReturn(Optional.of(item))
+        `when`(confirmationRepository.existsByItemAndSessionId(item, "G-1")).thenReturn(true)
+
+        assertThatThrownBy {
+            sut.updateConfirmations(
+                selectionId,
+                itemId,
+                "G-1",
+                managerId,
+                SetlistConfirmationUpdateRequest(confirm = listOf(2L)),
+            )
+        }.isInstanceOf(BusinessException::class.java)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SETLIST_MEETING_ITEM_SESSION_FULL)
+    }
+
+    @Test
+    fun `빈 세션에는 확정자를 추가할 수 있다`() {
+        val selection = selection()
+        val item = item(selection)
+        `when`(selectionRepository.findById(selectionId)).thenReturn(Optional.of(selection))
+        `when`(itemRepository.findById(itemId)).thenReturn(Optional.of(item))
+        `when`(confirmationRepository.existsByItemAndSessionId(item, "G-1")).thenReturn(false)
+        `when`(applicantRepository.findAllByItem(item)).thenReturn(emptyList())
+        `when`(confirmationRepository.findAllByItem(item)).thenReturn(emptyList())
+        `when`(memberService.getMemberSummaries(setOf(managerId))).thenReturn(emptyMap())
+
+        sut.updateConfirmations(
+            selectionId,
+            itemId,
+            "G-1",
+            managerId,
+            SetlistConfirmationUpdateRequest(confirm = listOf(2L)),
+        )
+    }
+
+    @Test
+    fun `세션 중 하나라도 확정자가 없으면 선택 확정할 수 없다`() {
+        val selection = selection()
+        val item = item(selection)
+        `when`(selectionRepository.findById(selectionId)).thenReturn(Optional.of(selection))
+        `when`(itemRepository.findById(itemId)).thenReturn(Optional.of(item))
+        `when`(confirmationRepository.existsByItemAndSessionId(item, "G-1")).thenReturn(false)
+
+        assertThatThrownBy {
+            sut.updateItemSelection(
+                selectionId,
+                itemId,
+                managerId,
+                TrackSelectionItemSelectionRequest(selected = true),
+            )
+        }.isInstanceOf(BusinessException::class.java)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SETLIST_SELECTION_INCOMPLETE_SESSION)
+    }
+}

--- a/src/test/kotlin/com/bandage/bandmanager/domain/setlist/dto/res/SetlistTrackResponseTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/setlist/dto/res/SetlistTrackResponseTest.kt
@@ -21,7 +21,7 @@ class SetlistTrackResponseTest {
         `when`(t.setlist).thenReturn(setlist)
         `when`(t.trackInfo).thenReturn(TrackInfo(title = "곡", artist = "아티스트"))
         `when`(t.note).thenReturn(null)
-        `when`(t.sessions).thenReturn(sessionIds.map { SessionDef(it, it, it, 1, false) })
+        `when`(t.sessions).thenReturn(sessionIds.map { SessionDef(it, it, it, false) })
         return t
     }
 


### PR DESCRIPTION
## 🛠️ Issue Number
### closes BD-165, BD-166

📌 **작업 내용 및 특이사항**

- SessionDef.need(정원) 필드 제거 — 정원 N명은 세션을 N개(예: G-1, G-2) 등록하는 것으로 표현하도록 정책 변경
- Jam 세션 개별 추가/수정/삭제 API 신설: `POST/PATCH/DELETE /jams/{jamId}/sessions[/{sessionId}]` — 기존 `PUT /jams/{jamId}/sessions`(전체 교체)는 그대로 유지
- Jam 세션당 배정 인원 1명 초과 방지 검증 추가 (`JAM_SESSION_FULL`)
- `TrackSelectionService`의 정원 검증(선곡 회의 세션 확정)을 카운트 비교 → 존재 여부 체크로 단순화
- DB 마이그레이션 021: `p_track_selection_item_session` / `p_setlist_track_session` / `p_jam_session`의 `session_need` 컬럼 DROP
- Jam 직접 생성 경로(`JamService.createJam`)와 Setlist→Jam facade 경로(`SetlistTrackToJamConverter`)가 이미 `Jam.create()` 팩토리를 공유하고 있어 별도 통합 작업은 불필요함을 확인

📚 **참고사항**

- 클라이언트 영향: "세션 정원 N명" 단일 입력이 API에서 사라짐. "기타 2명 필요"는 세션을 2개(`G-1`, `G-2`) 등록하는 것으로 표현해야 함
- 기존 `SessionDef(...)` 위치 인자 생성자 호출 3개(테스트 fixture)는 `need` 인자 제거에 맞춰 수정됨

✅ **체크리스트**
- [x] API(Controller/DTO)를 변경한 경우 `docs/openapi.json`을 갱신했습니다 (코드-스펙 동일 PR 규약)