### PR TITLE
[BD-184][BD-186] refactor: 공연/셋리스트 권한 양도 로직 구조 통일

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3947,12 +3947,17 @@
                         "type": "integer"
                     },
                     "managerIds": {
-                        "description": "\ub9e4\ub2c8\uc800 \uba64\ubc84 \uc544\uc774\ub514 \ubaa9\ub85d",
+                        "description": "\ub9e4\ub2c8\uc800(\uc18c\uc720\uc790 \uc81c\uc678) \uba64\ubc84 \uc544\uc774\ub514 \ubaa9\ub85d",
                         "items": {
                             "format": "int64",
                             "type": "integer"
                         },
                         "type": "array"
+                    },
+                    "ownerId": {
+                        "description": "\uacf5\uc5f0 \uc18c\uc720\uc790 \uba64\ubc84 \uc544\uc774\ub514",
+                        "format": "int64",
+                        "type": "integer"
                     },
                     "performanceId": {
                         "description": "\uacf5\uc5f0 \uace0\uc720 \uc2dd\ubcc4\uc790 (UUID)",
@@ -3987,6 +3992,7 @@
                 "required": [
                     "durationMinutes",
                     "managerIds",
+                    "ownerId",
                     "performanceId",
                     "setlists",
                     "startAt",
@@ -5296,6 +5302,11 @@
             "SetlistUpdateRequest": {
                 "description": "\uc14b\ub9ac\uc2a4\ud2b8 \uc218\uc815 \uc694\uccad",
                 "properties": {
+                    "managerId": {
+                        "description": "\ubcc0\uacbd\ud560 \ub9e4\ub2c8\uc800 \ud68c\uc6d0 ID",
+                        "format": "int64",
+                        "type": "integer"
+                    },
                     "title": {
                         "description": "\ubcc0\uacbd\ud560 \uc14b\ub9ac\uc2a4\ud2b8 \uc81c\ubaa9",
                         "minLength": 1,
@@ -9449,7 +9460,7 @@
                 ]
             },
             "patch": {
-                "description": "\ub9e4\ub2c8\uc800\uac00 \uc14b\ub9ac\uc2a4\ud2b8 \uc81c\ubaa9\uc744 \uc218\uc815\ud569\ub2c8\ub2e4.",
+                "description": "\ub9e4\ub2c8\uc800\uac00 \uc14b\ub9ac\uc2a4\ud2b8 \uc81c\ubaa9\uc744 \uc218\uc815\ud569\ub2c8\ub2e4. managerId \ub97c \ud568\uaed8 \uc804\ub2ec\ud558\uba74 \ub9e4\ub2c8\uc800 \uad8c\ud55c\uc744 \uc591\ub3c4\ud569\ub2c8\ub2e4(\ub300\uc0c1\uc740 \uc14b\ub9ac\uc2a4\ud2b8 \uc811\uadfc \uac00\ub2a5 \uba64\ubc84\uc5ec\uc57c \ud568).",
                 "operationId": "updateSetlist",
                 "parameters": [
                     {
@@ -9484,7 +9495,7 @@
                         "description": "OK"
                     }
                 },
-                "summary": "\uc14b\ub9ac\uc2a4\ud2b8 \ud0c0\uc774\ud2c0 \uc218\uc815",
+                "summary": "\uc14b\ub9ac\uc2a4\ud2b8 \uc218\uc815",
                 "tags": [
                     "setlists"
                 ]

--- a/src/main/kotlin/com/bandage/bandmanager/domain/performance/dto/res/PerformanceDetailResponse.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/performance/dto/res/PerformanceDetailResponse.kt
@@ -21,22 +21,27 @@ data class PerformanceDetailResponse(
     val venue: String?,
     @Schema(description = "참여 셋리스트 목록 (각 셋리스트는 참여 밴드 메타데이터를 포함)")
     val setlists: List<PerformanceSetlistSummary>,
-    @Schema(description = "매니저 멤버 아이디 목록")
+    @Schema(description = "공연 소유자 멤버 아이디")
+    val ownerId: Long,
+    @Schema(description = "매니저(소유자 제외) 멤버 아이디 목록")
     val managerIds: List<Long>,
 ) {
     companion object {
         fun of(
             performance: Performance,
             setlistSummariesBySetlistId: Map<UUID, PerformanceSetlistSummary>,
-        ): PerformanceDetailResponse =
-            PerformanceDetailResponse(
+        ): PerformanceDetailResponse {
+            val (owners, managers) = performance.managers.partition { it.isOwner() }
+            return PerformanceDetailResponse(
                 performanceId = performance.id,
                 title = performance.title,
                 startAt = performance.timeInfo.startAt,
                 durationMinutes = performance.timeInfo.durationMinutes,
                 venue = performance.timeInfo.venue,
                 setlists = performance.setlists.mapNotNull { ps -> setlistSummariesBySetlistId[ps.setlistId] },
-                managerIds = performance.managers.map { it.member },
+                ownerId = (owners.firstOrNull() ?: error("공연(${performance.id})에 OWNER 가 존재하지 않습니다.")).member,
+                managerIds = managers.map { it.member },
             )
+        }
     }
 }

--- a/src/main/kotlin/com/bandage/bandmanager/domain/setlist/controller/SetlistController.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/setlist/controller/SetlistController.kt
@@ -69,7 +69,11 @@ class SetlistController(
     ): ApiResponse<SetlistDetailResponse> = ApiResponse.success(setlistService.getSetlist(setlistId, memberId))
 
     @PatchMapping("/{setlistId}")
-    @Operation(operationId = "updateSetlist", summary = "셋리스트 타이틀 수정", description = "매니저가 셋리스트 제목을 수정합니다.")
+    @Operation(
+        operationId = "updateSetlist",
+        summary = "셋리스트 수정",
+        description = "매니저가 셋리스트 제목을 수정합니다. managerId 를 함께 전달하면 매니저 권한을 양도합니다(대상은 셋리스트 접근 가능 멤버여야 함).",
+    )
     fun updateSetlist(
         @PathVariable setlistId: UUID,
         @CurrentMemberId memberId: Long,

--- a/src/main/kotlin/com/bandage/bandmanager/domain/setlist/dto/req/SetlistUpdateRequest.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/setlist/dto/req/SetlistUpdateRequest.kt
@@ -8,4 +8,6 @@ data class SetlistUpdateRequest(
     @field:NotBlank
     @Schema(description = "변경할 셋리스트 제목")
     val title: String,
+    @Schema(description = "변경할 매니저 회원 ID")
+    val managerId: Long?,
 )

--- a/src/main/kotlin/com/bandage/bandmanager/domain/setlist/service/SetlistService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/setlist/service/SetlistService.kt
@@ -76,6 +76,13 @@ class SetlistService(
         val setlist = getSetlistOrThrow(setlistId)
         validateManager(setlist, memberId)
         setlist.updateTitle(request.title)
+        request.managerId?.let { newManagerId ->
+            if (newManagerId == memberId) throw BusinessException(ErrorCode.NO_CHANGE)
+            if (!setlistRepository.isAccessibleMember(setlist.id, newManagerId)) {
+                throw BusinessException(ErrorCode.SETLIST_MANAGER_NOT_PARTICIPANT)
+            }
+            setlist.changeManager(newManagerId)
+        }
         return SetlistDetailResponse.of(setlist, loadBandIds(setlist.id))
     }
 

--- a/src/test/kotlin/com/bandage/bandmanager/domain/performance/dto/res/PerformanceDetailResponseTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/performance/dto/res/PerformanceDetailResponseTest.kt
@@ -1,0 +1,54 @@
+package com.bandage.bandmanager.domain.performance.dto.res
+
+import com.bandage.bandmanager.domain.performance.model.Performance
+import com.bandage.bandmanager.domain.performance.model.PerformanceManager
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.time.LocalDateTime
+
+class PerformanceDetailResponseTest {
+    private val ownerId = 1L
+    private val managerId = 2L
+
+    private fun performanceWithManagers(managers: List<PerformanceManager>): Performance {
+        val performance = mock(Performance::class.java)
+        `when`(performance.id).thenReturn(java.util.UUID.randomUUID())
+        `when`(performance.title).thenReturn("정기공연")
+        `when`(performance.timeInfo).thenReturn(
+            com.bandage.bandmanager.global.common.domain.TimeInfoUnit(
+                startAt = LocalDateTime.now().plusDays(1),
+                durationMinutes = 90,
+                venue = null,
+            ),
+        )
+        `when`(performance.setlists).thenReturn(emptyList())
+        `when`(performance.managers).thenReturn(managers)
+        return performance
+    }
+
+    @Test
+    fun `of - OWNER와 MANAGER가 각각 ownerId, managerIds로 분리된다`() {
+        val performance =
+            mock(Performance::class.java).also {
+                `when`(it.id).thenReturn(java.util.UUID.randomUUID())
+            }
+        val owner = PerformanceManager.createOwner(performance, ownerId)
+        val manager = PerformanceManager.createManager(performance, managerId)
+        val target = performanceWithManagers(listOf(owner, manager))
+
+        val response = PerformanceDetailResponse.of(target, emptyMap())
+
+        assertThat(response.ownerId).isEqualTo(ownerId)
+        assertThat(response.managerIds).containsExactly(managerId)
+    }
+
+    @Test
+    fun `of - OWNER가 없으면 명확한 예외를 던진다`() {
+        val target = performanceWithManagers(emptyList())
+
+        assertThrows<IllegalStateException> { PerformanceDetailResponse.of(target, emptyMap()) }
+    }
+}

--- a/src/test/kotlin/com/bandage/bandmanager/domain/setlist/service/SetlistServiceTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/setlist/service/SetlistServiceTest.kt
@@ -1,0 +1,95 @@
+package com.bandage.bandmanager.domain.setlist.service
+
+import com.bandage.bandmanager.domain.band.repository.BandMemberRepository
+import com.bandage.bandmanager.domain.member.service.MemberService
+import com.bandage.bandmanager.domain.setlist.dto.req.SetlistUpdateRequest
+import com.bandage.bandmanager.domain.setlist.model.Setlist
+import com.bandage.bandmanager.domain.setlist.repository.SetlistBandRepository
+import com.bandage.bandmanager.domain.setlist.repository.SetlistRepository
+import com.bandage.bandmanager.domain.setlist.repository.SetlistTrackParticipantRepository
+import com.bandage.bandmanager.domain.setlist.repository.SetlistTrackRepository
+import com.bandage.bandmanager.global.error.errorcode.ErrorCode
+import com.bandage.bandmanager.global.error.exception.BusinessException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.util.Optional
+import java.util.UUID
+
+class SetlistServiceTest {
+    private val setlistRepository = mock(SetlistRepository::class.java)
+    private val setlistBandRepository = mock(SetlistBandRepository::class.java)
+    private val setlistTrackRepository = mock(SetlistTrackRepository::class.java)
+    private val setlistTrackParticipantRepository = mock(SetlistTrackParticipantRepository::class.java)
+    private val bandMemberRepository = mock(BandMemberRepository::class.java)
+    private val memberService = mock(MemberService::class.java)
+
+    private val sut =
+        SetlistService(
+            setlistRepository,
+            setlistBandRepository,
+            setlistTrackRepository,
+            setlistTrackParticipantRepository,
+            bandMemberRepository,
+            memberService,
+        )
+
+    private val setlistId: UUID = UUID.fromString("00000000-0000-0000-0000-0000000000a1")
+    private val managerId = 1L
+    private val newManagerId = 2L
+
+    private fun setlist(): Setlist {
+        val setlist = Setlist.create(trackSelectionId = UUID.randomUUID(), title = "셋리스트", managerId = managerId)
+        val field = setlist.javaClass.getDeclaredField("id")
+        field.isAccessible = true
+        field.set(setlist, setlistId)
+        `when`(setlistRepository.findById(setlistId)).thenReturn(Optional.of(setlist))
+        return setlist
+    }
+
+    @Test
+    fun `updateSetlist - managerId 를 전달하면 접근 가능한 멤버에게 매니저 권한을 양도한다`() {
+        val setlist = setlist()
+        `when`(setlistRepository.isAccessibleMember(setlistId, newManagerId)).thenReturn(true)
+
+        sut.updateSetlist(setlistId, managerId, SetlistUpdateRequest(title = setlist.title, managerId = newManagerId))
+
+        assertThat(setlist.managerId).isEqualTo(newManagerId)
+    }
+
+    @Test
+    fun `updateSetlist - 접근 불가한 멤버로는 양도할 수 없다`() {
+        val setlist = setlist()
+        `when`(setlistRepository.isAccessibleMember(setlistId, newManagerId)).thenReturn(false)
+
+        val ex =
+            assertThrows<BusinessException> {
+                sut.updateSetlist(setlistId, managerId, SetlistUpdateRequest(title = setlist.title, managerId = newManagerId))
+            }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.SETLIST_MANAGER_NOT_PARTICIPANT)
+    }
+
+    @Test
+    fun `updateSetlist - 본인에게 양도하면 NO_CHANGE`() {
+        val setlist = setlist()
+
+        val ex =
+            assertThrows<BusinessException> {
+                sut.updateSetlist(setlistId, managerId, SetlistUpdateRequest(title = setlist.title, managerId = managerId))
+            }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.NO_CHANGE)
+    }
+
+    @Test
+    fun `updateSetlist - 매니저가 아니면 SETLIST_NOT_MANAGER`() {
+        val setlist = setlist()
+
+        val ex =
+            assertThrows<BusinessException> {
+                sut.updateSetlist(setlistId, newManagerId, SetlistUpdateRequest(title = setlist.title, managerId = null))
+            }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.SETLIST_NOT_MANAGER)
+    }
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes BD-184, BD-186

📌 **작업 내용 및 특이사항**

공연/셋리스트/선곡/밴드 4개 도메인의 권한(owner/manager) 응답 및 양도(수동/자동) 로직을 전반적으로 점검하고, 발견된 두 가지 문제를 수정했습니다.

**1. 공연 상세 응답에서 OWNER/MANAGER 구분 복원**
- `PerformanceDetailResponse.managerIds`가 `PerformanceManager` 컬렉션 전체(OWNER 포함)를 role 구분 없이 평탄화해, 응답만으로는 누가 OWNER인지 알 수 없었음
- `ownerId`(단일) / `managerIds`(OWNER 제외)로 필드 분리
- Band가 이미 `role: BandRole`을 응답에 노출하는 패턴과 통일
- OWNER 부재 시(불변식 위반) `NoSuchElementException` 대신 명확한 예외를 던지도록 방어 처리

**2. 셋리스트 매니저 권한 수동 양도 API 추가**
- `Setlist.changeManager()` 메서드는 있었으나, 회원 탈퇴 시 자동 승계(`cleanupOnWithdrawal`) 내부에서만 호출되고 매니저 본인이 자기 의지로 넘기는 API가 없었음(TrackSelection은 이미 `updateSelection`으로 지원 중)
- `SetlistUpdateRequest.managerId` 필드 추가, `updateSetlist`에서 현재 매니저만 접근 가능한 멤버(`isAccessibleMember`)에게 양도 가능하도록 처리

📚 **참고사항**

- 점검 과정에서 다음 두 가지는 이번 PR 범위에서 제외하고 별도 이슈로 등록했습니다.
  - **밴드 이탈 시 권한 승계 여부**: 밴드는 활동 단위를 편리하게 묶는 그룹 메타데이터일 뿐, 개인 참여의 필수 전제조건이 되어서는 안 된다는 것이 원래 설계 의도임을 확인했습니다. 따라서 "밴드 이탈 → 리소스 권한 자동 승계"는 추가할 필요가 없다고 판단했습니다(이미 구현된 "회원 탈퇴 시 승계"만으로 충분).
  - **선곡(TrackSelection) 생성 시 밴드 필수 제약**: 반면 `TrackSelectionCreateRequest.bandIds`가 `@NotEmpty`로 강제되어 있어, 밴드 미소속 개인은 선곡/셋리스트를 만들 수 없는 상태입니다. 이는 위 설계 의도에 반하는 기존 결함으로 판단해 [BD-207](https://sunwoo1137.atlassian.net/browse/BD-207)로 등록했습니다.
- `docs/openapi.json` 갱신 완료(`OpenApiSpecGenerationTest` 통과 확인).

✅ **체크리스트**
- [x] API(Controller/DTO)를 변경한 경우 `docs/openapi.json`을 갱신했습니다 (코드-스펙 동일 PR 규약)

[BD-207]: https://sunwoo1137.atlassian.net/browse/BD-207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ