### PR TITLE
[BD-210] 밴드 가입 신청 재지원 시 최신/과거 이력 구분

### DIFF
--- a/src/main/kotlin/com/bandage/bandmanager/domain/band/model/BandApplication.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/band/model/BandApplication.kt
@@ -43,6 +43,10 @@ open class BandApplication(
     var processedBy: Long? = null
         protected set
 
+    @Column(name = "is_latest", nullable = false)
+    var isLatest: Boolean = true
+        protected set
+
     companion object {
         fun create(
             band: Band,
@@ -63,5 +67,10 @@ open class BandApplication(
 
     fun markProcessedBy(leaderId: Long) {
         this.processedBy = leaderId
+    }
+
+    /** 같은 (band, member) 조합에 새 지원 건이 생성될 때, 이전 지원 이력을 과거 이력으로 전환한다. */
+    fun markAsOutdated() {
+        this.isLatest = false
     }
 }

--- a/src/main/kotlin/com/bandage/bandmanager/domain/band/repository/BandApplicationRepository.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/band/repository/BandApplicationRepository.kt
@@ -30,8 +30,8 @@ interface BandApplicationRepository :
         status: ApplicationStatus,
     ): BandApplication?
 
-    /** 회원의 특정 밴드에 대한 가장 최근 가입 신청 단건(상태 무관). */
-    fun findTopByBandAndMemberOrderByCreatedAtDesc(
+    /** 회원의 특정 밴드에 대한 최신 가입 신청 단건. (band, member) 당 isLatest=true 는 유일하다. */
+    fun findByBandAndMemberAndIsLatestTrue(
         band: Band,
         member: Long,
     ): BandApplication?

--- a/src/main/kotlin/com/bandage/bandmanager/domain/band/repository/BandApplicationRepositoryImpl.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/band/repository/BandApplicationRepositoryImpl.kt
@@ -57,6 +57,7 @@ class BandApplicationRepositoryImpl(
                 .join(qBandApplication.band)
                 .fetchJoin()
                 .where(qBandApplication.member.eq(memberId))
+                .where(qBandApplication.isLatest.isTrue)
                 .where(status?.let { qBandApplication.status.eq(it) })
                 .where(ltBandId(lastId))
                 .orderBy(qBandApplication.id.desc())

--- a/src/main/kotlin/com/bandage/bandmanager/domain/band/service/BandService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/band/service/BandService.kt
@@ -82,6 +82,8 @@ class BandService(
         validateBandMemberNotExists(band, memberId)
         validateBandApplicationNotExists(band, memberId)
 
+        applicationRepository.findByBandAndMemberAndIsLatestTrue(band, memberId)?.markAsOutdated()
+
         applicationRepository.save(
             BandApplication.create(
                 band = band,
@@ -189,7 +191,7 @@ class BandService(
     ): MyBandApplicationInfoResponse {
         val band = getBand(bandId)
         val application =
-            applicationRepository.findTopByBandAndMemberOrderByCreatedAtDesc(band, memberId)
+            applicationRepository.findByBandAndMemberAndIsLatestTrue(band, memberId)
                 ?: throw BusinessException(ErrorCode.BAND_APPLICATION_NOT_FOUND)
         return MyBandApplicationInfoResponse.of(application, profileImageUrl(band.profileImg))
     }

--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/model/JamParticipantSession.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/model/JamParticipantSession.kt
@@ -9,6 +9,7 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.SQLRestriction
 import org.hibernate.annotations.UuidGenerator
 import java.util.UUID
 
@@ -22,6 +23,7 @@ import java.util.UUID
         ),
     ],
 )
+@SQLRestriction("deleted_at IS NULL")
 open class JamParticipantSession(
     jamParticipant: JamParticipant,
     sessionId: String,
@@ -33,7 +35,7 @@ open class JamParticipantSession(
         protected set
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "jam_participant_id")
+    @JoinColumn(name = "jam_participant_id", nullable = false)
     val jamParticipant: JamParticipant = jamParticipant
 
     @Column(name = "session_id", nullable = false)

--- a/src/main/resources/db/changelog/changes/023-band-application-is-latest.sql
+++ b/src/main/resources/db/changelog/changes/023-band-application-is-latest.sql
@@ -1,0 +1,24 @@
+-- BD-210: 밴드 가입 신청 재지원 시 과거/최신 이력 구분
+--         기존에는 재지원마다 새 row 만 추가하고 과거 이력을 구분할 방법이 없어,
+--         한 회원이 특정 밴드에 여러 번 지원한 경우 거절/승인 등 여러 상태가 동시에 조회되는 문제가 있었다.
+--         (band_id, member_id) 당 가장 최근 지원 건에만 is_latest = true 를 표시해 최신 상태만 구분 조회할 수 있게 한다.
+
+ALTER TABLE public.p_band_application ADD COLUMN is_latest boolean NOT NULL DEFAULT true;
+
+-- 기존 데이터 백필: (band_id, member_id) 당 가장 최근(created_at, 동률 시 id) 1건만 true, 나머지는 false
+WITH ranked AS (
+    SELECT id,
+           ROW_NUMBER() OVER (
+               PARTITION BY band_id, member_id
+               ORDER BY created_at DESC, id DESC
+           ) AS rn
+    FROM public.p_band_application
+    WHERE deleted_at IS NULL
+)
+UPDATE public.p_band_application a
+SET is_latest = false
+FROM ranked
+WHERE ranked.id = a.id AND ranked.rn > 1;
+
+CREATE UNIQUE INDEX uk_band_application_latest
+    ON public.p_band_application (band_id, member_id) WHERE is_latest AND deleted_at IS NULL;

--- a/src/main/resources/db/changelog/changes/024-jam-participant-session-soft-delete-columns.sql
+++ b/src/main/resources/db/changelog/changes/024-jam-participant-session-soft-delete-columns.sql
@@ -1,0 +1,6 @@
+-- BD-205 후속 수정: p_jam_participant_session 은 JamParticipantSession(BaseEntity 상속)의 테이블이지만
+--                   022 마이그레이션에서 soft delete 컬럼(deleted_at, deleted_by)이 누락되어
+--                   Hibernate 스키마 검증(ddl-auto=validate) 실패를 유발했다. 컬럼을 보강한다.
+
+ALTER TABLE public.p_jam_participant_session ADD COLUMN deleted_at timestamp(6) without time zone;
+ALTER TABLE public.p_jam_participant_session ADD COLUMN deleted_by bigint;

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -281,3 +281,31 @@ databaseChangeLog:
             splitStatements: true
             stripComments: true
             endDelimiter: ";"
+  - changeSet:
+      id: 023-band-application-is-latest
+      author: bandage
+      comment: |
+        BD-210: 밴드 가입 신청 재지원 시 최신/과거 이력 구분
+        - p_band_application.is_latest 컬럼 추가, (band_id, member_id) 당 최신 1건만 true 로 백필
+        - (band_id, member_id, is_latest=true) partial unique index 추가
+      changes:
+        - sqlFile:
+            path: changes/023-band-application-is-latest.sql
+            relativeToChangelogFile: true
+            splitStatements: true
+            stripComments: true
+            endDelimiter: ";"
+  - changeSet:
+      id: 024-jam-participant-session-soft-delete-columns
+      author: bandage
+      comment: |
+        BD-205 후속 수정: p_jam_participant_session soft delete 컬럼 누락 보강
+        - JamParticipantSession 은 BaseEntity 를 상속하나 022 마이그레이션에 deleted_at/deleted_by 컬럼이 빠져
+          Hibernate 스키마 검증(ddl-auto=validate) 실패를 유발하던 문제 수정
+      changes:
+        - sqlFile:
+            path: changes/024-jam-participant-session-soft-delete-columns.sql
+            relativeToChangelogFile: true
+            splitStatements: true
+            stripComments: true
+            endDelimiter: ";"

--- a/src/test/kotlin/com/bandage/bandmanager/domain/band/service/BandApplicationIsLatestTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/band/service/BandApplicationIsLatestTest.kt
@@ -1,0 +1,83 @@
+package com.bandage.bandmanager.domain.band.service
+
+import com.bandage.bandmanager.domain.band.model.Band
+import com.bandage.bandmanager.domain.band.model.BandApplication
+import com.bandage.bandmanager.domain.band.model.enums.ApplicationStatus
+import com.bandage.bandmanager.domain.band.repository.BandApplicationRepository
+import com.bandage.bandmanager.domain.band.repository.BandMemberRepository
+import com.bandage.bandmanager.domain.band.repository.BandRepository
+import com.bandage.bandmanager.domain.member.repository.MemberRepository
+import com.bandage.bandmanager.global.infra.s3.CloudFrontUrlResolver
+import com.bandage.bandmanager.global.infra.s3.ImagePresignSupport
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.util.Optional
+import java.util.UUID
+
+class BandApplicationIsLatestTest {
+    private val bandRepository = mock(BandRepository::class.java)
+    private val applicationRepository = mock(BandApplicationRepository::class.java)
+    private val bandMemberRepository = mock(BandMemberRepository::class.java)
+    private val memberRepository = mock(MemberRepository::class.java)
+    private val cloudFrontUrlResolver = mock(CloudFrontUrlResolver::class.java)
+    private val imagePresignSupport = mock(ImagePresignSupport::class.java)
+
+    private val sut =
+        BandService(
+            bandRepository,
+            applicationRepository,
+            bandMemberRepository,
+            memberRepository,
+            cloudFrontUrlResolver,
+            imagePresignSupport,
+        )
+
+    private val bandId: UUID = UUID.fromString("00000000-0000-0000-0000-0000000000a1")
+
+    private fun band(): Band {
+        val band = Band.create(name = "밴드", description = "설명", profileImg = null)
+        setEntityId(band, bandId)
+        return band
+    }
+
+    private fun setEntityId(
+        target: Any,
+        id: UUID,
+    ) {
+        val field = target.javaClass.getDeclaredField("id")
+        field.isAccessible = true
+        field.set(target, id)
+    }
+
+    @Test
+    fun `거절된 이전 신청은 재지원 시 isLatest 가 false 로 전환된다`() {
+        val band = band()
+        val rejected = BandApplication.create(band, 1L)
+        rejected.updateStatus(ApplicationStatus.REJECTED)
+
+        `when`(bandRepository.findById(bandId)).thenReturn(Optional.of(band))
+        `when`(bandMemberRepository.existsBandMemberByBandAndMember(band, 1L)).thenReturn(false)
+        `when`(applicationRepository.existsByBandAndMemberAndStatus(band, 1L, ApplicationStatus.PENDING)).thenReturn(false)
+        `when`(applicationRepository.findByBandAndMemberAndIsLatestTrue(band, 1L)).thenReturn(rejected)
+
+        sut.createBandApplication(bandId, 1L)
+
+        assertThat(rejected.isLatest).isFalse()
+    }
+
+    @Test
+    fun `나의 신청 단건 조회는 isLatest 인 신청만 반환한다`() {
+        val band = band()
+        val latest = BandApplication.create(band, 1L)
+        setEntityId(latest, UUID.randomUUID())
+
+        `when`(bandRepository.findById(bandId)).thenReturn(Optional.of(band))
+        `when`(applicationRepository.findByBandAndMemberAndIsLatestTrue(band, 1L)).thenReturn(latest)
+
+        val result = sut.getMyApplicationForBand(bandId, 1L)
+
+        assertThat(result.bandApplicationId).isEqualTo(latest.id)
+    }
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #BD-210

📌 **작업 내용 및 특이사항**

기존에는 밴드 가입 신청이 재지원될 때마다 새 row만 추가하고 과거 이력을 구분하지 않아, 지원자가 1차로 거절된 후 2차 지원에서 승인받은 경우 프론트 조회 시 REJECTED/APPROVED 상태가 동시에 노출되는 문제가 있었습니다.

- `BandApplication`에 `isLatest: Boolean`(기본 `true`) 필드 추가
- `createBandApplication`(재지원 생성 시점)에서 기존 `isLatest=true` 레코드를 outdated 처리(`markAsOutdated()`) 후 새 레코드 생성
- `(band_id, member_id)` 당 `isLatest=true`는 유일하도록 partial unique index 추가(마이그레이션 023), 기존 데이터는 밴드·회원별 최신 1건만 `true`로 백필
- **'나의 신청 현황' 조회**(`findAllByMemberPaging`, `getMyApplicationForBand`)는 `isLatest=true` 건만 조회하도록 변경
- **밴드 리더의 신청 목록 조회**(`findAllByPaging`)는 요구사항대로 현행 유지 — 과거 이력 포함 전체 조회
- 안 쓰이게 된 `findTopByBandAndMemberOrderByCreatedAtDesc`는 `findByBandAndMemberAndIsLatestTrue`로 대체
- 관련 단위 테스트 추가(`BandApplicationIsLatestTest`)

**별도 발견 사항 (BD-205 후속 수정)**
로컬 검증 중 `p_jam_participant_session`(BD-205, #130) 테이블에 `deleted_at`/`deleted_by` 컬럼이 누락되어 Hibernate 스키마 검증(`ddl-auto=validate`)이 실패하는 것을 발견해 함께 수정했습니다.
- 마이그레이션 024로 `deleted_at`/`deleted_by` 컬럼 보강
- `JamParticipantSession`에 `@SQLRestriction("deleted_at IS NULL")` 추가, `jamParticipant` FK `nullable=false` 명시 — 동일 패턴을 쓰는 `JamParticipant` 엔티티와 정합화

📚 **참고사항**

- `docs/openapi.json`은 갱신하지 않았습니다 — 컨트롤러 시그니처/응답 DTO 필드 변화 없이 내부 필터링 로직만 변경되었습니다.
- 로컬 postgres에 마이그레이션을 직접 적용해 백필 결과 및 `(band_id, member_id)`별 `isLatest=true` 유일성을 확인했고, `./gradlew bootRun`으로 애플리케이션이 정상 기동(Hibernate 스키마 검증 통과)됨을 확인했습니다.
- `./gradlew test` 전체 통과.

✅ **체크리스트**
- [x] API(Controller/DTO)를 변경한 경우 `docs/openapi.json`을 갱신했습니다 (코드-스펙 동일 PR 규약) — 본 PR은 API 스펙 변경 없음

## Test plan
- [x] 로컬 postgres에 마이그레이션(023, 024) 적용 후 스키마/백필 결과 확인
- [x] `./gradlew bootRun`으로 애플리케이션 정상 기동 확인 (Hibernate 스키마 검증 포함)
- [x] `./gradlew test` 전체 테스트 통과
- [x] 재지원 시나리오(거절 → 재지원 → 승인) 시뮬레이션 후 `isLatest` 전환 및 유니크 제약 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)