### PR TITLE
[BD-224] feat: 셋리스트 삭제 API 추가

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -8210,6 +8210,37 @@
             }
         },
         "/api/v1/setlists/{setlistId}": {
+            "delete": {
+                "description": "\ub9e4\ub2c8\uc800\uac00 \uc14b\ub9ac\uc2a4\ud2b8\ub97c \uc0ad\uc81c\ud569\ub2c8\ub2e4. \uc14b\ub9ac\uc2a4\ud2b8\uc758 \ud2b8\ub799\u00b7\ucc38\uc5ec\uc790\u00b7\ubc34\ub4dc \uc5f0\uacb0\ub3c4 \ud568\uaed8 \uc815\ub9ac\ub429\ub2c8\ub2e4.",
+                "operationId": "deleteSetlist",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "setlistId",
+                        "required": true,
+                        "schema": {
+                            "format": "uuid",
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiResponseUnit"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    }
+                },
+                "summary": "\uc14b\ub9ac\uc2a4\ud2b8 \uc0ad\uc81c",
+                "tags": [
+                    "setlists"
+                ]
+            },
             "get": {
                 "operationId": "getSetlist",
                 "parameters": [

--- a/src/main/kotlin/com/bandage/bandmanager/domain/setlist/controller/SetlistController.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/setlist/controller/SetlistController.kt
@@ -80,6 +80,20 @@ class SetlistController(
         @Valid @RequestBody request: SetlistUpdateRequest,
     ): ApiResponse<SetlistDetailResponse> = ApiResponse.success(setlistService.updateSetlist(setlistId, memberId, request))
 
+    @DeleteMapping("/{setlistId}")
+    @Operation(
+        operationId = "deleteSetlist",
+        summary = "셋리스트 삭제",
+        description = "매니저가 셋리스트를 삭제합니다. 셋리스트의 트랙·참여자·밴드 연결도 함께 정리됩니다.",
+    )
+    fun deleteSetlist(
+        @PathVariable setlistId: UUID,
+        @CurrentMemberId memberId: Long,
+    ): ApiResponse<Unit> {
+        setlistService.deleteSetlist(setlistId, memberId)
+        return ApiResponse.success()
+    }
+
     @PostMapping("/{setlistId}/jams")
     @Operation(
         operationId = "createJamsFromSetlist",

--- a/src/main/kotlin/com/bandage/bandmanager/domain/setlist/service/SetlistService.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/setlist/service/SetlistService.kt
@@ -86,6 +86,24 @@ class SetlistService(
         return SetlistDetailResponse.of(setlist, loadBandIds(setlist.id))
     }
 
+    /** 셋리스트 소프트 삭제. 트랙·참여자·밴드 연결도 함께 정리한다. */
+    @Transactional
+    fun deleteSetlist(
+        setlistId: UUID,
+        memberId: Long,
+    ) {
+        val setlist = getSetlistOrThrow(setlistId)
+        validateManager(setlist, memberId)
+
+        val tracks = setlistTrackRepository.findAllBySetlist(setlist)
+        if (tracks.isNotEmpty()) {
+            setlistTrackParticipantRepository.findAllByTrackIn(tracks).forEach { it.markAsDeleted(memberId) }
+            tracks.forEach { it.markAsDeleted(memberId) }
+        }
+        setlistBandRepository.findAllBySetlistId(setlistId).forEach { it.markAsDeleted(memberId) }
+        setlist.markAsDeleted(memberId)
+    }
+
     fun getTracks(
         setlistId: UUID,
         memberId: Long,

--- a/src/test/kotlin/com/bandage/bandmanager/domain/setlist/service/SetlistServiceTest.kt
+++ b/src/test/kotlin/com/bandage/bandmanager/domain/setlist/service/SetlistServiceTest.kt
@@ -4,10 +4,14 @@ import com.bandage.bandmanager.domain.band.repository.BandMemberRepository
 import com.bandage.bandmanager.domain.member.service.MemberService
 import com.bandage.bandmanager.domain.setlist.dto.req.SetlistUpdateRequest
 import com.bandage.bandmanager.domain.setlist.model.Setlist
+import com.bandage.bandmanager.domain.setlist.model.SetlistBand
+import com.bandage.bandmanager.domain.setlist.model.SetlistTrack
+import com.bandage.bandmanager.domain.setlist.model.SetlistTrackParticipant
 import com.bandage.bandmanager.domain.setlist.repository.SetlistBandRepository
 import com.bandage.bandmanager.domain.setlist.repository.SetlistRepository
 import com.bandage.bandmanager.domain.setlist.repository.SetlistTrackParticipantRepository
 import com.bandage.bandmanager.domain.setlist.repository.SetlistTrackRepository
+import com.bandage.bandmanager.global.common.domain.TrackInfo
 import com.bandage.bandmanager.global.error.errorcode.ErrorCode
 import com.bandage.bandmanager.global.error.exception.BusinessException
 import org.assertj.core.api.Assertions.assertThat
@@ -91,5 +95,33 @@ class SetlistServiceTest {
                 sut.updateSetlist(setlistId, newManagerId, SetlistUpdateRequest(title = setlist.title, managerId = null))
             }
         assertThat(ex.errorCode).isEqualTo(ErrorCode.SETLIST_NOT_MANAGER)
+    }
+
+    @Test
+    fun `deleteSetlist - 매니저는 셋리스트와 트랙·참여자·밴드 연결을 함께 소프트 삭제한다`() {
+        val setlist = setlist()
+        val track = SetlistTrack.create(setlist, TrackInfo(title = "곡", artist = "아티스트"), note = null, sessions = emptyList())
+        val participant = SetlistTrackParticipant.create(track, sessionId = "vocal", memberId = 9L)
+        val setlistBand = SetlistBand.create(UUID.randomUUID(), setlistId)
+        `when`(setlistTrackRepository.findAllBySetlist(setlist)).thenReturn(listOf(track))
+        `when`(setlistTrackParticipantRepository.findAllByTrackIn(listOf(track))).thenReturn(listOf(participant))
+        `when`(setlistBandRepository.findAllBySetlistId(setlistId)).thenReturn(listOf(setlistBand))
+
+        sut.deleteSetlist(setlistId, managerId)
+
+        assertThat(setlist.deletedAt).isNotNull()
+        assertThat(track.deletedAt).isNotNull()
+        assertThat(participant.deletedAt).isNotNull()
+        assertThat(setlistBand.deletedAt).isNotNull()
+    }
+
+    @Test
+    fun `deleteSetlist - 매니저가 아니면 SETLIST_NOT_MANAGER`() {
+        val setlist = setlist()
+
+        val ex = assertThrows<BusinessException> { sut.deleteSetlist(setlistId, newManagerId) }
+
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.SETLIST_NOT_MANAGER)
+        assertThat(setlist.deletedAt).isNull()
     }
 }


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #

📌 **작업 내용 및 특이사항**

셋리스트 삭제 API를 추가했습니다. **셋리스트 매니저만** 수행할 수 있습니다.

- `DELETE /api/v1/setlists/{setlistId}` 엔드포인트 추가 (`operationId: deleteSetlist`)
- `SetlistService.deleteSetlist` 구현
  - `validateManager` 로 매니저 권한 검증 → 매니저가 아니면 `SETLIST_NOT_MANAGER`(403)
  - 셋리스트 미존재 시 `SETLIST_NOT_FOUND`(404)
- 하드 삭제가 아닌 **소프트 삭제**이며, 연관 데이터를 함께 정리합니다
  - `Setlist` → `SetlistTrack` → `SetlistTrackParticipant` → `SetlistBand`
  - 기존 `deleteTrack` 의 정리 방식과 동일한 패턴을 따랐습니다
- 단위 테스트 추가 (`SetlistServiceTest`)
  - 매니저 삭제 시 셋리스트·트랙·참여자·밴드 연결이 모두 소프트 삭제되는지 검증
  - 매니저가 아니면 `SETLIST_NOT_MANAGER` 이며 아무것도 삭제되지 않는지 검증

📚 **참고사항**

- `docs/openapi.json` 변경은 신규 엔드포인트 추가만 포함된 **additive** 변경입니다 (31 insertions, 0 deletions). Breaking change 없습니다.
- 트랙 조회는 `findAllBySetlist`, 참여자는 `findAllByTrackIn` 으로 **일괄 조회**하여 트랙 수만큼의 N+1 쿼리를 피했습니다.
- `./gradlew build` (spotless + 전체 테스트) 통과했습니다.

✅ **체크리스트**
- [x] API(Controller/DTO)를 변경한 경우 `docs/openapi.json`을 갱신했습니다 (코드-스펙 동일 PR 규약)

🤖 Generated with [Claude Code](https://claude.com/claude-code)