### PR TITLE
[BD-222] refactor: 알림 메세지 동적 할당

### DIFF
--- a/src/main/kotlin/com/bandage/bandmanager/domain/band/notify/AuthorityPromotionResolver.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/band/notify/AuthorityPromotionResolver.kt
@@ -31,7 +31,7 @@ class AuthorityPromotionResolver(
                 recipientId = newLeader.member,
                 category = category,
                 title = "밴드 리더 승격",
-                message = "${newLeader.band.name}: 밴드의 새로운 리더로 승격되었습니다.",
+                message = "${newLeader.band.name} 밴드의 새로운 리더로 승격되었습니다.",
                 referenceId = bandId.toString(),
             ),
         )

--- a/src/main/kotlin/com/bandage/bandmanager/domain/band/notify/BandApplicationResolver.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/band/notify/BandApplicationResolver.kt
@@ -30,7 +30,7 @@ class BandApplicationResolver(
                     recipientId = leader.member,
                     category = category,
                     title = "새로운 가입 신청",
-                    message = "${leader.band.name}: 새로운 가입 신청이 접수되었습니다.",
+                    message = "${leader.band.name} 새로운 가입 신청이 접수되었습니다.",
                     referenceId = bandId.toString(),
                 )
             }

--- a/src/main/kotlin/com/bandage/bandmanager/domain/band/notify/BandApplicationResultResolver.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/band/notify/BandApplicationResultResolver.kt
@@ -31,8 +31,8 @@ class BandApplicationResultResolver(
 
         val (title, message) =
             when (status) {
-                ApplicationStatus.APPROVED -> "가입 신청 승인" to "${application.band.name}: 가입 신청이 승인되었습니다."
-                ApplicationStatus.REJECTED -> "가입 신청 거절" to "${application.band.name}: 가입 신청이 거절되었습니다."
+                ApplicationStatus.APPROVED -> "가입 신청 승인" to "${application.band.name} 가입 신청이 승인되었습니다."
+                ApplicationStatus.REJECTED -> "가입 신청 거절" to "${application.band.name} 가입 신청이 거절되었습니다."
                 else -> return emptyList()
             }
 

--- a/src/main/kotlin/com/bandage/bandmanager/domain/jam/notify/JamParticipantAddedResolver.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/jam/notify/JamParticipantAddedResolver.kt
@@ -46,7 +46,7 @@ class JamParticipantAddedResolver(
                 recipientId = request.memberId,
                 category = category,
                 title = "합주 참여자 추가",
-                message = "'${jam.title}' 합주에 참여자로 추가되었습니다.",
+                message = "${jam.title} 합주에 참여자로 추가되었습니다.",
                 referenceId = jamId.toString(),
             ),
         )

--- a/src/main/kotlin/com/bandage/bandmanager/domain/performance/notify/PerformanceManagerInvitedResolver.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/performance/notify/PerformanceManagerInvitedResolver.kt
@@ -32,7 +32,7 @@ class PerformanceManagerInvitedResolver(
                 recipientId = request.memberId,
                 category = category,
                 title = "공연 매니저 초대",
-                message = "'${performance.title}' 공연의 매니저로 초대되었습니다.",
+                message = "${performance.title} 공연의 매니저로 초대되었습니다.",
                 referenceId = performanceId.toString(),
             ),
         )

--- a/src/main/kotlin/com/bandage/bandmanager/domain/performance/notify/PerformanceOwnerPromotedResolver.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/performance/notify/PerformanceOwnerPromotedResolver.kt
@@ -31,7 +31,7 @@ class PerformanceOwnerPromotedResolver(
                 recipientId = targetMemberId,
                 category = category,
                 title = "공연 소유자 승격",
-                message = "'${performance.title}' 공연의 새로운 소유자로 승격되었습니다.",
+                message = "${performance.title} 공연의 새로운 소유자로 승격되었습니다.",
                 referenceId = performanceId.toString(),
             ),
         )

--- a/src/main/kotlin/com/bandage/bandmanager/domain/selection/notify/SelectionParticipantAddedResolver.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/selection/notify/SelectionParticipantAddedResolver.kt
@@ -38,7 +38,7 @@ class SelectionParticipantAddedResolver(
                     recipientId = memberId,
                     category = category,
                     title = "선곡 회의 참여자 추가",
-                    message = "'${selection.title}' 선곡 회의에 참여자로 추가되었습니다.",
+                    message = "${selection.title} 선곡 회의에 참여자로 추가되었습니다.",
                     referenceId = selectionId.toString(),
                 )
             }

--- a/src/main/kotlin/com/bandage/bandmanager/domain/setlist/notify/SetlistCreatedResolver.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/setlist/notify/SetlistCreatedResolver.kt
@@ -39,7 +39,7 @@ class SetlistCreatedResolver(
                     recipientId = memberId,
                     category = category,
                     title = "셋리스트 생성",
-                    message = "'${response.title}' 셋리스트가 생성되었습니다.",
+                    message = "${response.title} 셋리스트가 생성되었습니다.",
                     referenceId = response.setlistId.toString(),
                 )
             }


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #

📌 **작업 내용 및 특이사항**

- Band 알림(리더 승격 / 가입 신청 / 신청 결과) 메세지를 정적 문구에서 밴드명 기반 동적 문구로 변경
- 알림 메세지에서 동적 변수 꾸밈 제거
  - 밴드명 뒤 콜론(`:`) 제거
  - 공연/합주/선곡/셋리스트 제목을 감싼 작은따옴표(`''`) 제거

📚 **참고사항**

- API(Controller/DTO) 변경 없음 → `docs/openapi.json` 갱신 대상 아님
- `./gradlew test` 통과

✅ **체크리스트**
- [x] API(Controller/DTO)를 변경한 경우 `docs/openapi.json`을 갱신했습니다 (코드-스펙 동일 PR 규약)

🤖 Generated with [Claude Code](https://claude.com/claude-code)