### PR TITLE
[BD-181] feat: 내 합주/공연 목록 조회에 기간(from~to) 필터 추가

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2800,6 +2800,12 @@
             "JamPagingQuery": {
                 "description": "\ud569\uc8fc \ubaa9\ub85d \uc870\ud68c \ucffc\ub9ac",
                 "properties": {
+                    "from": {
+                        "description": "\uc870\ud68c \uc2dc\uc791\uc77c (\ubbf8\uc9c0\uc815 \uc2dc \uc81c\ud55c \uc5c6\uc74c)",
+                        "example": "2026-07-01",
+                        "format": "date",
+                        "type": "string"
+                    },
                     "lastId": {
                         "description": "\ub9c8\uc9c0\ub9c9\uc73c\ub85c \uc870\ud68c\ub41c \ud569\uc8fc ID (\ucee4\uc11c)",
                         "example": "550e8400-e29b-41d4-a716-446655440000",
@@ -2813,6 +2819,12 @@
                         "maximum": 100,
                         "minimum": 1,
                         "type": "integer"
+                    },
+                    "to": {
+                        "description": "\uc870\ud68c \uc885\ub8cc\uc77c (\ubbf8\uc9c0\uc815 \uc2dc \uc81c\ud55c \uc5c6\uc74c)",
+                        "example": "2026-07-31",
+                        "format": "date",
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -4147,6 +4159,12 @@
             "PerformancePagingQuery": {
                 "description": "\uacf5\uc5f0 \ubaa9\ub85d \uc870\ud68c \ucffc\ub9ac",
                 "properties": {
+                    "from": {
+                        "description": "\uc870\ud68c \uc2dc\uc791\uc77c (\ubbf8\uc9c0\uc815 \uc2dc \uc81c\ud55c \uc5c6\uc74c)",
+                        "example": "2026-07-01",
+                        "format": "date",
+                        "type": "string"
+                    },
                     "lastId": {
                         "description": "\ub9c8\uc9c0\ub9c9\uc73c\ub85c \uc870\ud68c\ub41c \uacf5\uc5f0 ID (\ucee4\uc11c)",
                         "example": "550e8400-e29b-41d4-a716-446655440000",
@@ -4160,6 +4178,12 @@
                         "maximum": 100,
                         "minimum": 1,
                         "type": "integer"
+                    },
+                    "to": {
+                        "description": "\uc870\ud68c \uc885\ub8cc\uc77c (\ubbf8\uc9c0\uc815 \uc2dc \uc81c\ud55c \uc5c6\uc74c)",
+                        "example": "2026-07-31",
+                        "format": "date",
+                        "type": "string"
                     }
                 },
                 "required": [

--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/dto/req/JamPagingQuery.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/dto/req/JamPagingQuery.kt
@@ -3,6 +3,7 @@ package com.bandage.bandmanager.domain.jam.dto.req
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
+import java.time.LocalDate
 import java.util.UUID
 
 @Schema(description = "합주 목록 조회 쿼리")
@@ -13,4 +14,8 @@ data class JamPagingQuery(
     @field:Max(100)
     @Schema(description = "페이지 크기", example = "10")
     val pageSize: Int = 10,
+    @Schema(description = "조회 시작일 (미지정 시 제한 없음)", example = "2026-07-01")
+    val from: LocalDate? = null,
+    @Schema(description = "조회 종료일 (미지정 시 제한 없음)", example = "2026-07-31")
+    val to: LocalDate? = null,
 )

--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/repository/JamRepositoryCustom.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/repository/JamRepositoryCustom.kt
@@ -2,6 +2,7 @@ package com.bandage.bandmanager.domain.jam.repository
 
 import com.bandage.bandmanager.domain.jam.model.Jam
 import com.bandage.bandmanager.global.common.response.CursorResponse
+import java.time.LocalDate
 import java.util.UUID
 
 interface JamRepositoryCustom {
@@ -20,6 +21,8 @@ interface JamRepositoryCustom {
         memberId: Long,
         lastId: UUID?,
         pageSize: Int,
+        from: LocalDate? = null,
+        to: LocalDate? = null,
     ): CursorResponse<Jam, UUID>
 
     fun searchByMemberAndKeywordAndPaging(

--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/repository/JamRepositoryImpl.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/repository/JamRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.bandage.bandmanager.domain.jam.model.QJamParticipant
 import com.bandage.bandmanager.global.common.response.CursorResponse
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
+import java.time.LocalDate
 import java.util.UUID
 
 class JamRepositoryImpl(
@@ -71,6 +72,8 @@ class JamRepositoryImpl(
         memberId: Long,
         lastId: UUID?,
         pageSize: Int,
+        from: LocalDate?,
+        to: LocalDate?,
     ): CursorResponse<Jam, UUID> {
         val qJam = QJam.jam
         val qParticipant = QJamParticipant.jamParticipant
@@ -82,6 +85,8 @@ class JamRepositoryImpl(
                 .on(qParticipant.jam.eq(qJam))
                 .where(qParticipant.member.eq(memberId))
                 .where(ltJamId(lastId))
+                .where(goeStartAt(from))
+                .where(ltStartAt(to))
                 .orderBy(qJam.id.desc())
                 .distinct()
                 .limit(pageSize.toLong() + 1)
@@ -132,4 +137,16 @@ class JamRepositoryImpl(
     }
 
     private fun ltJamId(lastId: UUID?): BooleanExpression? = lastId?.let { QJam.jam.id.lt(it) }
+
+    private fun goeStartAt(from: LocalDate?): BooleanExpression? =
+        from?.let {
+            QJam.jam.timeInfo.startAt
+                .goe(it.atStartOfDay())
+        }
+
+    private fun ltStartAt(to: LocalDate?): BooleanExpression? =
+        to?.let {
+            QJam.jam.timeInfo.startAt
+                .lt(it.plusDays(1).atStartOfDay())
+        }
 }

--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/service/JamService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/service/JamService.kt
@@ -93,7 +93,7 @@ class JamService(
         memberId: Long,
         query: JamPagingQuery,
     ): CursorResponse<JamListResponse, UUID> {
-        val result = jamRepository.findAllByMemberAndPaging(memberId, query.lastId, query.pageSize)
+        val result = jamRepository.findAllByMemberAndPaging(memberId, query.lastId, query.pageSize, query.from, query.to)
         return CursorResponse(
             content = result.content.map { JamListResponse.of(it) },
             nextCursor = result.nextCursor,

--- a/src/main/kotlin/com/bandage/bandmanager/domain/performance/dto/req/PerformancePagingQuery.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/performance/dto/req/PerformancePagingQuery.kt
@@ -3,6 +3,7 @@ package com.bandage.bandmanager.domain.performance.dto.req
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
+import java.time.LocalDate
 import java.util.UUID
 
 @Schema(description = "공연 목록 조회 쿼리")
@@ -13,4 +14,8 @@ data class PerformancePagingQuery(
     @field:Max(100)
     @Schema(description = "페이지 크기", example = "10")
     val pageSize: Int = 10,
+    @Schema(description = "조회 시작일 (미지정 시 제한 없음)", example = "2026-07-01")
+    val from: LocalDate? = null,
+    @Schema(description = "조회 종료일 (미지정 시 제한 없음)", example = "2026-07-31")
+    val to: LocalDate? = null,
 )

--- a/src/main/kotlin/com/bandage/bandmanager/domain/performance/repository/PerformanceRepositoryCustom.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/performance/repository/PerformanceRepositoryCustom.kt
@@ -2,6 +2,7 @@ package com.bandage.bandmanager.domain.performance.repository
 
 import com.bandage.bandmanager.domain.performance.model.Performance
 import com.bandage.bandmanager.global.common.response.CursorResponse
+import java.time.LocalDate
 import java.util.UUID
 
 interface PerformanceRepositoryCustom {
@@ -21,6 +22,8 @@ interface PerformanceRepositoryCustom {
         bandIds: List<UUID>,
         lastId: UUID?,
         pageSize: Int,
+        from: LocalDate? = null,
+        to: LocalDate? = null,
     ): CursorResponse<Performance, UUID>
 
     fun searchByTitleAndPaging(

--- a/src/main/kotlin/com/bandage/bandmanager/domain/performance/repository/PerformanceRepositoryImpl.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/performance/repository/PerformanceRepositoryImpl.kt
@@ -9,6 +9,7 @@ import com.bandage.bandmanager.global.common.response.CursorResponse
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.JPAExpressions
 import com.querydsl.jpa.impl.JPAQueryFactory
+import java.time.LocalDate
 import java.util.UUID
 
 class PerformanceRepositoryImpl(
@@ -62,6 +63,8 @@ class PerformanceRepositoryImpl(
         bandIds: List<UUID>,
         lastId: UUID?,
         pageSize: Int,
+        from: LocalDate?,
+        to: LocalDate?,
     ): CursorResponse<Performance, UUID> {
         val qPerformance = QPerformance.performance
         val qPerformanceSetlist = QPerformanceSetlist.performanceSetlist
@@ -93,6 +96,8 @@ class PerformanceRepositoryImpl(
                 .selectFrom(qPerformance)
                 .where(condition)
                 .where(ltPerformanceId(lastId))
+                .where(goeStartAt(from))
+                .where(ltStartAt(to))
                 .orderBy(qPerformance.id.desc())
                 .limit(pageSize.toLong() + 1)
                 .fetch()
@@ -130,4 +135,16 @@ class PerformanceRepositoryImpl(
     }
 
     private fun ltPerformanceId(lastId: UUID?): BooleanExpression? = lastId?.let { QPerformance.performance.id.lt(it) }
+
+    private fun goeStartAt(from: LocalDate?): BooleanExpression? =
+        from?.let {
+            QPerformance.performance.timeInfo.startAt
+                .goe(it.atStartOfDay())
+        }
+
+    private fun ltStartAt(to: LocalDate?): BooleanExpression? =
+        to?.let {
+            QPerformance.performance.timeInfo.startAt
+                .lt(it.plusDays(1).atStartOfDay())
+        }
 }

--- a/src/main/kotlin/com/bandage/bandmanager/domain/performance/service/PerformanceService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/performance/service/PerformanceService.kt
@@ -112,7 +112,8 @@ class PerformanceService(
         query: PerformancePagingQuery,
     ): CursorResponse<PerformanceListResponse, UUID> {
         val bandIds = bandMemberRepository.findAllBandIdsByMember(memberId)
-        val result = performanceRepository.findMyPerformancesByCursor(memberId, bandIds, query.lastId, query.pageSize)
+        val result =
+            performanceRepository.findMyPerformancesByCursor(memberId, bandIds, query.lastId, query.pageSize, query.from, query.to)
         val summaries = buildSetlistSummaries(result.content.flatMap { p -> p.setlists.map { it.setlistId } })
         return CursorResponse(
             content = result.content.map { PerformanceListResponse.of(it, summaries) },


### PR DESCRIPTION
## 🛠️ Issue Number
### closes BD-181

📌 **작업 내용 및 특이사항**
- MemberAvailability의 from~to 기간 조회와 동일한 방식으로, "내 합주"/"내 공연" 목록 조회에 기간 필터를 추가했습니다. 회원의 전체 가용 시간(가용성 + 예정된 합주/공연)을 한 화면에서 파악할 수 있도록 하기 위한 선행 작업입니다.
- `JamPagingQuery`, `PerformancePagingQuery`에 `from`/`to`(LocalDate, optional) 필드를 추가했습니다.
- 필터는 `GET /jams/me`, `GET /performances/me` 두 API에만 적용됩니다. 전체 목록(`GET /jams`, `GET /performances`)은 동일 DTO를 공유하지만 이번 변경으로 동작이 바뀌지 않습니다.
- 필터 기준은 합주/공연의 시작 시각(`timeInfo.startAt`)이 `[from 00:00, to+1일 00:00)` 범위에 포함되는지입니다. 소요 시간(durationMinutes)까지 반영한 정확한 구간 겹침 판정은 QueryDSL에 날짜 산술 연산자가 없어 네이티브 SQL 템플릿이 필요한데, 실사용 시나리오(합주/공연은 보통 자정을 넘기지 않음)를 고려해 시작 시각 기준 단순 필터로 구현했습니다.
- `from`, `to` 모두 optional이라 하나만 지정하거나 둘 다 생략할 수 있습니다(기존 동작과 동일).

📚 **참고사항**
- 시작 시각 기준 필터의 한계: 자정을 넘겨 진행되는 일정이 있는 경우 경계에서 근소한 오차가 발생할 수 있습니다. 추후 정밀한 겹침 판정이 필요해지면 `Expressions.dateTimeTemplate`로 DB interval 연산을 추가하는 방향을 고려할 수 있습니다.

✅ **체크리스트**
- [x] API(Controller/DTO)를 변경한 경우 `docs/openapi.json`을 갱신했습니다 (코드-스펙 동일 PR 규약)