### PR TITLE
[BD-215] fix: 밴드 가입 신청 처리 후 재신청 시 401 오류 해결

### DIFF
--- a/src/main/kotlin/com/bandage/bandmanager/domain/band/service/BandService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/band/service/BandService.kt
@@ -82,7 +82,13 @@ class BandService(
         validateBandMemberNotExists(band, memberId)
         validateBandApplicationNotExists(band, memberId)
 
-        applicationRepository.findByBandAndMemberAndIsLatestTrue(band, memberId)?.markAsOutdated()
+        applicationRepository.findByBandAndMemberAndIsLatestTrue(band, memberId)?.let {
+            it.markAsOutdated()
+            // 새 신청 INSERT 전에 이전 건의 is_latest=false 를 먼저 반영해야 partial unique index
+            // (band_id, member_id) WHERE is_latest 위반을 피한다. order_inserts 로 INSERT 가 UPDATE 보다
+            // 먼저 flush 되므로 명시적 flush 로 순서를 보장한다.
+            applicationRepository.flush()
+        }
 
         applicationRepository.save(
             BandApplication.create(

--- a/src/main/kotlin/com/bandage/bandmanager/global/error/handler/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/global/error/handler/GlobalExceptionHandler.kt
@@ -100,4 +100,16 @@ open class GlobalExceptionHandler {
         val response = ApiResponse.error(message = errorCode.message, code = errorCode.name)
         return ResponseEntity(response, HttpStatus.INTERNAL_SERVER_ERROR)
     }
+
+    /**
+     * 위 handleException 은 커스텀 Exception 타입만 잡으므로, 그 외 표준 예외
+     * (예: DataIntegrityViolationException)는 여기서 500 으로 매핑한다.
+     * 이 폴백이 없으면 미처리 예외가 Security 필터 체인까지 전파되어 401 로 오응답된다.
+     */
+    @ExceptionHandler(java.lang.Exception::class)
+    protected fun handleUnexpectedException(e: java.lang.Exception): ResponseEntity<ApiResponse<Nothing>> {
+        val errorCode = ErrorCode.INTERNAL_SERVER_ERROR
+        val response = ApiResponse.error(message = errorCode.message, code = errorCode.name)
+        return ResponseEntity(response, HttpStatus.INTERNAL_SERVER_ERROR)
+    }
 }


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #BD-215

📌 **작업 내용 및 특이사항**

밴드 가입 신청을 처리(거절/철회)한 뒤 **재신청**하면 `401 UNAUTHORIZED`("인증되지 않은 회원입니다.")가 반환되던 문제를 수정합니다.

**근본 원인**
- BD-210에서 추가된 partial unique index `uk_band_application_latest (band_id, member_id) WHERE is_latest AND deleted_at IS NULL` 위반이 원인입니다.
- 재신청 시 `createBandApplication`은 이전 `isLatest=true` 건을 `is_latest=false`로 UPDATE하고 새 건을 INSERT하는데, `application.yaml`의 `order_inserts=true` 설정으로 Hibernate가 **INSERT를 UPDATE보다 먼저 flush**합니다. 그 순간 `is_latest=true` 행이 2개가 되어 unique index 위반(`DataIntegrityViolationException`)이 발생합니다.
- 이 표준 예외가 `GlobalExceptionHandler`의 catch-all(`handleException`)에 잡히지 않고(커스텀 `Exception` 타입만 처리) Security 필터 체인까지 전파되어 `JwtAuthenticationEntryPoint`가 401로 오응답했습니다.

**수정 내용**
1. `BandService.createBandApplication`: 이전 건 `markAsOutdated()` 직후 `flush()`를 호출해 UPDATE(is_latest=false)를 새 건 INSERT보다 먼저 반영 → unique index 위반 제거
2. `GlobalExceptionHandler`: `java.lang.Exception` 폴백 핸들러 추가 → 미처리 표준 예외가 401로 새지 않고 500으로 매핑되도록 하는 구조적 안전망

**검증**
- 로컬 실서버(localhost:8080)에서 신청 → 거절 → 재신청 시나리오로 401 재현 후, 수정 적용하여 재신청 200 정상 동작 확인
- 재현 밴드 DB 상태 확인: 이전 건 `is_latest=false`, 새 건 `is_latest=true`, `is_latest=true` 건수 정확히 1건
- 회귀 확인: 기존 예외 매핑(401 인증누락 / 404 BAND_NOT_FOUND / 409 DUPLICATE) 정상 유지, 폴백 핸들러가 `BusinessException`을 가로채지 않음
- `./gradlew test` 전체 통과

📚 **참고사항**

- API(Controller/DTO) 변경이 없어 `docs/openapi.json` 갱신은 불필요합니다(내부 로직 및 에러 매핑만 변경).

✅ **체크리스트**
- [x] API(Controller/DTO)를 변경한 경우 `docs/openapi.json`을 갱신했습니다 (코드-스펙 동일 PR 규약) — 해당 없음(API 변경 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)