### PR TITLE
[BD-221] feat: 가용성 기간별 규칙/예외 조회 API 추가

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -6954,6 +6954,48 @@
                 ]
             }
         },
+        "/api/v1/me/availability/period": {
+            "get": {
+                "description": "\uc870\ud68c \uae30\uac04(from~to, \ucd5c\ub300 366\uc77c)\uacfc \uacb9\uce58\ub294 \uc8fc\uac04 \uaddc\uce59/\uc608\uc678 \uc6d0\ubcf8\uc744 \ubc18\ud658. \ubbf8\ub4f1\ub85d \uc2dc \ube48 \uc751\ub2f5.",
+                "operationId": "getMyAvailabilityByPeriod",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "from",
+                        "required": true,
+                        "schema": {
+                            "format": "date",
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "to",
+                        "required": true,
+                        "schema": {
+                            "format": "date",
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiResponseMemberAvailabilityResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    }
+                },
+                "summary": "\ub0b4 \uac00\uc6a9\uc131 \uae30\uac04\ubcc4 \uc870\ud68c",
+                "tags": [
+                    "member-availability"
+                ]
+            }
+        },
         "/api/v1/me/availability/slots": {
             "get": {
                 "description": "\uc870\ud68c \uae30\uac04(from~to, \ucd5c\ub300 366\uc77c)\uc5d0 \uc18d\ud55c \uac00\uc6a9 \uc2ac\ub86f\uc744 \ub0a0\uc9dc\ubcc4\ub85c \uc804\uac1c\ud574 \ubc18\ud658. \ud074\ub77c\uc774\uc5b8\ud2b8 \ucd94\uac00 \uacc4\uc0b0 \ubd88\ud544\uc694.",

--- a/src/main/kotlin/com/bandage/bandmanager/domain/availability/controller/MemberAvailabilityController.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/availability/controller/MemberAvailabilityController.kt
@@ -43,6 +43,19 @@ class MemberAvailabilityController(
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
     ): ApiResponse<List<ScheduleSlotResponse>> = ApiResponse.success(memberAvailabilityService.getMySlots(memberId, from, to))
 
+    @GetMapping("/period")
+    @Operation(
+        operationId = "getMyAvailabilityByPeriod",
+        summary = "내 가용성 기간별 조회",
+        description = "조회 기간(from~to, 최대 366일)과 겹치는 주간 규칙/예외 원본을 반환. 미등록 시 빈 응답.",
+    )
+    fun getMyAvailabilityByPeriod(
+        @CurrentMemberId memberId: Long,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
+    ): ApiResponse<MemberAvailabilityResponse> =
+        ApiResponse.success(memberAvailabilityService.getMyAvailabilityByPeriod(memberId, from, to))
+
     @PutMapping
     @Operation(
         operationId = "updateMyAvailability",

--- a/src/main/kotlin/com/bandage/bandmanager/domain/availability/dto/res/MemberAvailabilityResponse.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/availability/dto/res/MemberAvailabilityResponse.kt
@@ -17,10 +17,18 @@ data class MemberAvailabilityResponse(
 ) {
     companion object {
         fun from(availability: MemberAvailability): MemberAvailabilityResponse =
+            from(availability, availability.weeklyRules, availability.exceptions)
+
+        /** 기간 필터링 등으로 선별한 규칙/예외만 담아 응답한다(memberId/note/updatedAt 는 원본 유지). */
+        fun from(
+            availability: MemberAvailability,
+            weeklyRules: List<WeeklyRule>,
+            exceptions: List<AvailabilityException>,
+        ): MemberAvailabilityResponse =
             MemberAvailabilityResponse(
                 memberId = availability.memberId,
-                weeklyRules = availability.weeklyRules.map { WeeklyRuleResponse.from(it) },
-                exceptions = availability.exceptions.map { AvailabilityExceptionResponse.from(it) },
+                weeklyRules = weeklyRules.map { WeeklyRuleResponse.from(it) },
+                exceptions = exceptions.map { AvailabilityExceptionResponse.from(it) },
                 note = availability.note,
                 updatedAt = availability.lastModifiedAt,
             )

--- a/src/main/kotlin/com/bandage/bandmanager/domain/availability/model/WeeklyRule.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/availability/model/WeeklyRule.kt
@@ -60,6 +60,16 @@ open class WeeklyRule(
         return date.dayOfWeek == dayOfWeek
     }
 
+    /** 이 규칙의 유효 기간이 조회 구간 [from, to] 와 겹치는지 여부. effectiveTo == null 이면 무기한. */
+    fun overlapsPeriod(
+        from: LocalDate,
+        to: LocalDate,
+    ): Boolean {
+        if (effectiveFrom.isAfter(to)) return false
+        val end = effectiveTo ?: return true
+        return !end.isBefore(from)
+    }
+
     companion object {
         const val SLOTS_PER_DAY: Int = 48
     }

--- a/src/main/kotlin/com/bandage/bandmanager/domain/availability/service/MemberAvailabilityService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/availability/service/MemberAvailabilityService.kt
@@ -63,6 +63,30 @@ class MemberAvailabilityService(
         return slots
     }
 
+    /**
+     * 조회 기간 [from, to] 와 겹치는 주간 규칙/예외 원본을 그대로 반환한다.
+     * 슬롯 전개(getMySlots)와 달리 규칙/예외 자체가 필요한 화면(편집 등)을 위한 조회다.
+     * - 주간 규칙: 유효 기간이 [from, to] 와 겹치면 포함
+     * - 예외: date 가 [from, to] 안이면 포함
+     * 미등록 멤버는 빈 응답. 최대 366일까지 조회 가능.
+     */
+    fun getMyAvailabilityByPeriod(
+        memberId: Long,
+        from: LocalDate,
+        to: LocalDate,
+    ): MemberAvailabilityResponse {
+        if (from.isAfter(to) || ChronoUnit.DAYS.between(from, to) > MAX_RANGE_DAYS) {
+            throw BusinessException(ErrorCode.AVAILABILITY_RANGE_INVALID)
+        }
+        val availability =
+            memberAvailabilityRepository.findByMemberId(memberId)
+                ?: return MemberAvailabilityResponse.empty(memberId)
+
+        val rules = availability.weeklyRules.filter { it.overlapsPeriod(from, to) }
+        val exceptions = availability.exceptions.filter { !it.date.isBefore(from) && !it.date.isAfter(to) }
+        return MemberAvailabilityResponse.from(availability, rules, exceptions)
+    }
+
     private fun slotOf(
         date: LocalDate,
         startSlot: Int,

--- a/src/test/kotlin/com/bandage/bandmanager/domain/availability/service/MemberAvailabilityByPeriodTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/availability/service/MemberAvailabilityByPeriodTest.kt
@@ -1,0 +1,88 @@
+package com.bandage.bandmanager.domain.availability.service
+
+import com.bandage.bandmanager.domain.availability.model.AvailabilityException
+import com.bandage.bandmanager.domain.availability.model.AvailabilityKind
+import com.bandage.bandmanager.domain.availability.model.MemberAvailability
+import com.bandage.bandmanager.domain.availability.model.WeeklyRule
+import com.bandage.bandmanager.domain.availability.repository.MemberAvailabilityRepository
+import com.bandage.bandmanager.global.error.exception.BusinessException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.time.LocalDate
+
+class MemberAvailabilityByPeriodTest {
+    private val repository = mock(MemberAvailabilityRepository::class.java)
+    private val sut = MemberAvailabilityService(repository)
+
+    private val mon = LocalDate.of(2026, 6, 1)
+
+    private fun availability(
+        rules: List<WeeklyRule> = emptyList(),
+        exceptions: List<AvailabilityException> = emptyList(),
+    ): MemberAvailability =
+        MemberAvailability.create(1L).apply {
+            updateWeeklyRules(rules)
+            updateExceptions(exceptions)
+        }
+
+    @Test
+    fun `조회 구간과 겹치는 규칙만 반환한다`() {
+        val inRange = WeeklyRule(mon.dayOfWeek, 20, 44, effectiveFrom = mon, effectiveTo = mon.plusDays(10))
+        // 조회 구간(mon ~ mon+7) 이후에만 유효 → 제외
+        val outOfRange = WeeklyRule(mon.dayOfWeek, 20, 44, effectiveFrom = mon.plusDays(30), effectiveTo = mon.plusDays(40))
+        `when`(repository.findByMemberId(1L)).thenReturn(availability(rules = listOf(inRange, outOfRange)))
+
+        val result = sut.getMyAvailabilityByPeriod(1L, mon, mon.plusDays(7))
+
+        assertThat(result.weeklyRules).hasSize(1)
+        assertThat(result.weeklyRules.first().effectiveFrom).isEqualTo(mon)
+    }
+
+    @Test
+    fun `무기한(effectiveTo == null) 규칙은 구간 시작 이전부터여도 포함된다`() {
+        val openEnded = WeeklyRule(mon.dayOfWeek, 20, 44, effectiveFrom = mon.minusDays(100), effectiveTo = null)
+        `when`(repository.findByMemberId(1L)).thenReturn(availability(rules = listOf(openEnded)))
+
+        val result = sut.getMyAvailabilityByPeriod(1L, mon, mon.plusDays(7))
+
+        assertThat(result.weeklyRules).hasSize(1)
+    }
+
+    @Test
+    fun `조회 구간 안의 예외만 반환한다`() {
+        val inRange = AvailabilityException(mon.plusDays(2), AvailabilityKind.BLOCKED)
+        val outOfRange = AvailabilityException(mon.plusDays(20), AvailabilityKind.BLOCKED)
+        `when`(repository.findByMemberId(1L)).thenReturn(availability(exceptions = listOf(inRange, outOfRange)))
+
+        val result = sut.getMyAvailabilityByPeriod(1L, mon, mon.plusDays(7))
+
+        assertThat(result.exceptions).hasSize(1)
+        assertThat(result.exceptions.first().date).isEqualTo(mon.plusDays(2))
+    }
+
+    @Test
+    fun `미등록 멤버는 빈 응답`() {
+        `when`(repository.findByMemberId(1L)).thenReturn(null)
+
+        val result = sut.getMyAvailabilityByPeriod(1L, mon, mon.plusDays(7))
+
+        assertThat(result.memberId).isEqualTo(1L)
+        assertThat(result.weeklyRules).isEmpty()
+        assertThat(result.exceptions).isEmpty()
+    }
+
+    @Test
+    fun `from 이 to 보다 늦으면 예외`() {
+        assertThatThrownBy { sut.getMyAvailabilityByPeriod(1L, mon, mon.minusDays(1)) }
+            .isInstanceOf(BusinessException::class.java)
+    }
+
+    @Test
+    fun `366일을 초과하면 예외`() {
+        assertThatThrownBy { sut.getMyAvailabilityByPeriod(1L, mon, mon.plusDays(400)) }
+            .isInstanceOf(BusinessException::class.java)
+    }
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes # BD-221

📌 **작업 내용 및 특이사항**

특정 기간에 대한 일정 조회 시, 그 기간에 해당하는 주간 규칙(WeeklyRule)과 예외(AvailabilityException) 원본을 함께 조회하는 API를 추가했습니다. 기존 `MemberAvailability`의 슬롯 조회(`/slots`)와 동일한 `from`/`to` 기간 파라미터 구조를 따릅니다.

- **`GET /me/availability/period`** 신규 엔드포인트 — `from`~`to`(ISO date, 최대 366일)와 겹치는 규칙/예외 원본 반환. 미등록 시 빈 응답.
  - 주간 규칙: 유효 기간(`effectiveFrom`~`effectiveTo`, `null`이면 무기한)이 조회 구간과 겹치면 포함
  - 예외: `date`가 조회 구간 내면 포함
- `WeeklyRule.overlapsPeriod(from, to)` 기간 겹침 판정 헬퍼 추가
- `MemberAvailabilityService.getMyAvailabilityByPeriod()` 구현 — 범위 검증/최대 366일 규칙은 기존 `/slots`와 동일
- `MemberAvailabilityResponse.from()` 오버로드 추가 — 필터링된 규칙/예외만 담아 응답(memberId/note/updatedAt은 원본 유지)

기존 슬롯 조회(`/slots`)는 규칙/예외를 날짜별 슬롯으로 **전개**해 반환하지만, 이 API는 편집 화면 등을 위해 **규칙/예외 원본**을 그대로 반환한다는 점이 차이입니다.

📚 **참고사항**

- `MemberAvailabilityByPeriodTest` 신규 테스트 6개 (구간 겹침/무기한 규칙 포함/예외 필터/미등록/범위 검증)
- 순수 additive 변경으로 breaking change 없음

✅ **체크리스트**
- [x] API(Controller/DTO)를 변경한 경우 `docs/openapi.json`을 갱신했습니다 (코드-스펙 동일 PR 규약)

🤖 Generated with [Claude Code](https://claude.com/claude-code)