### PR TITLE
[BD-222] refactor: Band 알림 메세지 동적 할당

### DIFF
--- a/src/main/kotlin/com/bandage/bandmanager/domain/band/notify/AuthorityPromotionResolver.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/band/notify/AuthorityPromotionResolver.kt
@@ -31,7 +31,7 @@ class AuthorityPromotionResolver(
                 recipientId = newLeader.member,
                 category = category,
                 title = "밴드 리더 승격",
-                message = "밴드의 새로운 리더로 승격되었습니다.",
+                message = "${newLeader.band.name}: 밴드의 새로운 리더로 승격되었습니다.",
                 referenceId = bandId.toString(),
             ),
         )

--- a/src/main/kotlin/com/bandage/bandmanager/domain/band/notify/BandApplicationResolver.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/band/notify/BandApplicationResolver.kt
@@ -30,7 +30,7 @@ class BandApplicationResolver(
                     recipientId = leader.member,
                     category = category,
                     title = "새로운 가입 신청",
-                    message = "밴드에 새로운 가입 신청이 접수되었습니다.",
+                    message = "${leader.band.name}: 새로운 가입 신청이 접수되었습니다.",
                     referenceId = bandId.toString(),
                 )
             }

--- a/src/main/kotlin/com/bandage/bandmanager/domain/band/notify/BandApplicationResultResolver.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/band/notify/BandApplicationResultResolver.kt
@@ -31,8 +31,8 @@ class BandApplicationResultResolver(
 
         val (title, message) =
             when (status) {
-                ApplicationStatus.APPROVED -> "가입 신청 승인" to "밴드 가입 신청이 승인되었습니다."
-                ApplicationStatus.REJECTED -> "가입 신청 거절" to "밴드 가입 신청이 거절되었습니다."
+                ApplicationStatus.APPROVED -> "가입 신청 승인" to "${application.band.name}: 가입 신청이 승인되었습니다."
+                ApplicationStatus.REJECTED -> "가입 신청 거절" to "${application.band.name}: 가입 신청이 거절되었습니다."
                 else -> return emptyList()
             }
 


### PR DESCRIPTION
## 🛠️ Issue Number
### done #BD-222

📌 **작업 내용 및 특이사항**
- BandApplcation/BandApplicationResult/BandLeader 관련 알림 -> 밴드 이름 동적 할당

```kotlin
// BandApplicationResolver
"${leader.band.name}: 새로운 가입 신청이 접수되었습니다."

// BandApplicationResultResolver
"${application.band.name}: 가입 신청이 승인되었습니다."
"${application.band.name}: 가입 신청이 거절되었습니다."

// AuthorityPromotionResolver
"${newLeader.band.name}: 밴드의 새로운 리더로 승격되었습니다."

```


📚 **참고사항**


✅ **체크리스트**
- [ ] API(Controller/DTO)를 변경한 경우 `docs/openapi.json`을 갱신했습니다 (코드-스펙 동일 PR 규약)
- API 변경 X
