### PR TITLE
[BD-212] feat: 읽지 않은 알림만 필터링하는 조회 옵션 추가

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3678,10 +3678,16 @@
                         "maximum": 100,
                         "minimum": 1,
                         "type": "integer"
+                    },
+                    "unreadOnly": {
+                        "description": "true\uba74 \uc77d\uc9c0 \uc54a\uc740 \uc54c\ub9bc\ub9cc \uc870\ud68c",
+                        "example": false,
+                        "type": "boolean"
                     }
                 },
                 "required": [
-                    "pageSize"
+                    "pageSize",
+                    "unreadOnly"
                 ],
                 "type": "object"
             },
@@ -7758,7 +7764,7 @@
         },
         "/api/v1/notifications": {
             "get": {
-                "description": "\ub85c\uadf8\uc778\ud55c \ud68c\uc6d0\uc758 \uc804\uccb4 \uc54c\ub9bc\uc744 \ucee4\uc11c \uae30\ubc18 \ucd5c\uc2e0\uc21c\uc73c\ub85c \uc870\ud68c\ud569\ub2c8\ub2e4. \uce74\ud14c\uace0\ub9ac \ud544\ud130\ub9c1\uc740 \ud504\ub860\ud2b8\uac00 \ucc98\ub9ac\ud569\ub2c8\ub2e4.",
+                "description": "\ub85c\uadf8\uc778\ud55c \ud68c\uc6d0\uc758 \uc54c\ub9bc\uc744 \ucee4\uc11c \uae30\ubc18 \ucd5c\uc2e0\uc21c\uc73c\ub85c \uc870\ud68c\ud569\ub2c8\ub2e4. unreadOnly=true\uba74 \uc77d\uc9c0 \uc54a\uc740 \uc54c\ub9bc\ub9cc \uc870\ud68c\ud569\ub2c8\ub2e4. \uce74\ud14c\uace0\ub9ac \ud544\ud130\ub9c1\uc740 \ud504\ub860\ud2b8\uac00 \ucc98\ub9ac\ud569\ub2c8\ub2e4.",
                 "operationId": "getMyNotifications",
                 "parameters": [
                     {

--- a/src/main/kotlin/com/bandage/bandmanager/domain/notify/controller/NotificationController.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/notify/controller/NotificationController.kt
@@ -28,7 +28,7 @@ class NotificationController(
     @Operation(
         operationId = "getMyNotifications",
         summary = "내 알림 목록 조회 API",
-        description = "로그인한 회원의 전체 알림을 커서 기반 최신순으로 조회합니다. 카테고리 필터링은 프론트가 처리합니다.",
+        description = "로그인한 회원의 알림을 커서 기반 최신순으로 조회합니다. unreadOnly=true면 읽지 않은 알림만 조회합니다. 카테고리 필터링은 프론트가 처리합니다.",
     )
     fun getMyNotifications(
         @Valid query: NotificationPagingQuery,

--- a/src/main/kotlin/com/bandage/bandmanager/domain/notify/dto/req/NotificationPagingQuery.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/notify/dto/req/NotificationPagingQuery.kt
@@ -13,4 +13,6 @@ data class NotificationPagingQuery(
     @field:Max(100)
     @Schema(description = "페이지 크기", example = "20")
     val pageSize: Int = 20,
+    @Schema(description = "true면 읽지 않은 알림만 조회", example = "false")
+    val unreadOnly: Boolean = false,
 )

--- a/src/main/kotlin/com/bandage/bandmanager/domain/notify/repository/NotificationRepositoryCustom.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/notify/repository/NotificationRepositoryCustom.kt
@@ -9,5 +9,6 @@ interface NotificationRepositoryCustom {
         recipientId: Long,
         lastId: UUID?,
         pageSize: Int,
+        unreadOnly: Boolean,
     ): CursorResponse<Notification, UUID>
 }

--- a/src/main/kotlin/com/bandage/bandmanager/domain/notify/repository/NotificationRepositoryImpl.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/notify/repository/NotificationRepositoryImpl.kt
@@ -14,6 +14,7 @@ class NotificationRepositoryImpl(
         recipientId: Long,
         lastId: UUID?,
         pageSize: Int,
+        unreadOnly: Boolean,
     ): CursorResponse<Notification, UUID> {
         val qNotification = QNotification.notification
 
@@ -22,6 +23,7 @@ class NotificationRepositoryImpl(
                 .selectFrom(qNotification)
                 .where(qNotification.recipientId.eq(recipientId))
                 .where(ltNotificationId(lastId))
+                .where(unreadOnlyCondition(unreadOnly))
                 .orderBy(qNotification.id.desc())
                 .limit(pageSize.toLong() + 1)
                 .fetch()
@@ -38,4 +40,7 @@ class NotificationRepositoryImpl(
     }
 
     private fun ltNotificationId(lastId: UUID?): BooleanExpression? = lastId?.let { QNotification.notification.id.lt(it) }
+
+    private fun unreadOnlyCondition(unreadOnly: Boolean): BooleanExpression? =
+        if (unreadOnly) QNotification.notification.isRead.isFalse else null
 }

--- a/src/main/kotlin/com/bandage/bandmanager/domain/notify/service/NotificationService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/notify/service/NotificationService.kt
@@ -33,7 +33,8 @@ class NotificationService(
         memberId: Long,
         query: NotificationPagingQuery,
     ): CursorResponse<NotificationResponse, UUID> {
-        val result = notificationRepository.findAllByRecipientIdWithCursor(memberId, query.lastId, query.pageSize)
+        val result =
+            notificationRepository.findAllByRecipientIdWithCursor(memberId, query.lastId, query.pageSize, query.unreadOnly)
         return CursorResponse(
             content = result.content.map { NotificationResponse.of(it) },
             nextCursor = result.nextCursor,

--- a/src/test/kotlin/com/bandage/bandmanager/domain/notify/service/NotificationServiceTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/notify/service/NotificationServiceTest.kt
@@ -1,7 +1,9 @@
 package com.bandage.bandmanager.domain.notify.service
 
+import com.bandage.bandmanager.domain.notify.dto.req.NotificationPagingQuery
 import com.bandage.bandmanager.domain.notify.model.Notification
 import com.bandage.bandmanager.domain.notify.repository.NotificationRepository
+import com.bandage.bandmanager.global.common.response.CursorResponse
 import com.bandage.bandmanager.global.error.errorcode.ErrorCode
 import com.bandage.bandmanager.global.error.exception.BusinessException
 import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
@@ -89,5 +91,16 @@ class NotificationServiceTest {
         `when`(notificationRepository.countByRecipientIdAndIsReadFalse(1L)).thenReturn(3L)
 
         assertThat(sut.getUnreadCount(1L)).isEqualTo(3L)
+    }
+
+    @Test
+    fun `unreadOnly 쿼리는 레포지토리에 그대로 전달된다`() {
+        val query = NotificationPagingQuery(lastId = null, pageSize = 20, unreadOnly = true)
+        `when`(notificationRepository.findAllByRecipientIdWithCursor(1L, null, 20, true))
+            .thenReturn(CursorResponse(content = emptyList(), nextCursor = null, hasNext = false))
+
+        sut.getMyNotifications(1L, query)
+
+        verify(notificationRepository).findAllByRecipientIdWithCursor(1L, null, 20, true)
     }
 }


### PR DESCRIPTION
## 🛠️ Issue Number
### done #BD-212

📌 **작업 내용 및 특이사항**

기존 `GET /notifications` 목록 조회 API에 `unreadOnly` 쿼리 파라미터를 추가해 읽지 않은 알림만 필터링해서 조회할 수 있도록 했습니다. 별도 엔드포인트 대신 기존 커서 기반 목록 API를 확장하는 방식을 선택했습니다.

- `NotificationPagingQuery`에 `unreadOnly: Boolean = false` 필드 추가
- `NotificationRepositoryCustom`/`NotificationRepositoryImpl`: 커서 조회 쿼리에 `isRead = false` 조건을 조건부로 적용
- `NotificationService.getMyNotifications`가 새 파라미터를 레포지토리로 전달
- 사용 예: `GET /api/v1/notifications?unreadOnly=true&pageSize=20`

📚 **참고사항**

- 카테고리 필터링은 기존과 동일하게 프론트에서 처리
- `NotificationServiceTest`에 `unreadOnly` 값이 레포지토리 호출까지 정확히 전달되는지 검증하는 테스트 추가

✅ **체크리스트**
- [x] API(Controller/DTO)를 변경한 경우 `docs/openapi.json`을 갱신했습니다 (코드-스펙 동일 PR 규약)