### PR TITLE
[BD-205] refactor: 합주 세션 삭제와 참여자 생명주기 분리

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7163,7 +7163,7 @@
                 ]
             },
             "put": {
-                "description": "\ud569\uc8fc\uc758 \uc138\uc158 \uc815\uc758 \ubaa9\ub85d\uc744 \uc804\uccb4 \uad50\uccb4\ud569\ub2c8\ub2e4. \uc81c\uac70\ub41c \uc138\uc158\uc758 \ucc38\uc5ec\uc790 \ubc30\uc815\uc740 \ud568\uaed8 \uc0ad\uc81c\ub429\ub2c8\ub2e4.",
+                "description": "\ud569\uc8fc\uc758 \uc138\uc158 \uc815\uc758 \ubaa9\ub85d\uc744 \uc804\uccb4 \uad50\uccb4\ud569\ub2c8\ub2e4. \uc81c\uac70\ub41c \uc138\uc158\uc5d0 \ubc30\uc815\ub418\uc5b4 \uc788\ub358 \ucc38\uc5ec\uc790\ub294 \uc138\uc158 \ubbf8\ubc30\uc815 \uc0c1\ud0dc\ub85c \uc804\ud658\ub429\ub2c8\ub2e4(\ud569\uc8fc \ucc38\uc5ec \uc790\uccb4\ub294 \uc720\uc9c0).",
                 "operationId": "updateSessions",
                 "parameters": [
                     {
@@ -7206,7 +7206,7 @@
         },
         "/api/v1/jams/{jamId}/sessions/{sessionId}": {
             "delete": {
-                "description": "\ud569\uc8fc \uc138\uc158 \ud558\ub098\ub97c \uc0ad\uc81c\ud569\ub2c8\ub2e4. \ubc30\uc815\ub41c \ucc38\uc5ec\uc790\ub3c4 \ud568\uaed8 \uc0ad\uc81c\ub429\ub2c8\ub2e4.",
+                "description": "\ud569\uc8fc \uc138\uc158 \ud558\ub098\ub97c \uc0ad\uc81c\ud569\ub2c8\ub2e4. \ud574\ub2f9 \uc138\uc158\uc5d0 \ubc30\uc815\ub418\uc5b4 \uc788\ub358 \ucc38\uc5ec\uc790\ub294 \uc138\uc158 \ubbf8\ubc30\uc815 \uc0c1\ud0dc\ub85c \uc804\ud658\ub429\ub2c8\ub2e4.",
                 "operationId": "removeSession",
                 "parameters": [
                     {
@@ -10523,12 +10523,6 @@
     "security": [
         {
             "bearerAuth": []
-        }
-    ],
-    "servers": [
-        {
-            "description": "Generated server url",
-            "url": "http://bandage-band-manager:8080"
         }
     ],
     "tags": [

--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/controller/JamController.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/controller/JamController.kt
@@ -92,7 +92,7 @@ class JamController(
     @Operation(
         operationId = "updateSessions",
         summary = "합주 세션 정의 교체 API",
-        description = "합주의 세션 정의 목록을 전체 교체합니다. 제거된 세션의 참여자 배정은 함께 삭제됩니다.",
+        description = "합주의 세션 정의 목록을 전체 교체합니다. 제거된 세션에 배정되어 있던 참여자는 세션 미배정 상태로 전환됩니다(합주 참여 자체는 유지).",
     )
     fun updateSessions(
         @PathVariable jamId: UUID,
@@ -127,7 +127,11 @@ class JamController(
         )
 
     @DeleteMapping("/{jamId}/sessions/{sessionId}")
-    @Operation(operationId = "removeSession", summary = "합주 세션 삭제 API", description = "합주 세션 하나를 삭제합니다. 배정된 참여자도 함께 삭제됩니다.")
+    @Operation(
+        operationId = "removeSession",
+        summary = "합주 세션 삭제 API",
+        description = "합주 세션 하나를 삭제합니다. 해당 세션에 배정되어 있던 참여자는 세션 미배정 상태로 전환됩니다.",
+    )
     fun removeSession(
         @PathVariable jamId: UUID,
         @PathVariable sessionId: String,

--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/model/JamParticipant.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/model/JamParticipant.kt
@@ -50,6 +50,10 @@ open class JamParticipant(
         this.sessionId = sessionId
     }
 
+    fun unassignSession() {
+        this.sessionId = null
+    }
+
     companion object {
         fun create(
             jam: Jam,

--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/service/JamService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/service/JamService.kt
@@ -128,7 +128,7 @@ class JamService(
         validateParticipant(jam, memberId)
         val newDefs = request.sessions.map { it.toEntity() }
         val newSessionIds = newDefs.map { it.sessionId }.toSet()
-        deleteParticipantsNotIn(jam, newSessionIds)
+        unassignParticipantsNotIn(jam, newSessionIds)
         jam.replaceSessions(newDefs)
         jamReservationSyncService.sync(jam)
         return toDetailResponse(jam)
@@ -177,7 +177,7 @@ class JamService(
         val jam = getJam(jamId)
         validateParticipant(jam, memberId)
         validateSessionExists(jam, sessionId)
-        deleteParticipantsNotIn(jam, jam.sessions.map { it.sessionId }.toSet() - sessionId)
+        unassignParticipantsNotIn(jam, jam.sessions.map { it.sessionId }.toSet() - sessionId)
         jam.removeSession(sessionId)
         jamReservationSyncService.sync(jam)
         return toDetailResponse(jam)
@@ -318,17 +318,18 @@ class JamService(
     }
 
     /**
-     * 남길 세션(keepSessionIds)에 포함되지 않은 참여자 배정을 정리한다(세션 전체 교체/개별 삭제 공용).
-     * 세션 미배정 소속 참여자(sessionId=null, 생성자 등)는 세션 목록과 무관하므로 대상에서 제외한다.
+     * 남길 세션(keepSessionIds)에 없는 세션에 배정된 참여자의 배정을 해제한다(세션 전체 교체/개별 삭제 공용).
+     * 참여자 레코드 자체는 삭제하지 않는다 — 세션(메타데이터) 삭제가 합주 참여 포기를 의미하지 않는다.
+     * 세션 미배정 소속 참여자(sessionId=null, 생성자 등)는 이미 대상이 아니므로 필터에서 자연히 제외된다.
      */
-    private fun deleteParticipantsNotIn(
+    private fun unassignParticipantsNotIn(
         jam: Jam,
         keepSessionIds: Set<String>,
     ) {
         jamParticipantRepository
             .findAllByJam(jam)
             .filter { it.sessionId != null && it.sessionId !in keepSessionIds }
-            .forEach { jamParticipantRepository.delete(it) }
+            .forEach { it.unassignSession() }
     }
 
     private fun validateSessionNotFull(

--- a/src/test/kotlin/com/bandage/bandmanager/domain/jam/service/JamServiceTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/jam/service/JamServiceTest.kt
@@ -18,6 +18,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import java.time.LocalDateTime
@@ -125,10 +126,9 @@ class JamServiceTest {
     }
 
     @Test
-    fun `세션을 삭제하면 배정된 참여자도 함께 삭제된다`() {
+    fun `세션을 삭제하면 배정된 참여자는 세션 미배정 상태로 전환된다`() {
         val jam = jam(listOf(SessionDef("G-1", "기타", "G", false)))
-        val participant = mock(JamParticipant::class.java)
-        `when`(participant.sessionId).thenReturn("G-1")
+        val participant = JamParticipant.create(jam = jam, sessionId = "G-1", member = 2L)
         `when`(jamRepository.findById(jamId)).thenReturn(Optional.of(jam))
         `when`(jamParticipantRepository.existsByJamAndMember(jam, 1L)).thenReturn(true)
         `when`(jamParticipantRepository.findAllByJam(jam)).thenReturn(listOf(participant))
@@ -136,7 +136,8 @@ class JamServiceTest {
         sut.removeSession(jamId, "G-1", 1L)
 
         assertThat(jam.sessions).isEmpty()
-        verify(jamParticipantRepository).delete(participant)
+        assertThat(participant.sessionId).isNull()
+        verify(jamParticipantRepository, never()).delete(participant)
     }
 
     @Test


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #205

📌 **작업 내용 및 특이사항**
- 세션 삭제/교체 시 배정된 참여자를 하드 삭제하던 로직을 배정 해제(`sessionId=null`)로 변경
- 세션(정원 메타데이터) 삭제가 합주 참여 포기를 의미하지 않도록 세션과 참여자의 생명주기를 분리
- `updateSessions`, `removeSession`에서 사용하던 `deleteParticipantsNotIn`을 `unassignParticipantsNotIn`으로 교체

📚 **참고사항**
- 참여자 레코드 자체(soft delete 등)는 변경 없음 — 배정만 해제되어 세션 미배정 소속 참여자(생성자와 동일 상태)로 전환됨
- 관련 API(`updateSessions`, `removeSession`) description 문구 갱신

✅ **체크리스트**
- [x] API(Controller/DTO)를 변경한 경우 `docs/openapi.json`을 갱신했습니다 (코드-스펙 동일 PR 규약)

