### PR TITLE
[BD-205] JamParticipantSession soft delete 스키마/엔티티 정합화

### DIFF
--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/model/JamParticipantSession.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/model/JamParticipantSession.kt
@@ -9,6 +9,7 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.SQLRestriction
 import org.hibernate.annotations.UuidGenerator
 import java.util.UUID
 
@@ -22,6 +23,7 @@ import java.util.UUID
         ),
     ],
 )
+@SQLRestriction("deleted_at IS NULL")
 open class JamParticipantSession(
     jamParticipant: JamParticipant,
     sessionId: String,
@@ -33,7 +35,7 @@ open class JamParticipantSession(
         protected set
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "jam_participant_id")
+    @JoinColumn(name = "jam_participant_id", nullable = false)
     val jamParticipant: JamParticipant = jamParticipant
 
     @Column(name = "session_id", nullable = false)

--- a/src/main/resources/db/changelog/changes/023-jam-participant-session-soft-delete-columns.sql
+++ b/src/main/resources/db/changelog/changes/023-jam-participant-session-soft-delete-columns.sql
@@ -1,0 +1,6 @@
+-- BD-205 후속 수정: p_jam_participant_session 은 JamParticipantSession(BaseEntity 상속)의 테이블이지만
+--                   022 마이그레이션에서 soft delete 컬럼(deleted_at, deleted_by)이 누락되어
+--                   Hibernate 스키마 검증(ddl-auto=validate) 실패를 유발했다. 컬럼을 보강한다.
+
+ALTER TABLE public.p_jam_participant_session ADD COLUMN deleted_at timestamp(6) without time zone;
+ALTER TABLE public.p_jam_participant_session ADD COLUMN deleted_by bigint;

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -281,3 +281,17 @@ databaseChangeLog:
             splitStatements: true
             stripComments: true
             endDelimiter: ";"
+  - changeSet:
+      id: 023-jam-participant-session-soft-delete-columns
+      author: bandage
+      comment: |
+        BD-205 후속 수정: p_jam_participant_session soft delete 컬럼 누락 보강
+        - JamParticipantSession 은 BaseEntity 를 상속하나 022 마이그레이션에 deleted_at/deleted_by 컬럼이 빠져
+          Hibernate 스키마 검증(ddl-auto=validate) 실패를 유발하던 문제 수정
+      changes:
+        - sqlFile:
+            path: changes/023-jam-participant-session-soft-delete-columns.sql
+            relativeToChangelogFile: true
+            splitStatements: true
+            stripComments: true
+            endDelimiter: ";"


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #BD-205

📌 **작업 내용 및 특이사항**

BD-210 작업 로컬 검증 중 발견한 문제입니다. `p_jam_participant_session`(#130, 022 마이그레이션에서 신설)은 `JamParticipantSession` 엔티티(`BaseEntity` 상속)의 테이블인데, soft delete 컬럼(`deleted_at`, `deleted_by`)이 누락되어 있어 `./gradlew bootRun` 시 Hibernate 스키마 검증(`ddl-auto=validate`)이 실패했습니다.

- 마이그레이션 023으로 `p_jam_participant_session`에 `deleted_at`/`deleted_by` 컬럼 추가
- `JamParticipantSession`에 `@SQLRestriction("deleted_at IS NULL")` 추가, `jamParticipant` FK `nullable=false` 명시 — 동일 소속/배정 패턴을 쓰는 `JamParticipant` 엔티티와 정합화

📚 **참고사항**

- 로컬 postgres에서 022까지만 적용된 상태로 되돌린 뒤, 이번 023 마이그레이션만 적용해 `./gradlew bootRun`이 정상 기동(Hibernate 스키마 검증 통과)됨을 확인했습니다.
- `./gradlew test` 전체 통과.
- API/DTO 변경이 없어 `docs/openapi.json` 갱신은 불필요합니다.

✅ **체크리스트**
- [x] API(Controller/DTO)를 변경한 경우 `docs/openapi.json`을 갱신했습니다 (코드-스펙 동일 PR 규약) — 본 PR은 API 스펙 변경 없음

## Test plan
- [x] 로컬 postgres를 022까지만 적용된 상태로 초기화 후 023 마이그레이션 적용
- [x] `./gradlew bootRun`으로 애플리케이션 정상 기동 확인 (Hibernate 스키마 검증 포함)
- [x] `./gradlew test` 전체 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)