### PR TITLE
[BD-213] refactor: 선곡회의 생성 시 band 필수 조건 무효화

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5385,12 +5385,11 @@
                 "description": "\uc120\uace1 \uc0dd\uc131 \uc694\uccad",
                 "properties": {
                     "bandIds": {
-                        "description": "\ucc38\uc5ec \ubc34\ub4dc ID \ubaa9\ub85d (1..N)",
+                        "description": "\ucc38\uc5ec \ubc34\ub4dc ID \ubaa9\ub85d (0..N, \ubc34\ub4dc \uc5c6\uc774 \uac1c\uc778\uc73c\ub85c\ub9cc \uad6c\uc131 \uac00\ub2a5)",
                         "items": {
                             "format": "uuid",
                             "type": "string"
                         },
-                        "minItems": 1,
                         "type": "array"
                     },
                     "managerId": {

--- a/src/main/kotlin/com/bandage/bandmanager/domain/schedule/service/ScheduleAuthService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/schedule/service/ScheduleAuthService.kt
@@ -1,12 +1,11 @@
 package com.bandage.bandmanager.domain.schedule.service
 
-import com.bandage.bandmanager.domain.band.repository.BandMemberRepository
 import com.bandage.bandmanager.domain.performance.model.Performance
 import com.bandage.bandmanager.domain.performance.repository.PerformanceManagerRepository
 import com.bandage.bandmanager.domain.performance.repository.PerformanceRepository
 import com.bandage.bandmanager.domain.selection.repository.TrackSelectionMemberRepository
 import com.bandage.bandmanager.domain.selection.repository.TrackSelectionRepository
-import com.bandage.bandmanager.domain.setlist.repository.SetlistBandRepository
+import com.bandage.bandmanager.domain.setlist.repository.SetlistTrackParticipantRepository
 import com.bandage.bandmanager.global.error.errorcode.ErrorCode
 import com.bandage.bandmanager.global.error.exception.BusinessException
 import org.springframework.data.repository.findByIdOrNull
@@ -21,8 +20,7 @@ class ScheduleAuthService(
     private val trackSelectionMemberRepository: TrackSelectionMemberRepository,
     private val performanceRepository: PerformanceRepository,
     private val performanceManagerRepository: PerformanceManagerRepository,
-    private val setlistBandRepository: SetlistBandRepository,
-    private val bandMemberRepository: BandMemberRepository,
+    private val setlistTrackParticipantRepository: SetlistTrackParticipantRepository,
 ) {
     // ===== Performance 스코프 (PRD-2) =====
 
@@ -39,7 +37,7 @@ class ScheduleAuthService(
     }
 
     /**
-     * 공연 참여자 여부. 공연 매니저이거나, 공연의 셋리스트가 속한 밴드의 멤버이면 참여자로 본다.
+     * 공연 참여자 여부. 공연 매니저이거나, 공연의 셋리스트에 트랙 참여자로 등록되어 있으면 참여자로 본다.
      */
     fun isPerformanceParticipant(
         performanceId: UUID,
@@ -50,9 +48,7 @@ class ScheduleAuthService(
 
         val setlistIds = performance.setlists.map { it.setlistId }
         if (setlistIds.isEmpty()) return false
-        val bandIds = setlistBandRepository.findAllBySetlistIdIn(setlistIds).map { it.bandId }.distinct()
-        if (bandIds.isEmpty()) return false
-        return bandMemberRepository.findAllByBandIdIn(bandIds).any { it.member == memberId }
+        return setlistTrackParticipantRepository.existsByTrackSetlistIdInAndMemberId(setlistIds, memberId)
     }
 
     fun validatePerformanceManager(

--- a/src/main/kotlin/com/bandage/bandmanager/domain/selection/dto/req/TrackSelectionCreateRequest.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/selection/dto/req/TrackSelectionCreateRequest.kt
@@ -4,7 +4,6 @@ import com.bandage.bandmanager.domain.selection.dto.PracticeWindowDto
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.NotNull
 import java.util.UUID
 
@@ -13,9 +12,8 @@ data class TrackSelectionCreateRequest(
     @field:NotBlank
     @Schema(description = "선곡 제목", example = "여름 페스티벌 셋리스트")
     val title: String,
-    @field:NotEmpty
-    @Schema(description = "참여 밴드 ID 목록 (1..N)")
-    val bandIds: List<UUID>,
+    @Schema(description = "참여 밴드 ID 목록 (0..N, 밴드 없이 개인으로만 구성 가능)")
+    val bandIds: List<UUID> = emptyList(),
     @field:NotNull
     @Schema(description = "매니저 회원 ID")
     val managerId: Long,

--- a/src/main/kotlin/com/bandage/bandmanager/domain/setlist/repository/SetlistTrackParticipantRepository.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/setlist/repository/SetlistTrackParticipantRepository.kt
@@ -13,4 +13,9 @@ interface SetlistTrackParticipantRepository : JpaRepository<SetlistTrackParticip
     fun findAllByTrackIn(tracks: List<SetlistTrack>): List<SetlistTrackParticipant>
 
     fun deleteAllByTrack(track: SetlistTrack)
+
+    fun existsByTrackSetlistIdInAndMemberId(
+        setlistIds: List<UUID>,
+        memberId: Long,
+    ): Boolean
 }


### PR DESCRIPTION
## 🛠️ Issue Number
### closes BD-213

📌 **작업 내용 및 특이사항**
- 선곡회의(TrackSelection) 생성 시 BandId 리스트 요구 -> 밴드 아이디 입력 없이도 생성 가능
- 공연 참여 멤버 판단 기준: Band 소속 멤버 -> 셋리스트 참여 멤버로 변경


📚 **참고사항**


✅ **체크리스트**
- [x] API(Controller/DTO)를 변경한 경우 `docs/openapi.json`을 갱신했습니다 (코드-스펙 동일 PR 규약)
