### PR TITLE
Refactor: BandApplication 최신 상태 판별 로직 수정

### DIFF
--- a/src/main/kotlin/com/bandage/bandmanager/domain/band/repository/BandApplicationRepository.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/band/repository/BandApplicationRepository.kt
@@ -19,17 +19,6 @@ interface BandApplicationRepository :
         status: ApplicationStatus,
     ): Boolean
 
-    fun findByBandAndMemberAndStatus(
-        band: Band,
-        member: Long,
-        status: ApplicationStatus,
-    ): BandApplication?
-
-    fun findByIdAndStatus(
-        id: UUID,
-        status: ApplicationStatus,
-    ): BandApplication?
-
     /** 회원의 특정 밴드에 대한 최신 가입 신청 단건. (band, member) 당 isLatest=true 는 유일하다. */
     fun findByBandAndMemberAndIsLatestTrue(
         band: Band,

--- a/src/main/kotlin/com/bandage/bandmanager/domain/band/service/BandService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/band/service/BandService.kt
@@ -242,7 +242,10 @@ class BandService(
 
         when (status) {
             ApplicationStatus.APPROVED -> approve(band, application, memberId)
-            ApplicationStatus.REJECTED -> application.updateStatus(ApplicationStatus.REJECTED)
+            ApplicationStatus.REJECTED -> {
+                application.updateStatus(ApplicationStatus.REJECTED)
+                application.markProcessedBy(memberId)
+            }
             else -> throw BusinessException(ErrorCode.INVALID_INPUT_VALUE)
         }
     }

--- a/src/main/kotlin/com/bandage/bandmanager/domain/band/service/BandService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/band/service/BandService.kt
@@ -458,15 +458,21 @@ class BandService(
         bandRepository.findByIdOrNull(bandId)
             ?: throw BusinessException(ErrorCode.BAND_NOT_FOUND)
 
+    // BD-210: '현재 유효한 신청'은 isLatest=true 인 건으로 판단한다. status 로만 조회하면 재신청으로 밀려난
+    // 과거 레코드(isLatest=false)를 잘못 집어 처리할 수 있으므로, 최신 건을 찾은 뒤 상태를 확인한다.
     private fun getPendingBandApplicationById(bandApplicationId: UUID): BandApplication =
-        applicationRepository.findByIdAndStatus(bandApplicationId, ApplicationStatus.PENDING)
+        applicationRepository
+            .findByIdOrNull(bandApplicationId)
+            ?.takeIf { it.isLatest && it.status == ApplicationStatus.PENDING }
             ?: throw BusinessException(ErrorCode.BAND_APPLICATION_NOT_FOUND)
 
     private fun getPendingBandApplicationByMember(
         band: Band,
         member: Long,
     ): BandApplication =
-        applicationRepository.findByBandAndMemberAndStatus(band, member, ApplicationStatus.PENDING)
+        applicationRepository
+            .findByBandAndMemberAndIsLatestTrue(band, member)
+            ?.takeIf { it.status == ApplicationStatus.PENDING }
             ?: throw BusinessException(ErrorCode.UNABLE_TO_WITHDRAW)
 
     private fun getBandMemberById(bandMemberId: UUID): BandMember =
@@ -560,8 +566,11 @@ class BandService(
         band: Band,
         memberId: Long,
     ) {
-        val application = applicationRepository.findByBandAndMemberAndStatus(band, memberId, ApplicationStatus.APPROVED)
-        application?.updateStatus(ApplicationStatus.LEAVED)
+        // BD-210: 소속 중인 신청(APPROVED)은 최신 건이어야 한다. 최신 건을 찾아 APPROVED 일 때만 LEAVED 로 전환한다.
+        applicationRepository
+            .findByBandAndMemberAndIsLatestTrue(band, memberId)
+            ?.takeIf { it.status == ApplicationStatus.APPROVED }
+            ?.updateStatus(ApplicationStatus.LEAVED)
         bandMember.markAsDeleted(memberId)
     }
 }


### PR DESCRIPTION
## 🛠️ Issue Number
### done #BD-21-

📌 **작업 내용 및 특이사항**
### 기존 이슈

1. 처리 흐름(승인/거절/철회/LEAVED)이 isLatest를 전혀 갱신하지 않음. isLatest=false로 만드는 유일한 경로는 재신청 시 markAsOutdated() 에만 적용.
2. 승인 처리 시, 리더 목록이 outdated PENDING을 노출 → 리더가 그 id로 승인 요청 → findByIdAndStatus(PENDING)가 isLatest 검증 없이 통과 → approve가 isLatest=false인 건을 APPROVED로 전환. 

### 해결
status 기준으로만 최신 상태 판별하던 상태 전이 로직에 isLatest기반 신규 판별 로직 적용

위치 | Before | After
-- | -- | --
getPendingBandApplicationById (승인/거절) | findByIdAndStatus(PENDING) | findByIdOrNull → isLatest && PENDING 확인
getPendingBandApplicationByMember (철회) | findByBandAndMemberAndStatus(PENDING) | findByBandAndMemberAndIsLatestTrue → PENDING 확인
processBandMemberStatusAsLeaved (탈퇴 LEAVED) | findByBandAndMemberAndStatus(APPROVED) | findByBandAndMemberAndIsLatestTrue → APPROVED 확인


📚 **참고사항**
- 기존 누락되었던 REJECTED 처리 시 processedBy 컬럼 업데이트 로직 추가

✅ **체크리스트**
- [ ] API(Controller/DTO)를 변경한 경우 `docs/openapi.json`을 갱신했습니다 (코드-스펙 동일 PR 규약)
