### PR TITLE
refactor: Band 가입 신청 알림 메세지 변경

### DIFF
--- a/src/main/kotlin/com/bandage/bandmanager/domain/band/notify/BandApplicationResolver.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/band/notify/BandApplicationResolver.kt
@@ -30,7 +30,7 @@ class BandApplicationResolver(
                     recipientId = leader.member,
                     category = category,
                     title = "새로운 가입 신청",
-                    message = "${leader.band.name} 새로운 가입 신청이 접수되었습니다.",
+                    message = "${leader.band.name} 밴드에 새로운 가입 신청이 도착했습니다.",
                     referenceId = bandId.toString(),
                 )
             }

--- a/src/main/kotlin/com/bandage/bandmanager/domain/band/notify/BandApplicationResultResolver.kt
+++ b/src/main/kotlin/com/bandage/bandmanager/domain/band/notify/BandApplicationResultResolver.kt
@@ -31,8 +31,8 @@ class BandApplicationResultResolver(
 
         val (title, message) =
             when (status) {
-                ApplicationStatus.APPROVED -> "가입 신청 승인" to "${application.band.name} 가입 신청이 승인되었습니다."
-                ApplicationStatus.REJECTED -> "가입 신청 거절" to "${application.band.name} 가입 신청이 거절되었습니다."
+                ApplicationStatus.APPROVED -> "가입 신청 승인" to "${application.band.name} 밴드의 가입 신청이 승인되었습니다."
+                ApplicationStatus.REJECTED -> "가입 신청 거절" to "${application.band.name} 밴드의 가입 신청이 거절되었습니다."
                 else -> return emptyList()
             }
 


### PR DESCRIPTION
## 🛠️ Issue Number
### BD-222

📌 **작업 내용 및 특이사항**

- BandApplication 신청 승인/거절 시 알림 메세지 변경

```bash

# 변경 전
"가입 신청 승인" to "${application.band.name} 가입 신청이 승인되었습니다."

# 변경 후
"가입 신청 승인" to "${application.band.name} 밴드의 가입 신청이 승인되었습니다."

# 변경 전
"${leader.band.name} 새로운 가입 신청이 접수되었습니다.",

# 변경 후
"${leader.band.name} 밴드에 새로운 가입 신청이 도착했습니다."


```

📚 **참고사항**


✅ **체크리스트**
- [ ] API(Controller/DTO)를 변경한 경우 `docs/openapi.json`을 갱신했습니다 (코드-스펙 동일 PR 규약)
