### PR TITLE
[BD-203] feat: 도메인별 시스템 알림 구현 (BD-196~202)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3700,7 +3700,14 @@
                             "BAND_APPLICATION",
                             "BAND_APPLICATION_RESULT",
                             "AUTHORITY_PROMOTION",
-                            "JAM_UPCOMING"
+                            "JAM_UPCOMING",
+                            "JAM_PARTICIPANT_ADDED",
+                            "JAM_CREATED",
+                            "PERFORMANCE_UPCOMING",
+                            "PERFORMANCE_MANAGER_INVITED",
+                            "PERFORMANCE_OWNER_PROMOTED",
+                            "SELECTION_PARTICIPANT_ADDED",
+                            "SETLIST_CREATED"
                         ],
                         "example": "BAND_APPLICATION",
                         "type": "string"

--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/notify/JamCreatedFromSetlistResolver.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/notify/JamCreatedFromSetlistResolver.kt
@@ -1,0 +1,45 @@
+package com.bandage.bandmanager.domain.jam.notify
+
+import com.bandage.bandmanager.domain.jam.dto.res.JamResponse
+import com.bandage.bandmanager.domain.jam.repository.JamParticipantRepository
+import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
+import com.bandage.bandmanager.global.notify.resolver.NotificationPayload
+import com.bandage.bandmanager.global.notify.resolver.NotifyPayloadResolver
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+/**
+ * JAM_CREATED: 셋리스트 기반으로 합주가 일괄 생성되면, 생성된 합주들의 참여자 전원에게
+ * "N 건의 합주가 생성되었습니다" 요약 알림을 참여자당 1건씩 보낸다(N = 생성된 합주 개수).
+ * 트리거: JamCreateFromSetlistFacade.createJamsFromSetlist(memberId: Long, setlistId: UUID, request): List<JamResponse>
+ */
+@Component
+class JamCreatedFromSetlistResolver(
+    private val jamParticipantRepository: JamParticipantRepository,
+) : NotifyPayloadResolver {
+    override val category = NotifyCategory.JAM_CREATED
+
+    override fun resolve(
+        args: Array<Any?>,
+        returnValue: Any?,
+    ): List<NotificationPayload> {
+        val setlistId = args[1] as UUID
+        val jamIds = (returnValue as? List<*>).orEmpty().filterIsInstance<JamResponse>().map { it.jamId }
+        if (jamIds.isEmpty()) return emptyList()
+
+        val count = jamIds.size
+        return jamParticipantRepository
+            .findAllByJamIdIn(jamIds)
+            .map { it.member }
+            .distinct()
+            .map { memberId ->
+                NotificationPayload(
+                    recipientId = memberId,
+                    category = category,
+                    title = "합주 생성",
+                    message = "${count}건의 합주가 생성되었습니다.",
+                    referenceId = setlistId.toString(),
+                )
+            }
+    }
+}

--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/notify/JamParticipantAddedResolver.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/notify/JamParticipantAddedResolver.kt
@@ -1,0 +1,54 @@
+package com.bandage.bandmanager.domain.jam.notify
+
+import com.bandage.bandmanager.domain.jam.dto.req.JamMemberAddRequest
+import com.bandage.bandmanager.domain.jam.repository.JamRepository
+import com.bandage.bandmanager.domain.notify.repository.NotificationRepository
+import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
+import com.bandage.bandmanager.global.notify.resolver.NotificationPayload
+import com.bandage.bandmanager.global.notify.resolver.NotifyPayloadResolver
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+/**
+ * JAM_PARTICIPANT_ADDED: 합주 참여자로 추가된 멤버에게 알림.
+ * 트리거: JamService.addParticipant(jamId: UUID, request: JamMemberAddRequest, memberId: Long)
+ *
+ * addParticipant 는 세션 배정마다 호출되어 동일 멤버가 여러 번 지나므로,
+ * (recipient, JAM_PARTICIPANT_ADDED, jamId) 멱등성으로 합주당 1회만 생성한다.
+ */
+@Component
+class JamParticipantAddedResolver(
+    private val jamRepository: JamRepository,
+    private val notificationRepository: NotificationRepository,
+) : NotifyPayloadResolver {
+    override val category = NotifyCategory.JAM_PARTICIPANT_ADDED
+
+    override fun resolve(
+        args: Array<Any?>,
+        returnValue: Any?,
+    ): List<NotificationPayload> {
+        val jamId = args[0] as UUID
+        val request = args[1] as JamMemberAddRequest
+        val jam = jamRepository.findByIdOrNull(jamId) ?: return emptyList()
+
+        if (notificationRepository.existsByRecipientIdAndCategoryAndReferenceId(
+                request.memberId,
+                category,
+                jamId.toString(),
+            )
+        ) {
+            return emptyList()
+        }
+
+        return listOf(
+            NotificationPayload(
+                recipientId = request.memberId,
+                category = category,
+                title = "합주 참여자 추가",
+                message = "'${jam.title}' 합주에 참여자로 추가되었습니다.",
+                referenceId = jamId.toString(),
+            ),
+        )
+    }
+}

--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/repository/JamParticipantRepository.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/repository/JamParticipantRepository.kt
@@ -18,6 +18,8 @@ interface JamParticipantRepository : JpaRepository<JamParticipant, UUID> {
 
     fun findAllByJam(jam: Jam): List<JamParticipant>
 
+    fun findAllByJamIdIn(jamIds: Collection<UUID>): List<JamParticipant>
+
     fun existsByJamAndMember(
         jam: Jam,
         member: Long,

--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/service/JamService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/service/JamService.kt
@@ -25,6 +25,8 @@ import com.bandage.bandmanager.global.common.domain.SessionDef
 import com.bandage.bandmanager.global.common.response.CursorResponse
 import com.bandage.bandmanager.global.error.errorcode.ErrorCode
 import com.bandage.bandmanager.global.error.exception.BusinessException
+import com.bandage.bandmanager.global.notify.annotation.Notify
+import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -183,6 +185,7 @@ class JamService(
         return toDetailResponse(jam)
     }
 
+    @Notify(NotifyCategory.JAM_PARTICIPANT_ADDED)
     @Transactional
     fun addParticipant(
         jamId: UUID,

--- a/src/main/kotlin/com/bandage/bandmanager/domain/performance/notify/PerformanceManagerInvitedResolver.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/performance/notify/PerformanceManagerInvitedResolver.kt
@@ -1,0 +1,40 @@
+package com.bandage.bandmanager.domain.performance.notify
+
+import com.bandage.bandmanager.domain.performance.dto.req.PerformanceInvitationCreateRequest
+import com.bandage.bandmanager.domain.performance.repository.PerformanceRepository
+import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
+import com.bandage.bandmanager.global.notify.resolver.NotificationPayload
+import com.bandage.bandmanager.global.notify.resolver.NotifyPayloadResolver
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+/**
+ * PERFORMANCE_MANAGER_INVITED: 공연 매니저로 초대받은 멤버에게 알림.
+ * 트리거: PerformanceService.sendInvitation(performanceId: UUID, request: PerformanceInvitationCreateRequest, ownerId: Long)
+ */
+@Component
+class PerformanceManagerInvitedResolver(
+    private val performanceRepository: PerformanceRepository,
+) : NotifyPayloadResolver {
+    override val category = NotifyCategory.PERFORMANCE_MANAGER_INVITED
+
+    override fun resolve(
+        args: Array<Any?>,
+        returnValue: Any?,
+    ): List<NotificationPayload> {
+        val performanceId = args[0] as UUID
+        val request = args[1] as PerformanceInvitationCreateRequest
+        val performance = performanceRepository.findByIdOrNull(performanceId) ?: return emptyList()
+
+        return listOf(
+            NotificationPayload(
+                recipientId = request.memberId,
+                category = category,
+                title = "공연 매니저 초대",
+                message = "'${performance.title}' 공연의 매니저로 초대되었습니다.",
+                referenceId = performanceId.toString(),
+            ),
+        )
+    }
+}

--- a/src/main/kotlin/com/bandage/bandmanager/domain/performance/notify/PerformanceOwnerPromotedResolver.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/performance/notify/PerformanceOwnerPromotedResolver.kt
@@ -1,0 +1,39 @@
+package com.bandage.bandmanager.domain.performance.notify
+
+import com.bandage.bandmanager.domain.performance.repository.PerformanceRepository
+import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
+import com.bandage.bandmanager.global.notify.resolver.NotificationPayload
+import com.bandage.bandmanager.global.notify.resolver.NotifyPayloadResolver
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+/**
+ * PERFORMANCE_OWNER_PROMOTED: 공연 소유권을 넘겨받은 새 소유자에게 알림.
+ * 트리거: PerformanceService.delegateOwnership(performanceId: UUID, targetMemberId: Long, ownerId: Long)
+ */
+@Component
+class PerformanceOwnerPromotedResolver(
+    private val performanceRepository: PerformanceRepository,
+) : NotifyPayloadResolver {
+    override val category = NotifyCategory.PERFORMANCE_OWNER_PROMOTED
+
+    override fun resolve(
+        args: Array<Any?>,
+        returnValue: Any?,
+    ): List<NotificationPayload> {
+        val performanceId = args[0] as UUID
+        val targetMemberId = args[1] as Long
+        val performance = performanceRepository.findByIdOrNull(performanceId) ?: return emptyList()
+
+        return listOf(
+            NotificationPayload(
+                recipientId = targetMemberId,
+                category = category,
+                title = "공연 소유자 승격",
+                message = "'${performance.title}' 공연의 새로운 소유자로 승격되었습니다.",
+                referenceId = performanceId.toString(),
+            ),
+        )
+    }
+}

--- a/src/main/kotlin/com/bandage/bandmanager/domain/performance/repository/PerformanceRepository.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/performance/repository/PerformanceRepository.kt
@@ -22,4 +22,11 @@ interface PerformanceRepository :
         @Param("bandIds") bandIds: Collection<UUID>,
         @Param("now") now: LocalDateTime,
     ): Long
+
+    // 임박 공연 알림 스케줄러용: [from, to) 구간에 시작하는 공연 조회
+    @Query("SELECT p FROM Performance p WHERE p.timeInfo.startAt >= :from AND p.timeInfo.startAt < :to")
+    fun findUpcomingBetween(
+        @Param("from") from: LocalDateTime,
+        @Param("to") to: LocalDateTime,
+    ): List<Performance>
 }

--- a/src/main/kotlin/com/bandage/bandmanager/domain/performance/scheduler/PerformanceReminderScheduler.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/performance/scheduler/PerformanceReminderScheduler.kt
@@ -1,0 +1,64 @@
+package com.bandage.bandmanager.domain.performance.scheduler
+
+import com.bandage.bandmanager.domain.notify.repository.NotificationRepository
+import com.bandage.bandmanager.domain.performance.repository.PerformanceRepository
+import com.bandage.bandmanager.global.async.publisher.EventPublisher
+import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
+import com.bandage.bandmanager.global.notify.event.NotificationCreateEvent
+import com.bandage.bandmanager.global.notify.resolver.NotificationPayload
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+/**
+ * 임박한 공연(시작 [REMIND_BEFORE_HOURS, +1h) 구간) 참여자(매니저 전원)에게 PERFORMANCE_UPCOMING 알림을 생성한다.
+ *
+ * - JamReminderScheduler 와 동일한 구조: AOP 경로가 아니므로 NotificationCreateEvent 를 직접 발행.
+ * - 멱등성: (recipientId, PERFORMANCE_UPCOMING, performanceId) 가 이미 있으면 제외해 재실행에도 1회만 생성.
+ * - @Transactional(readOnly): performance.managers(LAZY) 로딩 + 커밋 시 AFTER_COMMIT 핸들러 발화.
+ */
+@Component
+class PerformanceReminderScheduler(
+    private val performanceRepository: PerformanceRepository,
+    private val notificationRepository: NotificationRepository,
+    private val eventPublisher: EventPublisher,
+) {
+    @Scheduled(cron = "0 0 * * * *")
+    @Transactional(readOnly = true)
+    fun remindUpcomingPerformances() {
+        val from = LocalDateTime.now().plusHours(REMIND_BEFORE_HOURS)
+        val to = from.plusHours(1)
+
+        val payloads =
+            performanceRepository.findUpcomingBetween(from, to).flatMap { performance ->
+                performance.managers
+                    .map { it.member }
+                    .distinct()
+                    .filter { memberId ->
+                        !notificationRepository.existsByRecipientIdAndCategoryAndReferenceId(
+                            memberId,
+                            NotifyCategory.PERFORMANCE_UPCOMING,
+                            performance.id.toString(),
+                        )
+                    }.map { memberId ->
+                        NotificationPayload(
+                            recipientId = memberId,
+                            category = NotifyCategory.PERFORMANCE_UPCOMING,
+                            title = "다가오는 공연",
+                            message = "'${performance.title}' 공연이 곧 시작됩니다.",
+                            referenceId = performance.id.toString(),
+                        )
+                    }
+            }
+
+        if (payloads.isNotEmpty()) {
+            eventPublisher.publish(NotificationCreateEvent(payloads))
+        }
+    }
+
+    companion object {
+        // 명세: 1일 전 기준
+        const val REMIND_BEFORE_HOURS = 24L
+    }
+}

--- a/src/main/kotlin/com/bandage/bandmanager/domain/performance/service/PerformanceService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/performance/service/PerformanceService.kt
@@ -38,6 +38,8 @@ import com.bandage.bandmanager.global.common.response.CursorResponse
 import com.bandage.bandmanager.global.error.errorcode.ErrorCode
 import com.bandage.bandmanager.global.error.exception.BusinessException
 import com.bandage.bandmanager.global.infra.s3.CloudFrontUrlResolver
+import com.bandage.bandmanager.global.notify.annotation.Notify
+import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -223,6 +225,7 @@ class PerformanceService(
         target.promoteToOwner()
     }
 
+    @Notify(NotifyCategory.PERFORMANCE_MANAGER_INVITED)
     @Transactional
     fun sendInvitation(
         performanceId: UUID,

--- a/src/main/kotlin/com/bandage/bandmanager/domain/performance/service/PerformanceService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/performance/service/PerformanceService.kt
@@ -204,6 +204,7 @@ class PerformanceService(
      * 공연 소유권(OWNER) 수동 양도. 현재 OWNER 가 같은 공연의 MANAGER 에게 권한을 넘긴다.
      * 기존 OWNER 는 MANAGER 로 강등된다.
      */
+    @Notify(NotifyCategory.PERFORMANCE_OWNER_PROMOTED)
     @Transactional
     fun delegateOwnership(
         performanceId: UUID,

--- a/src/main/kotlin/com/bandage/bandmanager/domain/selection/notify/SelectionParticipantAddedResolver.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/selection/notify/SelectionParticipantAddedResolver.kt
@@ -1,0 +1,46 @@
+package com.bandage.bandmanager.domain.selection.notify
+
+import com.bandage.bandmanager.domain.selection.dto.req.SetlistParticipantsUpdateRequest
+import com.bandage.bandmanager.domain.selection.repository.TrackSelectionRepository
+import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
+import com.bandage.bandmanager.global.notify.resolver.NotificationPayload
+import com.bandage.bandmanager.global.notify.resolver.NotifyPayloadResolver
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+/**
+ * SELECTION_PARTICIPANT_ADDED: 선곡회의 참여자로 추가된 멤버(들)에게 알림.
+ * 트리거: TrackSelectionService.updateParticipants(selectionId: UUID, memberId: Long, request: SetlistParticipantsUpdateRequest)
+ *
+ * request.add 의 각 memberId 가 신규 추가 대상(수신자)이다. remove 만 있으면 알림 없음.
+ */
+@Component
+class SelectionParticipantAddedResolver(
+    private val trackSelectionRepository: TrackSelectionRepository,
+) : NotifyPayloadResolver {
+    override val category = NotifyCategory.SELECTION_PARTICIPANT_ADDED
+
+    override fun resolve(
+        args: Array<Any?>,
+        returnValue: Any?,
+    ): List<NotificationPayload> {
+        val selectionId = args[0] as UUID
+        val request = args[2] as SetlistParticipantsUpdateRequest
+        if (request.add.isEmpty()) return emptyList()
+        val selection = trackSelectionRepository.findByIdOrNull(selectionId) ?: return emptyList()
+
+        return request.add
+            .map { it.memberId }
+            .distinct()
+            .map { memberId ->
+                NotificationPayload(
+                    recipientId = memberId,
+                    category = category,
+                    title = "선곡 회의 참여자 추가",
+                    message = "'${selection.title}' 선곡 회의에 참여자로 추가되었습니다.",
+                    referenceId = selectionId.toString(),
+                )
+            }
+    }
+}

--- a/src/main/kotlin/com/bandage/bandmanager/domain/selection/service/TrackSelectionService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/selection/service/TrackSelectionService.kt
@@ -39,6 +39,8 @@ import com.bandage.bandmanager.global.common.domain.TrackInfo
 import com.bandage.bandmanager.global.common.response.CursorResponse
 import com.bandage.bandmanager.global.error.errorcode.ErrorCode
 import com.bandage.bandmanager.global.error.exception.BusinessException
+import com.bandage.bandmanager.global.notify.annotation.Notify
+import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -151,6 +153,7 @@ class TrackSelectionService(
         selection.markAsDeleted(memberId)
     }
 
+    @Notify(NotifyCategory.SELECTION_PARTICIPANT_ADDED)
     @Transactional
     fun updateParticipants(
         selectionId: UUID,

--- a/src/main/kotlin/com/bandage/bandmanager/domain/setlist/notify/SetlistCreatedResolver.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/setlist/notify/SetlistCreatedResolver.kt
@@ -1,0 +1,47 @@
+package com.bandage.bandmanager.domain.setlist.notify
+
+import com.bandage.bandmanager.domain.setlist.dto.res.SetlistResponse
+import com.bandage.bandmanager.domain.setlist.repository.SetlistTrackParticipantRepository
+import com.bandage.bandmanager.domain.setlist.repository.SetlistTrackRepository
+import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
+import com.bandage.bandmanager.global.notify.resolver.NotificationPayload
+import com.bandage.bandmanager.global.notify.resolver.NotifyPayloadResolver
+import org.springframework.stereotype.Component
+
+/**
+ * SETLIST_CREATED: 셋리스트가 생성되면 트랙 참여자(세션 확정자) 전원에게 알림.
+ * 트리거: SetlistCreateFacade.createSetlist(memberId: Long, request: SetlistCreateRequest): SetlistResponse
+ *
+ * 생성 결과 setlistId/이름은 반환값(SetlistResponse)에서 얻고, 수신자는 저장된 트랙 참여자로부터 조회한다.
+ */
+@Component
+class SetlistCreatedResolver(
+    private val setlistTrackRepository: SetlistTrackRepository,
+    private val setlistTrackParticipantRepository: SetlistTrackParticipantRepository,
+) : NotifyPayloadResolver {
+    override val category = NotifyCategory.SETLIST_CREATED
+
+    override fun resolve(
+        args: Array<Any?>,
+        returnValue: Any?,
+    ): List<NotificationPayload> {
+        val response = returnValue as? SetlistResponse ?: return emptyList()
+
+        val tracks = setlistTrackRepository.findAllBySetlistIdIn(listOf(response.setlistId))
+        if (tracks.isEmpty()) return emptyList()
+
+        return setlistTrackParticipantRepository
+            .findAllByTrackIn(tracks)
+            .map { it.memberId }
+            .distinct()
+            .map { memberId ->
+                NotificationPayload(
+                    recipientId = memberId,
+                    category = category,
+                    title = "셋리스트 생성",
+                    message = "'${response.title}' 셋리스트가 생성되었습니다.",
+                    referenceId = response.setlistId.toString(),
+                )
+            }
+    }
+}

--- a/src/main/kotlin/com/bandage/bandmanager/facade/JamCreateFromSetlistFacade.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/facade/JamCreateFromSetlistFacade.kt
@@ -8,6 +8,8 @@ import com.bandage.bandmanager.domain.setlist.repository.SetlistTrackParticipant
 import com.bandage.bandmanager.domain.setlist.repository.SetlistTrackRepository
 import com.bandage.bandmanager.global.error.errorcode.ErrorCode
 import com.bandage.bandmanager.global.error.exception.BusinessException
+import com.bandage.bandmanager.global.notify.annotation.Notify
+import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -25,6 +27,7 @@ class JamCreateFromSetlistFacade(
     private val setlistTrackParticipantRepository: SetlistTrackParticipantRepository,
     private val setlistTrackToJamConverter: SetlistTrackToJamConverter,
 ) {
+    @Notify(NotifyCategory.JAM_CREATED)
     @Transactional
     fun createJamsFromSetlist(
         memberId: Long,

--- a/src/main/kotlin/com/bandage/bandmanager/facade/SetlistCreateFacade.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/facade/SetlistCreateFacade.kt
@@ -17,6 +17,8 @@ import com.bandage.bandmanager.domain.setlist.repository.SetlistTrackRepository
 import com.bandage.bandmanager.global.common.domain.TrackInfo
 import com.bandage.bandmanager.global.error.errorcode.ErrorCode
 import com.bandage.bandmanager.global.error.exception.BusinessException
+import com.bandage.bandmanager.global.notify.annotation.Notify
+import com.bandage.bandmanager.global.notify.annotation.NotifyCategory
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -32,6 +34,7 @@ class SetlistCreateFacade(
     private val setlistTrackRepository: SetlistTrackRepository,
     private val setlistTrackParticipantRepository: SetlistTrackParticipantRepository,
 ) {
+    @Notify(NotifyCategory.SETLIST_CREATED)
     @Transactional
     fun createSetlist(
         memberId: Long,

--- a/src/main/kotlin/com/bandage/bandmanager/global/notify/annotation/NotifyCategory.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/global/notify/annotation/NotifyCategory.kt
@@ -11,4 +11,11 @@ enum class NotifyCategory {
     BAND_APPLICATION_RESULT, // 신청 승인/거절 결과 → 신청자에게
     AUTHORITY_PROMOTION, // 권한 승격(리더 승격 등) → 승격된 멤버에게
     JAM_UPCOMING, // 임박한 합주 → 참여자에게
+    JAM_PARTICIPANT_ADDED, // 합주 참여자 추가 → 추가된 참여자에게
+    JAM_CREATED, // 셋리스트 기반 합주 생성 → 생성된 합주 참여자들에게
+    PERFORMANCE_UPCOMING, // 임박한 공연 → 공연 참여자(매니저)들에게
+    PERFORMANCE_MANAGER_INVITED, // 공연 매니저 초대 → 초대받은 멤버에게
+    PERFORMANCE_OWNER_PROMOTED, // 공연 소유자 승격 → 새 소유자에게
+    SELECTION_PARTICIPANT_ADDED, // 선곡회의 참여자 추가 → 추가된 참여자에게
+    SETLIST_CREATED, // 셋리스트 생성 → 셋리스트 참여자들에게
 }


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #196 #197 #198 #199 #200 #201 #202

📌 **작업 내용 및 특이사항**

기존 알림 인프라(`@Notify` AOP + `NotifyPayloadResolver`, 스케줄러 직접 발행)를 활용해 BD-196~202 하위 이슈의 시스템 알림을 구현했습니다. Notion "Band Manager 시스템 알림 명세" 기준으로 수신자/메시지를 맞췄습니다.

| 이슈 | 알림 | 트리거 | 수신자 |
|---|---|---|---|
| BD-196 | 합주 참여자 추가 | `JamService.addParticipant` | 추가된 참여자 (합주당 1회 멱등) |
| BD-197 | 임박한 공연 (1일 전) | `PerformanceReminderScheduler` (신규) | 공연 매니저 전원 (멱등) |
| BD-198 | 공연 매니저 초대 | `PerformanceService.sendInvitation` | 피초대자 |
| BD-199 | 공연 소유자 승격 | `PerformanceService.delegateOwnership` | 새 소유자 |
| BD-200 | 선곡회의 참여자 추가 | `TrackSelectionService.updateParticipants` | 추가된 참여자들 |
| BD-201 | 셋리스트 생성 | `SetlistCreateFacade.createSetlist` | 트랙 참여자 전원 |
| BD-202 | 합주 생성 안내 | `JamCreateFromSetlistFacade.createJamsFromSetlist` | 생성 합주 참여자 전원 (참여자당 'N건' 요약 1건) |

**구현 방식**
- 대부분 `@Notify(category)` + 도메인 `notify/` 하위 `NotifyPayloadResolver` 추가 (기존 밴드 알림과 동일 패턴).
- BD-197은 AOP 경로가 아니므로 `JamReminderScheduler`를 본떠 스케줄러에서 `NotificationCreateEvent`를 직접 발행. `existsByRecipientIdAndCategoryAndReferenceId` 멱등성 체크로 재실행 중복 방지.
- BD-196도 세션 배정마다 `addParticipant`가 호출되는 특성상 멱등성 체크로 합주당 1회만 발송.
- `NotifyCategory` enum에 7개 카테고리 추가 → `NotificationResponse`에 노출되므로 `docs/openapi.json` 동기화 커밋 포함.

**특이사항 / 확인 필요**
- BD-199 '승격' 해석: 명세 Q&A("매니저 → 소유자로 변경")에 따라 `delegateOwnership`(소유권 양도)를 트리거로 잡았습니다. 초대 수락(`respondInvitation`)으로 매니저가 되는 경로는 BD-198 초대 알림과 중복이라 제외했습니다.
- BD-202 메시지는 명세대로 "N건의 합주가 생성되었습니다"(N=생성 합주 수) 요약 1건 방식입니다.

📚 **참고사항**
- 기존 커밋(BD-210·212·215 등)에 이어 알림 도메인 확장 작업입니다.
- 각 하위 이슈는 개별 커밋(`[BD-196]`~`[BD-202]`)으로 분리되어 있습니다.

✅ **체크리스트**
- [x] API(Controller/DTO)를 변경한 경우 `docs/openapi.json`을 갱신했습니다 (코드-스펙 동일 PR 규약)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BD-196]: https://sunwoo1137.atlassian.net/browse/BD-196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ